### PR TITLE
Fix for issue #2.

### DIFF
--- a/test/test_datatypes.py
+++ b/test/test_datatypes.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python
+from datatypes import *
+import random
+import string
+import unittest
+
+class TestMM3(unittest.TestCase):
+    def setUp(self):
+        self.ff = MM3()
+    def test_match_mm3_label_bond(self):
+        self.assertTrue(self.ff.match_mm3_bond(' 1'))
+    def test_match_mm3_label_geo_dep_bond(self):
+        self.assertTrue(self.ff.match_mm3_bond('a1'))
+    def test_match_mm3_label_angle(self):
+        self.assertTrue(self.ff.match_mm3_angle(' 2'))
+    def test_match_mm3_label_stretch_bend(self):
+        self.assertTrue(self.ff.match_mm3_stretch_bend(' 3'))
+    def test_match_mm3_label_lower_torsion(self):
+        self.assertTrue(self.ff.match_mm3_lower_torsion(' 4'))
+    def test_match_mm3_label_higher_torsion(self):
+        self.assertTrue(self.ff.match_mm3_higher_torsion('54'))
+    def test_match_mm3_label_improper(self):
+        self.assertTrue(self.ff.match_mm3_improper(' 5'))
+    def test_match_mm3_label(self):
+        self.assertTrue(self.ff.match_mm3_label('{}{}'.format(
+                    random.choice(string.ascii_lowercase), random.randint(1, 5))))
+                        
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
Each MM3* parameter has what I call a mm3_label. It is the 1st 2
characters of the line containing the values for a given parameter. In
your case, "a2" is the mm3_label. The "a" comes from geometric
dependence on when to use that parameter.

datatypes.py contains the MM3 force field class, and it has the methods
import_ff and export_ff, which do exactly what their names suggest. The
import_ff method worked with these geometry dependent parameters, but
export_ff failed to recognize them. I have since updated datatypes.py
to let it handle this sort of issue. I also added a short test script
to check parameter labels (this is my first of hopefully many tests
that will be implemented).

The MM3 class now has a number of methods that check mm3_label using
regex. I'm still unsure whether these methods are best located here,
but this at least works for now.