### PR TITLE
Fixed bug associated with torsion check error

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -134,7 +134,7 @@ RE_SMILES = '[\w\-\=\(\)\.\+\[\]\*]+'
 # Possible symbols used to split atoms in SMARTS notation.
 RE_SPLIT_ATOMS = '[\s\-\(\)\=\.\[\]\*]+'
 # Name of MM3* substructures.
-RE_SUB = '[\w\s\-\.\*\(\)\%\=]+'
+RE_SUB = '[\w\s\-\.\*\(\)\%\=\,]+'
 
 # .MMO RELATED
 # Match bonds in lines of a .mmo file.


### PR DESCRIPTION
RE_SUB would not recognize comments in an *.mmo file that had commas such as:
-C(sp2)-, WCS (CU)

If it did not match this comment then it would not pick out the bond/angle/etc. for that line.