### PR TITLE
Many changes to help with issue #22

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -74,15 +74,15 @@ LOG_SETTINGS = {
 # quotes), the new parameter value will be decremented or incremented by a
 # percentage of its current value.
 #     x_new = x +/- (x * step)
-STEPS = {'ae':      2.0,
+STEPS = {'ae':      1.0,
          'af':      0.1,
-         'be':      0.1,
+         'be':      0.02,
          'bf':      0.1,
          'df':      0.1,
          'imp1':    0.2,
          'imp2':    0.2,
          'sb':      0.2,
-         'q':       0.5
+         'q':       0.1
          }
 
 # WEIGHTS

--- a/datatypes.py
+++ b/datatypes.py
@@ -647,7 +647,7 @@ class MM3(FF):
             # Someday export_ff should raise an exception when these values
             # get too rediculous, and this exception should be handled by the
             # optimization techniques appropriately.
-            if abs(param.value) > 100.:
+            if abs(param.value) > 999.:
                 logger.warning(
                     'Value of {} is too high! Skipping write.'.format(param))
             elif param.mm3_col == 1:

--- a/simplex.py
+++ b/simplex.py
@@ -161,7 +161,6 @@ class Simplex(opt.Optimizer):
             # Still make that FF copy.
             ff_copy = copy.deepcopy(self.ff)
         # Add your copy of the orignal to FF to the forward differentiated FFs.
-        self.new_ffs = sorted(self.new_ffs + [ff_copy], key=lambda x: x.score)
         # Double check and make sure they're all scored.
         for ff in self.new_ffs:
             if ff.score is None:
@@ -170,10 +169,8 @@ class Simplex(opt.Optimizer):
                 data = calculate.main(self.args_ff)
                 ff.score = compare.compare_data(r_data, data)
                 opt.pretty_ff_results(ff)
+        self.new_ffs = sorted(self.new_ffs + [ff_copy], key=lambda x: x.score)
         wrapper = textwrap.TextWrapper(width=79)
-        logger.log(20, 'ORDERED FF SCORES:')
-        logger.log(20, wrapper.fill('{}'.format(
-                ' '.join('{:15.4f}'.format(x.score) for x in self.new_ffs))))
         # Shows all FFs parameters.
         opt.pretty_ff_params(self.new_ffs)
         # Start the simplex cycles.
@@ -186,6 +183,9 @@ class Simplex(opt.Optimizer):
             best_ff = self.new_ffs[0]
             logger.log(20, '~~ START SIMPLEX CYCLE {} ~~'.format(
                     current_cycle).rjust(79, '~'))
+	    logger.log(20, 'ORDERED FF SCORES:')
+	    logger.log(20, wrapper.fill('{}'.format(
+		    ' '.join('{:15.4f}'.format(x.score) for x in self.new_ffs))))
             inv_ff = self.ff.__class__()
             if self.do_weighted_reflection:
                 inv_ff.method = 'WEIGHTED INVERSION'

--- a/simplex.py
+++ b/simplex.py
@@ -162,7 +162,6 @@ class Simplex(opt.Optimizer):
             self.new_ffs = opt.differentiate_ff(self.ff, central=False)
             # Still make that FF copy.
             ff_copy = copy.deepcopy(self.ff)
-        # Add your copy of the orignal to FF to the forward differentiated FFs.
         # Double check and make sure they're all scored.
         for ff in self.new_ffs:
             if ff.score is None:
@@ -171,6 +170,7 @@ class Simplex(opt.Optimizer):
                 data = calculate.main(self.args_ff)
                 ff.score = compare.compare_data(r_data, data)
                 opt.pretty_ff_results(ff)
+        # Add your copy of the orignal to FF to the forward differentiated FFs.
         self.new_ffs = sorted(self.new_ffs + [ff_copy], key=lambda x: x.score)
         # Allow 3 cycles w/o change for each parameter present
         self.max_cycles_wo_change = 3*(len(self.new_ffs)-1)

--- a/simplex.py
+++ b/simplex.py
@@ -65,6 +65,8 @@ class Simplex(opt.Optimizer):
             self.new_ffs = sorted(self.new_ffs, key=lambda x: x.score)
             # I think this is necessary after massive contraction.
             # Massive contraction can potentially make eveything worse.
+# No, it can't!!! The best FF is always retained! /Per-Ola
+
             if self.new_ffs[0].score < self.ff.score:
                 best_ff = self.new_ffs[0]
                 best_ff = restore_simp_ff(best_ff, self.ff)

--- a/simplex.py
+++ b/simplex.py
@@ -52,10 +52,10 @@ class Simplex(opt.Optimizer):
                  args_ref=None):
         super(Simplex, self).__init__(
             direc, ff, ff_lines, args_ff, args_ref)
+        self._max_cycles_wo_change = None
         self.do_massive_contraction = True
         self.do_weighted_reflection = True
         self.max_cycles = 100
-        self.max_cycles_wo_change = 3
         self.max_params = 10
     @property
     def best_ff(self):
@@ -173,7 +173,7 @@ class Simplex(opt.Optimizer):
         # Add your copy of the orignal to FF to the forward differentiated FFs.
         self.new_ffs = sorted(self.new_ffs + [ff_copy], key=lambda x: x.score)
         # Allow 3 cycles w/o change for each parameter present
-        self.max_cycles_wo_change = 3*(len(self.new_ffs)-1)
+        self._max_cycles_wo_change = 3 * (len(self.new_ffs) - 1)
         wrapper = textwrap.TextWrapper(width=79)
         # Shows all FFs parameters.
         opt.pretty_ff_params(self.new_ffs)

--- a/simplex.py
+++ b/simplex.py
@@ -296,7 +296,9 @@ class Simplex(opt.Optimizer):
                 data = calculate.main(self.args_ff)
                 con_ff.score = compare.compare_data(r_data, data)
                 opt.pretty_ff_results(con_ff)
-                if con_ff.score < self.new_ffs[-1].score:
+                # This change was made to reflect the 1998 Q2MM publication.
+                # if con_ff.score < self.new_ffs[-1].score:
+                if con_ff.score < self.new_ffs[-2].score:
                     self.new_ffs[-1] = con_ff
                 elif self.do_massive_contraction:
                     logger.log(

--- a/simplex.py
+++ b/simplex.py
@@ -66,8 +66,8 @@ class Simplex(opt.Optimizer):
             self.new_ffs = sorted(self.new_ffs, key=lambda x: x.score)
             # I think this is necessary after massive contraction.
             # Massive contraction can potentially make eveything worse.
-# No, it can't!!! The best FF is always retained! /Per-Ola
-
+            # No, it can't!!! The best FF is always retained! /Per-Ola
+            # Yep, he's right. /Eric
             if self.new_ffs[0].score < self.ff.score:
                 best_ff = self.new_ffs[0]
                 best_ff = restore_simp_ff(best_ff, self.ff)
@@ -188,9 +188,9 @@ class Simplex(opt.Optimizer):
             best_ff = self.new_ffs[0]
             logger.log(20, '~~ START SIMPLEX CYCLE {} ~~'.format(
                     current_cycle).rjust(79, '~'))
-	    logger.log(20, 'ORDERED FF SCORES:')
-	    logger.log(20, wrapper.fill('{}'.format(
-		    ' '.join('{:15.4f}'.format(x.score) for x in self.new_ffs))))
+        logger.log(20, 'ORDERED FF SCORES:')
+        logger.log(20, wrapper.fill('{}'.format(' '.join('{:15.4f}'.format(
+                            x.score) for x in self.new_ffs))))
             inv_ff = self.ff.__class__()
             if self.do_weighted_reflection:
                 inv_ff.method = 'WEIGHTED INVERSION'
@@ -209,11 +209,11 @@ class Simplex(opt.Optimizer):
                 break
             for i in xrange(0, len(best_ff.params)):
                 if self.do_weighted_reflection:
-		    inv_val = (
-			sum([x.params[i].value *
-			     (x.score - self.new_ffs[-1].score)
-			     for x in self.new_ffs[:-1]])
-			/ score_diff_sum)
+            inv_val = (
+            sum([x.params[i].value *
+                 (x.score - self.new_ffs[-1].score)
+                 for x in self.new_ffs[:-1]])
+            / score_diff_sum)
                 else:
                     inv_val = (
                         sum([x.params[i].value for x in self.new_ffs[:-1]])

--- a/simplex.py
+++ b/simplex.py
@@ -28,6 +28,10 @@ class Simplex(opt.Optimizer):
 
     Attributes
     ----------
+    _max_cycles_wo_change : int
+                            End the simplex optimization early if there have
+                            been this many consecutive simplex steps without
+                            improvement in the objective function.
     do_massive_contraction : bool
                              If True, allows massive contractions to be
                              performed, contracting all parameters at once.
@@ -37,10 +41,7 @@ class Simplex(opt.Optimizer):
                              reflection point.
     max_cycles : int
                  Maximum number of simplex cycles.
-    max_cycles_wo_change : int
-                           End the simplex optimization early if there have
-                           been this many consecutive simplex steps without
-                           improvement in the objective function.
+
     max_params : int
                  Maximum number of parameters used in a single simplex cycle.
     """
@@ -181,7 +182,7 @@ class Simplex(opt.Optimizer):
         current_cycle = 0
         cycles_wo_change = 0
         while current_cycle < self.max_cycles \
-                and cycles_wo_change < self.max_cycles_wo_change:
+                and cycles_wo_change < self._max_cycles_wo_change:
             current_cycle += 1
             last_best = self.new_ffs[0].score
             best_ff = self.new_ffs[0]
@@ -294,7 +295,7 @@ class Simplex(opt.Optimizer):
             else:
                 cycles_wo_change += 1
                 logger.log(20, '  -- {} cycles without improvement, out of {} allowed.'.format(
-                        cycles_wo_change, self.max_cycles_wo_change))
+                        cycles_wo_change, self._max_cycles_wo_change))
             best_ff = self.new_ffs[0]
             logger.log(20, 'BEST:')
             opt.pretty_ff_results(self.new_ffs[0], level=20)

--- a/simplex.py
+++ b/simplex.py
@@ -291,7 +291,7 @@ class Simplex(opt.Optimizer):
                 cycles_wo_change = 0
             else:
                 cycles_wo_change += 1
-                logger.log(20, '  -- {} cycles without change, out of {} allowed.'.format(
+                logger.log(20, '  -- {} cycles without improvement, out of {} allowed.'.format(
                         cycles_wo_change, self.max_cycles_wo_change))
             best_ff = self.new_ffs[0]
             logger.log(20, 'BEST:')


### PR DESCRIPTION
Lots of helpful changes inside here.

Still need to do testing before going forward. Here's some things to consider.

1. Is simplex reading the estimated derivatives properly from gradient?
1. How best to handle raise when all trial parameter sets produce the same objective function score.
1. If simplex follows gradient, should simplex only act on parameters with negative 2nd derivatives? Would simplex do nothing if no parameter has a negative 2nd derivative? Or would we rather keep it the same and have it act on which parameters have the lowest 2nd derivatives, not necessarily negative?
1. If the user wants to run only simplex and specifies more parameters, than the maximum parameter number set inside `simplex.Simplex.__init__`, do we want to let them use that number of parameters or should it check the 2nd derivatives?