### PR TITLE
Update Param Tethering

### DIFF
--- a/q2mm/calculate.py
+++ b/q2mm/calculate.py
@@ -469,7 +469,25 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT'], invert=None):
         # Unlike most datatypes, these Datum only get the attributes _lbl,
         # val and wht. This is to ensure that making and working with these
         # reference text files isn't too cumbersome.
-        data.extend(collect_reference(os.path.join(direc, filename)))
+        data.extend(collect_reference(os.path.join(direc, filename)))    
+    # MACROMODEL MM3* CURRENT PARAMETER VALUES
+    filenames = chain.from_iterable(coms['mp'])
+    for comma_filenames in filenames:
+        # FF file and parameter file.
+        name_fld, name_txt = comma_filenames.split(',')
+        ff = datatypes.MM3(os.path.join(direc, name_fld))
+        ff.import_ff()
+        ff.params = parameters.trim_params_by_file(
+            ff.params, os.path.join(direc, name_txt))
+        for param in ff.params:
+            data.extend([datatypes.Datum(
+                val=param.value,
+                com='mp',
+                typ='p',
+                src_1=name_fld,
+                src_2=name_txt,
+                idx_1=param.mm3_row,
+                idx_2=param.mm3_col)])
     # JAGUAR ENERGIES
     filenames_s = coms['je']
     # idx_1 is the number used to group sets of relative energies.
@@ -1270,24 +1288,6 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT'], invert=None):
                     idx_2=y + 1)
                      for e, x, y in izip(
                     low_tri, low_tri_idx[0], low_tri_idx[1])])
-    # MACROMODEL MM3* CURRENT PARAMETER VALUES
-    filenames = chain.from_iterable(coms['mp'])
-    for comma_filenames in filenames:
-        # FF file and parameter file.
-        name_fld, name_txt = comma_filenames.split(',')
-        ff = datatypes.MM3(os.path.join(direc, name_fld))
-        ff.import_ff()
-        ff.params = parameters.trim_params_by_file(
-            ff.params, os.path.join(direc, name_txt))
-        for param in ff.params:
-            data.extend([datatypes.Datum(
-                val=param.value,
-                com='mp',
-                typ='p',
-                src_1=name_fld,
-                src_2=name_txt,
-                idx_1=param.mm3_row,
-                idx_2=param.mm3_col)])
     logger.log(15, 'TOTAL DATA POINTS: {}'.format(len(data)))
     return np.array(data, dtype=datatypes.Datum)
 


### PR DESCRIPTION
This address the problem highlighted in PO's email below. I simply moved the parameter tethering section of collect_data right after the collection from a reference file. I'm sure we have had this discussion in the past, but instead of having two giant lists (or arrays) of data it would be nice to have blocks of data/structures/whatever where an object consists of the reference and calculated values, label, and weights.

From Per-Ola's Email:



""""
Hi,
 
We’re having GitHub problems here, can’t upload changes (firewall, don’t know if it will be resolved). We needed to implement tethering, which fails with the current code. The problem is that the reference data ( -r ) gets written first, but the parameter tethering data ( -mp ) gets written last, so you get a mismatch in compare. I just moved 18 lines in “calculate.py”, the MacroModel parameter tethering, earlier into the file (just after the general data section). Now it works.
 
Could one of you make this fix “officially”? Xin will need this soon.
 
We did find that in at least one case, tethering seems to be the only way to keep the angles in check. The same problem I’ve discussed before, if you look into a system where angles strain against each other (just do H-C-H in methane as an example), increasing all angle reference values will give an equally good structure fit, but will make a highly strained and unstable force field. I think we should do this generally, everywhere, tether the angle reference values to the average of the observed.
 
Cheers,
 
Per-Ola
"""