### PR TITLE
feat(parsers): Add __eq__ and __hash__ to Param

### DIFF
--- a/q2mm/parsers/param.py
+++ b/q2mm/parsers/param.py
@@ -82,11 +82,35 @@ class Param:
         return f"Param[{self.ptype}]({val})"
 
     def __eq__(self, other: object) -> bool:
+        if self is other:
+            return True
         if not isinstance(other, Param):
+            return NotImplemented
+        # Parameters with incomplete identity are not meaningfully comparable.
+        if (
+            self.ptype is None
+            or self.ff_row is None
+            or self.ff_col is None
+            or other.ptype is None
+            or other.ff_row is None
+            or other.ff_col is None
+        ):
             return NotImplemented
         return (self.ptype, self.ff_row, self.ff_col) == (other.ptype, other.ff_row, other.ff_col)
 
     def __hash__(self) -> int:
+        """Hash based on (ptype, ff_row, ff_col) identity.
+
+        These fields are set at construction by the FF parsers and should not
+        be mutated after the Param is used in a set or as a dict key.
+
+        Raises:
+            TypeError: If any identity field is None (incomplete parameter).
+        """
+        if self.ptype is None or self.ff_row is None or self.ff_col is None:
+            raise TypeError(
+                f"Param with incomplete identity ({self.ptype}, {self.ff_row}, {self.ff_col}) is unhashable"
+            )
         return hash((self.ptype, self.ff_row, self.ff_col))
 
     @property

--- a/test/test_param.py
+++ b/test/test_param.py
@@ -46,6 +46,24 @@ class TestParamEquality:
         assert p != "not a param"
         assert p != 42
 
+    def test_identity_shortcut(self):
+        p = Param(ptype="bf", ff_row=5, ff_col=1)
+        assert p == p  # noqa: PLR0124
+
+    def test_incomplete_identity_not_comparable(self):
+        """Params with None in identity fields fall back to identity comparison."""
+        a = Param(ptype="ae")
+        b = Param(ptype="ae")
+        # NotImplemented from __eq__ causes Python to fall back to `is`
+        assert not (a == b)
+        assert a == a  # noqa: PLR0124
+
+    def test_incomplete_identity_not_hashable(self):
+        with pytest.raises(TypeError, match="unhashable"):
+            hash(Param())
+        with pytest.raises(TypeError, match="unhashable"):
+            hash(Param(ptype="bf"))
+
 
 class TestParamConstruction:
     """Verify default construction and None handling."""


### PR DESCRIPTION
## Summary

Add `__eq__` and `__hash__` to `Param` so parameters can be compared, deduplicated, and used in sets.

## Changes

- **`q2mm/parsers/param.py`** -- Add `__eq__` and `__hash__` based on `(ptype, ff_row, ff_col)` identity tuple
- **`test/test_param.py`** -- New test suite (19 tests) covering equality, hashing, set operations, construction, angle normalization, and range validation

## Why

The original authors noted this was needed ("Need a general index scheme to compare the equalness of two parameters"). Without `__eq__`, comparing params required manual `ff_row`/`ff_col` checks, and params couldn't be used in sets or as dict keys.

## Testing

- 19 new tests, all passing
- 188 passed, 19 skipped total (fast tier)

Closes #78
