### PR TITLE
test: Add parity stability tests and Seminario benchmark

### DIFF
--- a/test/integration/test_seminario_parity.py
+++ b/test/integration/test_seminario_parity.py
@@ -1,8 +1,14 @@
-"""Fixture-backed end-to-end Seminario parity tests."""
+"""Fixture-backed end-to-end Seminario parity tests.
+
+Covers issue #74: validates that the refactored code reproduces the
+upstream Seminario results to within 1e-8 tolerance for both the
+rh-enamide and SN2 systems, plus runtime benchmarks.
+"""
 
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 
 import numpy as np
@@ -187,3 +193,122 @@ def test_sn2_bond_projections_match_fixture(sn2_fixture):
             bond["legacy_force_constant_mdyn_a"],
             abs=1e-8,
         )
+
+
+# ---------------------------------------------------------------------------
+# Rh-enamide full pipeline stability tests (#74)
+# ---------------------------------------------------------------------------
+_RH_DATA_AVAILABLE = MM3_PATH.exists() and MMO_PATH.exists() and JAG_DIR.exists() and RH_FIXTURE_PATH.exists()
+
+
+@pytest.mark.skipif(not _RH_DATA_AVAILABLE, reason="Rh-enamide data not found")
+def test_rh_enamide_forcefield_roundtrip():
+    """Loading, estimating, and re-loading FF gives consistent params."""
+    structures = MacroModel(str(MMO_PATH)).structures
+    hessian_files = sorted(JAG_DIR.glob("*.in"))
+    molecules = [
+        Q2MMMolecule.from_structure(
+            s,
+            hessian=JaguarIn(str(h)).get_hessian(len(s.atoms)),
+            name=f"rh_{i}",
+        )
+        for i, (s, h) in enumerate(zip(structures, hessian_files))
+    ]
+
+    ff1 = ForceField.from_mm3_fld(MM3_PATH)
+    est1 = estimate_force_constants(molecules, forcefield=ff1, invalid_policy="skip")
+
+    # Re-estimate from the same starting point — must be deterministic
+    ff2 = ForceField.from_mm3_fld(MM3_PATH)
+    est2 = estimate_force_constants(molecules, forcefield=ff2, invalid_policy="skip")
+
+    for b1, b2 in zip(est1.bonds, est2.bonds):
+        assert b1.force_constant == pytest.approx(b2.force_constant, abs=1e-12)
+        assert b1.equilibrium == pytest.approx(b2.equilibrium, abs=1e-12)
+    for a1, a2 in zip(est1.angles, est2.angles):
+        assert a1.force_constant == pytest.approx(a2.force_constant, abs=1e-12)
+        assert a1.equilibrium == pytest.approx(a2.equilibrium, abs=1e-12)
+
+
+@pytest.mark.skipif(not _RH_DATA_AVAILABLE, reason="Rh-enamide data not found")
+def test_rh_enamide_param_vector_parity(rh_enamide_clean_results, rh_enamide_fixture):
+    """Parameter vector matches fixture values for all bond and angle params."""
+    estimated = rh_enamide_clean_results["clean_estimated"]
+    fixture_bf = _int_keyed_map(rh_enamide_fixture["parameters"]["bond_force_constants_mdyn_a"])
+    fixture_be = _int_keyed_map(rh_enamide_fixture["parameters"]["bond_equilibria_angstrom"])
+    fixture_af = _int_keyed_map(rh_enamide_fixture["parameters"]["angle_force_constants_mdyn_a_rad2"])
+    fixture_ae = _int_keyed_map(rh_enamide_fixture["parameters"]["angle_equilibria_degrees"])
+
+    # Collect max deviations for reporting
+    max_bond_k_diff = 0.0
+    max_bond_eq_diff = 0.0
+    max_angle_k_diff = 0.0
+    max_angle_eq_diff = 0.0
+
+    starting = rh_enamide_clean_results["clean_start"]
+    starting_bonds = {p.ff_row: p for p in starting.bonds}
+    starting_angles = {p.ff_row: p for p in starting.angles}
+
+    for b in estimated.bonds:
+        expected_k = fixture_bf.get(b.ff_row)
+        if expected_k is None:
+            expected_k = starting_bonds[b.ff_row].force_constant
+        max_bond_k_diff = max(max_bond_k_diff, abs(b.force_constant - expected_k))
+        max_bond_eq_diff = max(max_bond_eq_diff, abs(b.equilibrium - fixture_be[b.ff_row]))
+
+    for a in estimated.angles:
+        expected_k = fixture_af.get(a.ff_row)
+        if expected_k is None:
+            expected_k = starting_angles[a.ff_row].force_constant
+        max_angle_k_diff = max(max_angle_k_diff, abs(a.force_constant - expected_k))
+        max_angle_eq_diff = max(max_angle_eq_diff, abs(a.equilibrium - fixture_ae[a.ff_row]))
+
+    assert max_bond_k_diff < 1e-8, f"Bond FC max diff: {max_bond_k_diff}"
+    assert max_bond_eq_diff < 1e-8, f"Bond eq max diff: {max_bond_eq_diff}"
+    assert max_angle_k_diff < 1e-8, f"Angle FC max diff: {max_angle_k_diff}"
+    assert max_angle_eq_diff < 1e-8, f"Angle eq max diff: {max_angle_eq_diff}"
+
+
+# ---------------------------------------------------------------------------
+# Runtime benchmarks (informational, never fail)
+# ---------------------------------------------------------------------------
+@pytest.mark.skipif(not _RH_DATA_AVAILABLE, reason="Rh-enamide data not found")
+@pytest.mark.slow
+def test_rh_enamide_seminario_benchmark(rh_enamide_clean_results, capsys):
+    """Benchmark: time the full rh-enamide Seminario pipeline (informational)."""
+    structures = MacroModel(str(MMO_PATH)).structures
+    hessian_files = sorted(JAG_DIR.glob("*.in"))
+
+    # Time parsing
+    t0 = time.perf_counter()
+    hessians = [JaguarIn(str(p)).get_hessian(len(s.atoms)) for s, p in zip(structures, hessian_files)]
+    t_parse = time.perf_counter() - t0
+
+    # Time molecule creation
+    t0 = time.perf_counter()
+    molecules = [
+        Q2MMMolecule.from_structure(s, hessian=h, name=f"rh_{i}") for i, (s, h) in enumerate(zip(structures, hessians))
+    ]
+    t_mol = time.perf_counter() - t0
+
+    # Time Seminario estimation (10 iterations for stable timing)
+    ff_template = ForceField.from_mm3_fld(MM3_PATH)
+    times = []
+    for _ in range(10):
+        ff = ff_template.copy()
+        t0 = time.perf_counter()
+        estimate_force_constants(molecules, forcefield=ff, invalid_policy="skip")
+        times.append(time.perf_counter() - t0)
+
+    t_est_mean = np.mean(times)
+    t_est_std = np.std(times)
+
+    with capsys.disabled():
+        print(f"\n{'=' * 60}")
+        print(f"Rh-enamide Seminario benchmark ({len(structures)} structures)")
+        print(f"{'=' * 60}")
+        print(f"  Jaguar parsing:     {t_parse:.3f}s")
+        print(f"  Molecule creation:  {t_mol:.3f}s")
+        print(f"  Seminario estimate: {t_est_mean:.4f}s ± {t_est_std:.4f}s (10 runs)")
+        print(f"  Total (single run): {t_parse + t_mol + t_est_mean:.3f}s")
+        print(f"{'=' * 60}")


### PR DESCRIPTION
## Summary

Add parity stability tests and a runtime benchmark for the Rh-enamide Seminario pipeline.

Ref #74

## Changes

- **Deterministic roundtrip test** -- re-estimate from the same FF/molecules twice, assert identical results (1e-12 tolerance)
- **Parameter vector parity test** -- collect max deviations across all bond/angle params vs fixture, fail if any > 1e-8
- **Seminario benchmark** (`@pytest.mark.slow`) -- times parsing, molecule creation, and Seminario estimation separately with 10-run statistics

## Benchmark results

```
Rh-enamide Seminario benchmark (9 structures)
  Jaguar parsing:     0.059s
  Molecule creation:  0.005s
  Seminario estimate: 0.0249s +/- 0.0002s (10 runs)
  Total (single run): 0.088s
```

## Note on #74 scope

Full gradient-optimizer loop parity requires a Schrodinger/MacroModel MM backend which is not available in CI. The Seminario pipeline parity (QM parsing, Hessian projection, FF parameter estimation) is fully validated to 1e-8 tolerance across both rh-enamide and SN2 systems.

## Testing

227 passed, 20 skipped (fast tier). Benchmark passes with `--run-slow`.
