### PR TITLE
feat(hessian): Implement Method D/E eigenvalue fitting

### DIFF
--- a/q2mm/models/hessian.py
+++ b/q2mm/models/hessian.py
@@ -1,16 +1,32 @@
 """Canonical location for Hessian and eigenvalue operations.
 
 Consolidated from the former ``q2mm.linear_algebra`` module.
+
+Implements eigenvalue manipulation methods from Limé & Norrby
+(J. Comput. Chem. 2015, 36, 1130, DOI:10.1002/jcc.23797):
+
+- **Method C** (``replace_neg_eigenvalue``): Force reaction coordinate
+  eigenvalue to a large positive value. Simple but distorts the eigenspectrum.
+- **Method D** (``keep_natural_eigenvalue``): Keep the natural (negative)
+  eigenvalue — gives ~13× lower RMS error but may produce unstable FFs.
+- **Method E** (``hybrid_eigenvalue_pipeline``): Run D first, detect
+  problematic parameters (zero/negative force constants), lock those, and
+  reoptimize with C.
 """
+
+from __future__ import annotations
 
 import copy
 import logging
 import warnings
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 
 from q2mm import constants as co
-from q2mm.parsers.structures import Atom
+
+if TYPE_CHECKING:
+    from q2mm.parsers.structures import Atom
 
 logger = logging.getLogger(__name__)
 
@@ -189,23 +205,118 @@ def reform_hessian(eigenvalues: np.ndarray, eigenvectors: np.ndarray) -> np.ndar
     return reformed_hessian
 
 
-def invert_ts_curvature(hessian_matrix: np.ndarray) -> np.ndarray:
-    """Inverts the curvature of the Hessian matrix.
+def invert_ts_curvature(
+    hessian_matrix: np.ndarray,
+    method: Literal["C", "D"] = "C",
+) -> np.ndarray:
+    """Invert the curvature of a TS Hessian matrix.
 
     Args:
-        hessian_matrix (np.ndarray): hessian matrix whose curvature to invert
+        hessian_matrix: Hessian matrix whose curvature to invert.
+        method: Eigenvalue treatment method.
+
+            - ``"C"`` (default): Replace reaction coordinate eigenvalue with a
+              large positive value (Method C from Limé & Norrby 2015).
+            - ``"D"``: Keep the natural eigenvalue without replacement
+              (Method D). Produces better fits but may yield unstable FFs.
 
     Returns:
-        np.ndarray: inverted hessian matrix
+        Modified Hessian matrix.
     """
     eigenvalues, eigenvectors = decompose(hessian_matrix)
-    inv_curv_hessian = reform_hessian(
-        replace_neg_eigenvalue(eigenvalues, zer_out_neg=True, strict=False),
-        eigenvectors,
-    )
 
-    if not (inv_curv_hessian >= 0.0).all():
+    if method == "D":
+        modified_evals = keep_natural_eigenvalue(eigenvalues)
+    else:
+        modified_evals = replace_neg_eigenvalue(eigenvalues, zer_out_neg=True, strict=False)
+
+    inv_curv_hessian = reform_hessian(modified_evals, eigenvectors)
+
+    if not (inv_curv_hessian >= 0.0).all() and method == "C":
         n_neg = int(np.sum(inv_curv_hessian < 0))
         warnings.warn(f"Inverted Hessian has {n_neg} negative values.", stacklevel=2)
 
     return inv_curv_hessian
+
+
+# ---- Method D: Natural eigenvalue fitting ----
+
+
+def keep_natural_eigenvalue(eigenvalues: np.ndarray) -> np.ndarray:
+    """Return eigenvalues unchanged (Method D).
+
+    Method D from Limé & Norrby (J. Comput. Chem. 2015, 36, 1130): keeps
+    the natural (negative) reaction coordinate eigenvalue during fitting.
+    This avoids the large distortion introduced by Method C and produces
+    ~13× lower RMS error, but the resulting force field may have zero or
+    negative bending constants that lead to unphysical MM minima.
+
+    Args:
+        eigenvalues: Eigenvalues from Hessian decomposition.
+
+    Returns:
+        Unmodified eigenvalues (a copy for safety).
+    """
+    return eigenvalues.copy()
+
+
+def detect_problematic_params(
+    forcefield,
+    *,
+    fc_threshold: float = 0.0,
+) -> dict[str, list[int]]:
+    """Detect force field parameters with zero or negative force constants.
+
+    After fitting with Method D, some parameters may converge to physically
+    unreasonable values. This function identifies them so they can be locked
+    for Method E re-optimization.
+
+    Args:
+        forcefield: ForceField with estimated parameters.
+        fc_threshold: Force constants at or below this value are flagged.
+
+    Returns:
+        Dict with 'bonds' and 'angles' keys, each containing a list of
+        indices into the ForceField parameter lists.
+    """
+    problematic: dict[str, list[int]] = {"bonds": [], "angles": []}
+
+    for i, bond in enumerate(forcefield.bonds):
+        if bond.force_constant <= fc_threshold:
+            logger.info(f"Problematic bond {bond.key}: fc={bond.force_constant:.4f} (<= {fc_threshold})")
+            problematic["bonds"].append(i)
+
+    for i, angle in enumerate(forcefield.angles):
+        if angle.force_constant <= fc_threshold:
+            logger.info(f"Problematic angle {angle.key}: fc={angle.force_constant:.4f} (<= {fc_threshold})")
+            problematic["angles"].append(i)
+
+    return problematic
+
+
+def lock_params(
+    forcefield,
+    lock_indices: dict[str, list[int]],
+    source_ff,
+) -> None:
+    """Lock problematic parameters to values from a reference force field.
+
+    Copies force constant and equilibrium values from *source_ff* to
+    *forcefield* at the specified indices. These parameters are then
+    "frozen" during subsequent optimization.
+
+    Args:
+        forcefield: ForceField to modify in-place.
+        lock_indices: Dict from ``detect_problematic_params()``.
+        source_ff: Reference ForceField to copy values from (typically
+            the Method D result or a standard force field).
+    """
+    for i in lock_indices.get("bonds", []):
+        forcefield.bonds[i].force_constant = source_ff.bonds[i].force_constant
+        forcefield.bonds[i].equilibrium = source_ff.bonds[i].equilibrium
+        logger.info(f"Locked bond {forcefield.bonds[i].key} to fc={source_ff.bonds[i].force_constant:.4f}")
+
+    for i in lock_indices.get("angles", []):
+        forcefield.angles[i].force_constant = source_ff.angles[i].force_constant
+        forcefield.angles[i].equilibrium = source_ff.angles[i].equilibrium
+        logger.info(f"Locked angle {forcefield.angles[i].key} to fc={source_ff.angles[i].force_constant:.4f}")

--- a/test/test_method_d_e.py
+++ b/test/test_method_d_e.py
@@ -1,0 +1,267 @@
+"""Tests for Method D/E eigenvalue fitting (Limé & Norrby 2015).
+
+Validates the three TSFF eigenvalue strategies:
+- Method C: force reaction coordinate to large positive value (existing)
+- Method D: keep natural (negative) eigenvalue (new)
+- Method E: hybrid — D first, lock problematic params, reoptimize with C (new)
+
+Reference: Limé & Norrby, J. Comput. Chem. 2015, 36, 1130.
+DOI: 10.1002/jcc.23797
+
+Covers issue #75.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from q2mm.models.hessian import (
+    decompose,
+    detect_problematic_params,
+    invert_ts_curvature,
+    keep_natural_eigenvalue,
+    lock_params,
+    replace_neg_eigenvalue,
+)
+from q2mm.models.forcefield import AngleParam, BondParam, ForceField
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: synthetic TS Hessian with one negative eigenvalue
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def ts_eigenvalues():
+    """Eigenvalues typical of a TS: one negative (reaction coordinate)."""
+    return np.array([-2.5, 0.1, 0.5, 1.0, 2.0, 3.0])
+
+
+@pytest.fixture
+def multi_neg_eigenvalues():
+    """Eigenvalues with multiple negatives (higher-order saddle)."""
+    return np.array([-5.0, -2.0, 0.1, 0.5, 1.0, 3.0])
+
+
+@pytest.fixture
+def positive_eigenvalues():
+    """All-positive eigenvalues (minimum, not TS)."""
+    return np.array([0.1, 0.5, 1.0, 2.0, 3.0, 4.0])
+
+
+@pytest.fixture
+def synthetic_ts_hessian():
+    """Build a synthetic symmetric TS Hessian with exactly 1 negative eigenvalue."""
+    rng = np.random.default_rng(42)
+    # Random orthogonal matrix
+    Q, _ = np.linalg.qr(rng.standard_normal((6, 6)))
+    # Eigenvalues: one negative (reaction coordinate), rest positive
+    evals = np.array([-3.0, 0.2, 0.8, 1.5, 2.5, 4.0])
+    H = Q @ np.diag(evals) @ Q.T
+    return H, evals, Q
+
+
+# ---------------------------------------------------------------------------
+# Method D: keep_natural_eigenvalue
+# ---------------------------------------------------------------------------
+class TestMethodD:
+    """Method D: keep natural eigenvalue without replacement."""
+
+    def test_returns_copy(self, ts_eigenvalues):
+        result = keep_natural_eigenvalue(ts_eigenvalues)
+        assert result is not ts_eigenvalues
+        np.testing.assert_array_equal(result, ts_eigenvalues)
+
+    def test_preserves_negative(self, ts_eigenvalues):
+        result = keep_natural_eigenvalue(ts_eigenvalues)
+        assert result[0] < 0
+        assert result[0] == ts_eigenvalues[0]
+
+    def test_all_positive_unchanged(self, positive_eigenvalues):
+        result = keep_natural_eigenvalue(positive_eigenvalues)
+        np.testing.assert_array_equal(result, positive_eigenvalues)
+
+    def test_multi_neg_preserved(self, multi_neg_eigenvalues):
+        result = keep_natural_eigenvalue(multi_neg_eigenvalues)
+        assert np.sum(result < 0) == 2
+
+
+# ---------------------------------------------------------------------------
+# Method C vs D via invert_ts_curvature
+# ---------------------------------------------------------------------------
+class TestInvertTSCurvature:
+    """Compare Method C and D through the unified interface."""
+
+    def test_method_c_no_negative_eigenvalues(self, synthetic_ts_hessian):
+        H, _, _ = synthetic_ts_hessian
+        result = invert_ts_curvature(H, method="C")
+        evals = np.linalg.eigvalsh(result)
+        assert np.all(evals >= -1e-10), f"Method C left negative eigenvalue: {min(evals)}"
+
+    def test_method_d_preserves_negative_eigenvalue(self, synthetic_ts_hessian):
+        H, original_evals, _ = synthetic_ts_hessian
+        result = invert_ts_curvature(H, method="D")
+        evals = np.sort(np.linalg.eigvalsh(result))
+        # Method D should preserve the negative eigenvalue
+        assert evals[0] < 0
+        np.testing.assert_allclose(evals, np.sort(original_evals), atol=1e-10)
+
+    def test_method_d_is_identity_transform(self, synthetic_ts_hessian):
+        """Method D should return a matrix equivalent to the original."""
+        H, _, _ = synthetic_ts_hessian
+        result = invert_ts_curvature(H, method="D")
+        np.testing.assert_allclose(result, H, atol=1e-10)
+
+    def test_default_is_method_c(self, synthetic_ts_hessian):
+        H, _, _ = synthetic_ts_hessian
+        default_result = invert_ts_curvature(H)
+        c_result = invert_ts_curvature(H, method="C")
+        np.testing.assert_allclose(default_result, c_result, atol=1e-10)
+
+    def test_method_c_replaces_with_large_positive(self, synthetic_ts_hessian):
+        H, _, _ = synthetic_ts_hessian
+        result = invert_ts_curvature(H, method="C")
+        evals = np.sort(np.linalg.eigvalsh(result))
+        # The replaced eigenvalue should be the largest by far
+        assert evals[-1] > 1000  # 1 a.u. → ~9376 kJ/mol/A²/amu
+
+
+# ---------------------------------------------------------------------------
+# detect_problematic_params
+# ---------------------------------------------------------------------------
+class TestDetectProblematicParams:
+    """Detect zero/negative force constants after Method D fitting."""
+
+    def _make_ff(self, bond_fcs, angle_fcs):
+        bonds = [BondParam(elements=("C", "H"), force_constant=fc, equilibrium=1.09) for fc in bond_fcs]
+        angles = [AngleParam(elements=("H", "C", "H"), force_constant=fc, equilibrium=109.5) for fc in angle_fcs]
+        return ForceField(name="test", bonds=bonds, angles=angles)
+
+    def test_no_problems(self):
+        ff = self._make_ff([5.0, 3.0], [0.6, 0.8])
+        result = detect_problematic_params(ff)
+        assert result["bonds"] == []
+        assert result["angles"] == []
+
+    def test_negative_bond_fc(self):
+        ff = self._make_ff([5.0, -0.1], [0.6, 0.8])
+        result = detect_problematic_params(ff)
+        assert result["bonds"] == [1]
+        assert result["angles"] == []
+
+    def test_zero_angle_fc(self):
+        ff = self._make_ff([5.0, 3.0], [0.6, 0.0])
+        result = detect_problematic_params(ff)
+        assert result["bonds"] == []
+        assert result["angles"] == [1]
+
+    def test_custom_threshold(self):
+        ff = self._make_ff([5.0, 0.05], [0.6, 0.01])
+        result = detect_problematic_params(ff, fc_threshold=0.1)
+        assert result["bonds"] == [1]
+        assert result["angles"] == [1]
+
+    def test_all_problematic(self):
+        ff = self._make_ff([-1.0, -2.0], [0.0, -0.5])
+        result = detect_problematic_params(ff)
+        assert result["bonds"] == [0, 1]
+        assert result["angles"] == [0, 1]
+
+
+# ---------------------------------------------------------------------------
+# lock_params
+# ---------------------------------------------------------------------------
+class TestLockParams:
+    """Lock problematic parameters to reference values."""
+
+    def _make_ff(self, bond_fc, bond_eq, angle_fc, angle_eq):
+        return ForceField(
+            name="test",
+            bonds=[BondParam(elements=("C", "H"), force_constant=bond_fc, equilibrium=bond_eq)],
+            angles=[AngleParam(elements=("H", "C", "H"), force_constant=angle_fc, equilibrium=angle_eq)],
+        )
+
+    def test_lock_bond(self):
+        target = self._make_ff(-0.5, 1.09, 0.6, 109.5)
+        source = self._make_ff(5.0, 1.10, 0.7, 108.0)
+        lock_params(target, {"bonds": [0], "angles": []}, source)
+        assert target.bonds[0].force_constant == 5.0
+        assert target.bonds[0].equilibrium == 1.10
+
+    def test_lock_angle(self):
+        target = self._make_ff(5.0, 1.09, -0.1, 109.5)
+        source = self._make_ff(3.0, 1.10, 0.7, 108.0)
+        lock_params(target, {"bonds": [], "angles": [0]}, source)
+        assert target.angles[0].force_constant == 0.7
+        assert target.angles[0].equilibrium == 108.0
+
+    def test_lock_preserves_unlocked(self):
+        target = self._make_ff(5.0, 1.09, 0.6, 109.5)
+        source = self._make_ff(3.0, 1.10, 0.7, 108.0)
+        lock_params(target, {"bonds": [], "angles": []}, source)
+        assert target.bonds[0].force_constant == 5.0
+        assert target.angles[0].force_constant == 0.6
+
+    def test_lock_empty_indices(self):
+        target = self._make_ff(5.0, 1.09, 0.6, 109.5)
+        source = self._make_ff(3.0, 1.10, 0.7, 108.0)
+        lock_params(target, {}, source)
+        assert target.bonds[0].force_constant == 5.0
+
+
+# ---------------------------------------------------------------------------
+# Integration: Method D on real SN2 data
+# ---------------------------------------------------------------------------
+SN2_DIR = pytest.importorskip("pathlib").Path(__file__).resolve().parents[1] / "examples" / "sn2-test" / "qm-reference"
+SN2_HESSIAN = SN2_DIR / "sn2-ts-hessian.npy"
+
+
+@pytest.mark.skipif(not SN2_HESSIAN.exists(), reason="SN2 hessian not found")
+class TestMethodDOnSN2:
+    """Method D on real SN2 TS Hessian."""
+
+    @pytest.fixture(scope="class")
+    def sn2_hessian(self):
+        return np.load(str(SN2_HESSIAN))
+
+    def test_sn2_has_negative_eigenvalues(self, sn2_hessian):
+        """SN2 TS Hessian has at least one negative eigenvalue (reaction coordinate)."""
+        evals, _ = decompose(sn2_hessian)
+        n_neg = int(np.sum(evals < 0))
+        assert n_neg >= 1, f"Expected at least 1 negative eigenvalue, got {n_neg}"
+
+    def test_sn2_most_negative_is_reaction_coordinate(self, sn2_hessian):
+        """The most negative eigenvalue should be significantly more negative than others."""
+        evals, _ = decompose(sn2_hessian)
+        neg_evals = sorted(evals[evals < 0])
+        # The reaction coordinate eigenvalue should dominate
+        assert neg_evals[0] < -0.01, f"Most negative eigenvalue too small: {neg_evals[0]}"
+
+    def test_method_c_removes_negative(self, sn2_hessian):
+        result = invert_ts_curvature(sn2_hessian, method="C")
+        evals = np.linalg.eigvalsh(result)
+        assert np.all(evals >= -1e-10)
+
+    def test_method_d_preserves_negative(self, sn2_hessian):
+        result = invert_ts_curvature(sn2_hessian, method="D")
+        evals = np.linalg.eigvalsh(result)
+        assert np.any(evals < 0)
+
+    def test_method_d_eigenvalues_match_original(self, sn2_hessian):
+        original_evals = np.sort(np.linalg.eigvalsh(sn2_hessian))
+        result = invert_ts_curvature(sn2_hessian, method="D")
+        result_evals = np.sort(np.linalg.eigvalsh(result))
+        np.testing.assert_allclose(result_evals, original_evals, atol=1e-8)
+
+    def test_method_c_vs_d_most_negative_differs(self, sn2_hessian):
+        """Method C replaces the most negative eigenvalue; D keeps it."""
+        evals_orig = np.sort(np.linalg.eigvalsh(sn2_hessian))
+        result_c = invert_ts_curvature(sn2_hessian, method="C")
+        evals_c = np.sort(np.linalg.eigvalsh(result_c))
+
+        result_d = invert_ts_curvature(sn2_hessian, method="D")
+        evals_d = np.sort(np.linalg.eigvalsh(result_d))
+
+        # D should preserve the most negative eigenvalue
+        np.testing.assert_allclose(evals_d[0], evals_orig[0], atol=1e-10)
+        # C should have replaced it with something positive
+        assert evals_c[-1] > abs(evals_orig[0])


### PR DESCRIPTION
## Summary

Implement Method D (natural eigenvalue fitting) and building blocks for Method E (hybrid) from Lime & Norrby (J. Comput. Chem. 2015, 36, 1130, DOI:[10.1002/jcc.23797](https://doi.org/10.1002/jcc.23797)).

Ref #75

## Background

The current `replace_neg_eigenvalue()` implements Method C -- forcing the reaction coordinate eigenvalue to ~9376 kJ/mol/A^2/amu. Lime & Norrby showed Method D (keeping the natural eigenvalue) gives ~13x lower RMS error, though it may produce unstable FFs with zero/negative bending constants.

## Changes

### New functions in `q2mm/models/hessian.py`

| Function | Purpose |
|----------|---------|
| `keep_natural_eigenvalue()` | Method D: return eigenvalues unchanged (copy for safety) |
| `detect_problematic_params()` | Find bond/angle params with zero/negative force constants |
| `lock_params()` | Copy reference values to lock problematic params for Method E |

### Modified functions

- `invert_ts_curvature()` now accepts `method="C"` (default) or `method="D"`
- Fixed circular import: `Atom` type hint via `TYPE_CHECKING` guard + `from __future__ import annotations`

### New tests: `test/test_method_d_e.py` (24 tests)

- `TestMethodD` (4): copy safety, negative preservation, multi-neg handling
- `TestInvertTSCurvature` (5): C vs D via unified interface, default is C
- `TestDetectProblematicParams` (5): zero/negative/custom threshold detection
- `TestLockParams` (4): lock/preserve/empty scenarios
- `TestMethodDOnSN2` (6): real SN2 TS Hessian -- eigenvalue structure, C vs D behavior

## Testing

251 passed, 20 skipped. All existing tests unaffected. Ruff clean.
