### PR TITLE
fix: resolve F821 undefined name violations, remove per-file-ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,12 +128,3 @@ ignore = [
     "SIM108", # ternary (readability preference in scientific code)
 ]
 
-[tool.ruff.lint.per-file-ignores]
-# Legacy parsers use unimported List type hints and have scoping quirks
-"q2mm/parsers/gaussian.py" = ["F821"]
-"q2mm/parsers/jaguar.py" = ["F821"]
-"q2mm/parsers/macromodel.py" = ["F821"]
-"q2mm/parsers/mol2.py" = ["F821"]
-"q2mm/parsers/structures.py" = ["F821"]
-# Legacy test with undefined references in incomplete refactoring
-"test/test_linear_algebra.py" = ["F821"]

--- a/q2mm/parsers/jaguar.py
+++ b/q2mm/parsers/jaguar.py
@@ -179,6 +179,8 @@ class JaguarOut(File):
             section_geometry = False
             section_eigenvalues = False
             section_eigenvectors = False
+            current_structure = None
+            temp_eigenvectors = []
             for i, line in enumerate(f):
                 if section_geometry:
                     cols = line.split()

--- a/q2mm/parsers/macromodel.py
+++ b/q2mm/parsers/macromodel.py
@@ -49,6 +49,11 @@ class MacroModel(File):
                 count_input = 0
                 count_structure = 0
                 count_previous = 0
+                bonds = []
+                angles = []
+                torsions = []
+                atoms = []
+                current_structure = None
                 section = None
                 for line in f:
                     # This would probably be better as a function in the structure
@@ -254,6 +259,9 @@ class MacroModelLog(File):
             section_hessian = False
             start_row = False
             start_col = False
+            row_num = 0
+            col_nums = []
+            elements = []
             for i, word in enumerate(words):
                 # 1. Start of Hessian section.
                 if word == "Mass-weighted":

--- a/test/test_linear_algebra.py
+++ b/test/test_linear_algebra.py
@@ -1,4 +1,3 @@
-import copy
 import unittest
 
 import numpy as np
@@ -111,18 +110,7 @@ class TestLinearAlgebra(unittest.TestCase):
         zero_out: bool,
         hessian_units=constants.GAUSSIAN,
     ):
-        # TODO this might need to be refactored for python 3.8 at some point if it will be run with Schrodinger...
-        # Last Gaussian Eigenvalue Analysis Check TODO finish refactoring this after moving from seminario.py
-
-        estimated_ff = copy.deepcopy(force_field)
-        structs = structures
-
-        last_evec_ch = log.evecs[-1]
-        normed = last_evec_ch / np.linalg.norm(last_evec_ch)
-        print("normed final eigenvector ch: " + str(normed))
-        last_evec_hess = np.dot(normed, min_hessian)
-        print("last evec dot hess: " + str(last_evec_hess))
-        dotted_again = last_evec_hess.dot(np.transpose(normed))
-        print("last evec dot dot: " + str(dotted_again))
-        print("all close hessian dotted: " + str(np.allclose(log.evals[-1], dotted_again)))
-        print("last eigenvalue/force constant: " + str(log.evals[-1]))
+        # TODO: This test is incomplete. `log` (a JaguarOut-like object with .evecs/.evals)
+        # and `min_hessian` need to be derived from the test parameters before this test
+        # can run. See issue #128.
+        pass


### PR DESCRIPTION
## Summary

Resolves all 33 F821 (undefined name) violations across 3 files and removes the entire `per-file-ignores` section from `pyproject.toml`.

## Changes

**`q2mm/parsers/jaguar.py`** — Initialize `current_structure` and `temp_eigenvectors` before the parsing loop. These were assigned inside conditional blocks but used outside them; works at runtime but ruff couldn't verify the control flow.

**`q2mm/parsers/macromodel.py`** — Initialize `bonds`, `angles`, `torsions`, `atoms`, `current_structure` before the main loop in `MacroModel.structures`, and `col_nums`, `elements`, `row_num` before the word loop in `MacroModelLog.hessian`. Same scoping pattern.

**`test/test_linear_algebra.py`** — Replace dead code in `test_last` (already `@unittest.skip`) with `pass`. The method referenced `log` and `min_hessian` that were never defined — genuinely incomplete refactoring.

**`pyproject.toml`** — Remove entire `[tool.ruff.lint.per-file-ignores]` section. Also removed 3 stale entries (`gaussian.py`, `mol2.py`, `structures.py`) that had zero violations.

## Verification

- `ruff check .` — all checks passed
- `ruff format --check` — all files formatted
- 421 tests passed, 83 skipped

Closes #128
