### PR TITLE
perf(backends): Add GPU acceleration support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ jax-md = [
     "scipy",
 ]
 gpu = [
-    "jax[cuda12]",
+    "jax[cuda12]; sys_platform != 'win32'",
     "scipy",
 ]
 qcel = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,10 @@ jax-md = [
     "jaxlib; sys_platform != 'win32'",
     "scipy",
 ]
+gpu = [
+    "jax[cuda12]",
+    "scipy",
+]
 qcel = [
     "qcelemental",
 ]

--- a/q2mm/backends/mm/jax_engine.py
+++ b/q2mm/backends/mm/jax_engine.py
@@ -17,11 +17,14 @@ For MM3-specific JAX forms, see issue #91.
 from __future__ import annotations
 
 import copy
+import logging
 import math
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 from q2mm.backends.base import MMEngine
 from q2mm.backends.registry import register_mm
@@ -460,16 +463,19 @@ class JaxEngine(MMEngine):
 
         """
         _ensure_jax()
+        devices = jax.devices()
+        logger.info("JAX devices: %s", [str(d) for d in devices])
 
     @property
     def name(self) -> str:
-        """Human-readable engine name.
+        """Human-readable engine name including device type.
 
         Returns:
-            str: ``"JAX (harmonic)"``.
+            str: e.g. ``"JAX (harmonic, gpu)"`` or ``"JAX (harmonic, cpu)"``.
 
         """
-        return "JAX (harmonic)"
+        backend = jax.default_backend()
+        return f"JAX (harmonic, {backend})"
 
     def supported_functional_forms(self) -> frozenset[str]:
         """JAX currently supports harmonic forms only (see issue #91 for MM3).

--- a/q2mm/backends/mm/jax_md_engine.py
+++ b/q2mm/backends/mm/jax_md_engine.py
@@ -45,11 +45,14 @@ full feature set of jax-md.
 from __future__ import annotations
 
 import copy
+import logging
 import math
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 from q2mm.backends.base import MMEngine
 from q2mm.backends.registry import register_mm
@@ -600,11 +603,14 @@ class JaxMDEngine(MMEngine):
         self._box = np.array(box, dtype=np.float64)
         self._coulomb = coulomb if coulomb is not None else CutoffCoulomb(r_cut=12.0)
         self._nb_options = nb_options if nb_options is not None else NonbondedOptions(r_cut=12.0)
+        devices = jax.devices()
+        logger.info("JAX-MD devices: %s", [str(d) for d in devices])
 
     @property
     def name(self) -> str:
-        """Return the engine display name."""
-        return "JAX-MD (OPLSAA)"
+        """Return the engine display name including device type."""
+        backend = jax.default_backend()
+        return f"JAX-MD (OPLSAA, {backend})"
 
     def supported_functional_forms(self) -> frozenset[str]:
         """OPLSAA uses harmonic bonds/angles + proper torsions + LJ 12-6."""

--- a/q2mm/backends/mm/openmm.py
+++ b/q2mm/backends/mm/openmm.py
@@ -493,6 +493,14 @@ class OpenMMEngine(MMEngine):
         if platform_name is None:
             platform_name = detect_best_platform()
         self._platform_name = platform_name
+
+        _VALID_PRECISIONS = {"single", "mixed", "double"}
+        if precision is not None:
+            precision = precision.strip().lower()
+            if precision not in _VALID_PRECISIONS:
+                raise ValueError(
+                    f"Invalid precision {precision!r}. Allowed values: {', '.join(sorted(_VALID_PRECISIONS))}."
+                )
         self._precision = precision
         logger.info("OpenMM platform: %s", self._platform_name)
 

--- a/q2mm/backends/mm/openmm.py
+++ b/q2mm/backends/mm/openmm.py
@@ -8,11 +8,14 @@ functional forms with runtime parameter updates via :class:`OpenMMHandle`.
 from __future__ import annotations
 
 import copy
+import logging
 from typing import Any
 from dataclasses import dataclass, field
 from pathlib import Path
 
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 from q2mm.backends.base import MMEngine
 from q2mm.backends.registry import register_mm
@@ -203,6 +206,30 @@ def _ensure_openmm() -> None:
     """
     if not _HAS_OPENMM:
         raise ImportError('OpenMM is not installed. Install with `pip install openmm` or `pip install -e ".[openmm]"`.')
+
+
+_PLATFORM_PRIORITY = ("CUDA", "OpenCL", "CPU", "Reference")
+
+
+def detect_best_platform() -> str:
+    """Return the name of the fastest available OpenMM platform.
+
+    Platform preference order: CUDA > OpenCL > CPU > Reference.
+
+    Returns:
+        str: Name of the best available platform.
+
+    Raises:
+        ImportError: If OpenMM is not installed.
+
+    """
+    _ensure_openmm()
+    available = {mm.Platform.getPlatform(i).getName() for i in range(mm.Platform.getNumPlatforms())}
+    for name in _PLATFORM_PRIORITY:
+        if name in available:
+            return name
+    # Fallback — shouldn't happen since OpenMM always has Reference
+    return mm.Platform.getPlatform(0).getName()  # pragma: no cover
 
 
 def _as_molecule(structure: Q2MMMolecule | str | Path) -> Q2MMMolecule:
@@ -441,29 +468,43 @@ class OpenMMEngine(MMEngine):
     updates during optimization loops.
     """
 
-    def __init__(self, platform_name: str | None = None) -> None:
+    def __init__(
+        self,
+        platform_name: str | None = None,
+        precision: str | None = None,
+    ) -> None:
         """Initialize the OpenMM engine.
 
         Args:
             platform_name: OpenMM platform to use (e.g. ``"CPU"``,
-                ``"CUDA"``). Auto-selected if ``None``.
+                ``"CUDA"``, ``"OpenCL"``).  When ``None``, the fastest
+                available platform is auto-detected
+                (CUDA > OpenCL > CPU > Reference).
+            precision: Floating-point precision for GPU platforms
+                (``"single"``, ``"mixed"``, or ``"double"``).  Ignored
+                for CPU/Reference platforms.  Defaults to ``"mixed"``
+                when a GPU platform is selected.
 
         Raises:
             ImportError: If OpenMM is not installed.
 
         """
         _ensure_openmm()
+        if platform_name is None:
+            platform_name = detect_best_platform()
         self._platform_name = platform_name
+        self._precision = precision
+        logger.info("OpenMM platform: %s", self._platform_name)
 
     @property
     def name(self) -> str:
-        """Human-readable engine name.
+        """Human-readable engine name including the active platform.
 
         Returns:
-            str: ``"OpenMM"``.
+            str: e.g. ``"OpenMM (CUDA)"``.
 
         """
-        return "OpenMM"
+        return f"OpenMM ({self._platform_name})"
 
     def supported_functional_forms(self) -> frozenset[str]:
         """Functional forms this engine can evaluate.
@@ -515,11 +556,15 @@ class OpenMMEngine(MMEngine):
 
         """
         integrator = mm.VerletIntegrator(1.0 * unit.femtoseconds)
-        if self._platform_name:
-            platform = mm.Platform.getPlatformByName(self._platform_name)
-            context = mm.Context(system, integrator, platform)
+        platform = mm.Platform.getPlatformByName(self._platform_name)
+        # Set precision for GPU platforms (CUDA/OpenCL).
+        gpu_platforms = {"CUDA", "OpenCL"}
+        if self._platform_name in gpu_platforms:
+            precision = self._precision or "mixed"
+            prop_key = "CudaPrecision" if self._platform_name == "CUDA" else "OpenCLPrecision"
+            context = mm.Context(system, integrator, platform, {prop_key: precision})
         else:
-            context = mm.Context(system, integrator)
+            context = mm.Context(system, integrator, platform)
         return integrator, context
 
     def create_context(

--- a/q2mm/diagnostics/cli.py
+++ b/q2mm/diagnostics/cli.py
@@ -117,6 +117,7 @@ def _run_matrix(
     *,
     leaderboard_only: bool = False,
     data_dir: Path | None = None,
+    platform: str | None = None,
 ) -> list:
     """Run the full backend × optimizer matrix.
 
@@ -130,6 +131,9 @@ def _run_matrix(
         leaderboard_only (bool): If ``True``, skip streaming detailed
             SI tables during the run.
         data_dir (Path | None): Override for QM reference data directory.
+        platform (str | None): OpenMM platform override (e.g. ``"CUDA"``).
+            Passed to :class:`OpenMMEngine` when instantiating OpenMM
+            backends.  ``None`` triggers auto-detection.
 
     Returns:
         list[BenchmarkResult]: One result per (backend, optimizer) combination.
@@ -151,9 +155,15 @@ def _run_matrix(
     total = len(backends) * len(optimizers)
     idx = 0
 
-    for backend_name, engine_cls, _ in backends:
+    for backend_name, engine_cls, registry_key in backends:
         try:
-            engine = engine_cls()
+            # Pass platform to OpenMM when specified
+            if registry_key == "openmm" and platform is not None:
+                engine = engine_cls(platform_name=platform)
+            else:
+                engine = engine_cls()
+            # Update display name to reflect actual engine config
+            backend_name = engine.name
         except Exception as e:
             print(f"  Skipping {backend_name}: {e}", file=sys.stderr)
             continue
@@ -325,6 +335,12 @@ def main(argv: list[str] | None = None) -> int:
         help="Path to QM reference data directory (containing ch3f-*.xyz, etc.). "
         "Required for pip-installed q2mm; optional for git checkouts.",
     )
+    parser.add_argument(
+        "--platform",
+        metavar="NAME",
+        default=None,
+        help="OpenMM platform to use (e.g. CPU, CUDA, OpenCL). Default: auto-detect fastest available.",
+    )
 
     args = parser.parse_args(argv)
 
@@ -389,7 +405,12 @@ def main(argv: list[str] | None = None) -> int:
         print(f"  Combos:     {len(backends) * len(optimizers)}\n")
 
         results = _run_matrix(
-            backends, optimizers, output_dir=output_dir, leaderboard_only=args.leaderboard_only, data_dir=args.data_dir
+            backends,
+            optimizers,
+            output_dir=output_dir,
+            leaderboard_only=args.leaderboard_only,
+            data_dir=args.data_dir,
+            platform=args.platform,
         )
 
     if not results:

--- a/q2mm/diagnostics/cli.py
+++ b/q2mm/diagnostics/cli.py
@@ -383,10 +383,10 @@ def main(argv: list[str] | None = None) -> int:
         backends = all_backends
         if args.backend:
             filter_names = {b.lower() for b in args.backend}
-            backends = [(n, c, m) for n, c, m in all_backends if n.lower() in filter_names]
+            backends = [(n, c, m) for n, c, m in all_backends if m.lower() in filter_names]
             if not backends:
                 print(f"Error: no matching backends for {args.backend}", file=sys.stderr)
-                print(f"Available: {[n for n, _, _ in all_backends]}", file=sys.stderr)
+                print(f"Available: {[m for _, _, m in all_backends]}", file=sys.stderr)
                 return 1
 
         # Filter optimizers

--- a/test/integration/test_backend_optimizer_matrix.py
+++ b/test/integration/test_backend_optimizer_matrix.py
@@ -205,7 +205,7 @@ class TestBenchmarkPipeline:
         )
 
     def test_result_has_all_sections(self, result: BenchmarkResult) -> None:
-        assert result.metadata["backend"].startswith("OpenMM")
+        assert result.metadata["backend"] == "OpenMM"
         assert result.qm_reference["frequencies_cm1"]
         assert result.default_ff is not None
         assert result.seminario is not None

--- a/test/integration/test_backend_optimizer_matrix.py
+++ b/test/integration/test_backend_optimizer_matrix.py
@@ -205,7 +205,7 @@ class TestBenchmarkPipeline:
         )
 
     def test_result_has_all_sections(self, result: BenchmarkResult) -> None:
-        assert result.metadata["backend"] == "OpenMM"
+        assert result.metadata["backend"].startswith("OpenMM")
         assert result.qm_reference["frequencies_cm1"]
         assert result.default_ff is not None
         assert result.seminario is not None

--- a/test/integration/test_engine_contract.py
+++ b/test/integration/test_engine_contract.py
@@ -488,7 +488,7 @@ class TestTorsionEnergy:
     def test_torsion_energy_matches_openmm(self, engine: MMEngine, ethane: tuple[Q2MMMolecule, ForceField]) -> None:
         """Cross-engine parity: torsion energy must agree with OpenMM reference."""
         self._skip_if_no_torsion_support(engine)
-        if engine.name == "OpenMM":
+        if engine.name.startswith("OpenMM"):
             pytest.skip("Reference engine")
         if "openmm" not in available_mm_engines():
             pytest.skip("OpenMM not available for reference comparison")

--- a/test/test_openmm_platform.py
+++ b/test/test_openmm_platform.py
@@ -1,0 +1,94 @@
+"""Unit tests for OpenMM platform detection."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+openmm = pytest.importorskip("openmm")
+
+from q2mm.backends.mm.openmm import (  # noqa: E402
+    OpenMMEngine,
+    _PLATFORM_PRIORITY,
+    detect_best_platform,
+)
+
+
+def _mock_platforms(names: list[str]) -> tuple:
+    """Build mock getNumPlatforms / getPlatform callables.
+
+    Args:
+        names: Ordered list of platform names the mock should expose.
+
+    Returns:
+        (getNumPlatforms, getPlatform) pair for patching.
+
+    """
+    platforms = [SimpleNamespace(getName=lambda n=n: n) for n in names]
+    return len(platforms), lambda i: platforms[i]
+
+
+class TestDetectBestPlatform:
+    """Tests for detect_best_platform()."""
+
+    def test_prefers_cuda_over_cpu(self) -> None:
+        num, get = _mock_platforms(["Reference", "CPU", "CUDA"])
+        with (
+            patch.object(openmm.Platform, "getNumPlatforms", return_value=num),
+            patch.object(openmm.Platform, "getPlatform", side_effect=get),
+        ):
+            assert detect_best_platform() == "CUDA"
+
+    def test_prefers_opencl_when_no_cuda(self) -> None:
+        num, get = _mock_platforms(["Reference", "CPU", "OpenCL"])
+        with (
+            patch.object(openmm.Platform, "getNumPlatforms", return_value=num),
+            patch.object(openmm.Platform, "getPlatform", side_effect=get),
+        ):
+            assert detect_best_platform() == "OpenCL"
+
+    def test_falls_back_to_cpu(self) -> None:
+        num, get = _mock_platforms(["Reference", "CPU"])
+        with (
+            patch.object(openmm.Platform, "getNumPlatforms", return_value=num),
+            patch.object(openmm.Platform, "getPlatform", side_effect=get),
+        ):
+            assert detect_best_platform() == "CPU"
+
+    def test_cuda_beats_opencl(self) -> None:
+        num, get = _mock_platforms(["OpenCL", "CUDA", "CPU", "Reference"])
+        with (
+            patch.object(openmm.Platform, "getNumPlatforms", return_value=num),
+            patch.object(openmm.Platform, "getPlatform", side_effect=get),
+        ):
+            assert detect_best_platform() == "CUDA"
+
+    def test_priority_constant_has_expected_order(self) -> None:
+        assert _PLATFORM_PRIORITY == ("CUDA", "OpenCL", "CPU", "Reference")
+
+
+class TestPrecisionValidation:
+    """Tests for precision parameter validation in OpenMMEngine."""
+
+    def test_valid_precision_accepted(self) -> None:
+        for p in ("single", "mixed", "double"):
+            engine = OpenMMEngine(precision=p)
+            assert engine._precision == p
+
+    def test_precision_normalized_to_lowercase(self) -> None:
+        engine = OpenMMEngine(precision="Mixed")
+        assert engine._precision == "mixed"
+
+    def test_precision_strips_whitespace(self) -> None:
+        engine = OpenMMEngine(precision="  double  ")
+        assert engine._precision == "double"
+
+    def test_invalid_precision_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid precision"):
+            OpenMMEngine(precision="half")
+
+    def test_none_precision_allowed(self) -> None:
+        engine = OpenMMEngine(precision=None)
+        assert engine._precision is None


### PR DESCRIPTION
## Summary

Add GPU acceleration support across q2mm's MM backends and benchmark CLI. This is the low-hanging fruit from the GPU acceleration epic (#155).

## Changes

### OpenMM CUDA platform auto-detection (#154)
- New `detect_best_platform()` public API — auto-selects fastest available platform (CUDA > OpenCL > CPU > Reference)
- `OpenMMEngine.__init__` now auto-detects when `platform_name=None` (the default)
- New `precision` parameter for GPU platforms (`"single"`, `"mixed"`, `"double"`); defaults to `"mixed"` for CUDA/OpenCL
- Engine `name` property now includes platform: e.g. `"OpenMM (CUDA)"`, `"OpenMM (CPU)"`
- Platform selection logged via `logging.info`

### JAX GPU dependency & device logging (#150)
- New `gpu` optional extra in pyproject.toml: `pip install q2mm[gpu]` installs `jax[cuda12]`
- Both `JaxEngine` and `JaxMDEngine` log `jax.devices()` on init
- Engine `name` properties now include device backend: e.g. `"JAX (harmonic, gpu)"`, `"JAX-MD (OPLSAA, cpu)"`
- Zero code changes needed for GPU execution — JAX auto-dispatches

### Benchmark CLI `--platform` flag (#151)
- New `--platform` argument (e.g. `--platform CUDA`, `--platform CPU`)
- Passed through to `OpenMMEngine` when instantiating OpenMM backends
- Engine display names (with platform/device info) flow into benchmark metadata and output

## Testing

- 446 passed, 116 skipped, 16 warnings
- Full lint clean (`ruff check` + `ruff format --check`)
- Verified `detect_best_platform()` returns `CPU` on non-GPU machine
- Verified `--platform` flag appears in CLI `--help`
- Updated 2 test assertions that hardcoded `"OpenMM"` name to use `startswith("OpenMM")`

## On a GPU machine

No code changes needed — just:
```bash
# OpenMM with CUDA
pip install q2mm[openmm]  # CUDA auto-detected if available

# JAX on GPU
pip install q2mm[gpu]     # installs jax[cuda12]

# Benchmark with explicit platform
q2mm-benchmark --platform CUDA
```
