### PR TITLE
docs: OpenMM CUDA works on Blackwell via OpenMM-CUDA-12 + fix GPU gradient precision

### DIFF
--- a/benchmarks/GPU_BENCHMARKS.md
+++ b/benchmarks/GPU_BENCHMARKS.md
@@ -57,9 +57,16 @@ GPU-accelerated Q2MM parameter optimization on NVIDIA RTX 5090
 
 ### OpenMM
 
-OpenMM's CUDA platform does **not** support RTX 5090 (Blackwell / sm_120).
-Attempting to use it produces `CUDA_ERROR_UNSUPPORTED_PTX_VERSION (error 222)`.
+OpenMM's CUDA platform works on RTX 5090 (Blackwell / sm_120) via the
+`OpenMM-CUDA-12` pip package, which provides CUDA plugin binaries that
+JIT-compile kernels at runtime using NVRTC.
+
+```bash
+pip install OpenMM-CUDA-12
+```
+
 OpenMM benchmarks were run on CPU only (existing results in `rh-enamide/results/`).
+GPU benchmarks with `OpenMM-CUDA-12` are planned (see issue #194).
 
 ## Key Findings
 

--- a/benchmarks/GPU_BENCHMARKS.md
+++ b/benchmarks/GPU_BENCHMARKS.md
@@ -60,9 +60,10 @@ GPU-accelerated Q2MM parameter optimization on NVIDIA RTX 5090
 OpenMM's CUDA platform works on RTX 5090 (Blackwell / sm_120) via the
 `OpenMM-CUDA-12` pip package, which provides CUDA plugin binaries that
 JIT-compile kernels at runtime using NVRTC.
+Requires Linux with an NVIDIA GPU and compatible driver.
 
 ```bash
-pip install OpenMM-CUDA-12
+pip install OpenMM-CUDA-12  # Linux only
 ```
 
 OpenMM benchmarks were run on CPU only (existing results in `rh-enamide/results/`).

--- a/docs/backends/openmm.md
+++ b/docs/backends/openmm.md
@@ -20,6 +20,15 @@ Or with pip (Linux/macOS):
 pip install openmm
 ```
 
+For **GPU (CUDA) support**, also install the CUDA plugin package:
+
+```bash
+pip install OpenMM-CUDA-12
+```
+
+This provides CUDA plugin binaries that JIT-compile kernels via NVRTC,
+supporting all NVIDIA architectures including Blackwell (RTX 5090).
+
 !!! tip "Verify installation"
     ```python
     import openmm

--- a/docs/backends/openmm.md
+++ b/docs/backends/openmm.md
@@ -20,7 +20,7 @@ Or with pip (Linux/macOS):
 pip install openmm
 ```
 
-For **GPU (CUDA) support**, also install the CUDA plugin package:
+For **GPU (CUDA) support** on Linux, also install the CUDA plugin package:
 
 ```bash
 pip install OpenMM-CUDA-12
@@ -28,6 +28,7 @@ pip install OpenMM-CUDA-12
 
 This provides CUDA plugin binaries that JIT-compile kernels via NVRTC,
 supporting all NVIDIA architectures including Blackwell (RTX 5090).
+Requires Linux with an NVIDIA GPU and a compatible driver.
 
 !!! tip "Verify installation"
     ```python

--- a/docs/benchmarks/gpu.md
+++ b/docs/benchmarks/gpu.md
@@ -425,7 +425,7 @@ compiled kernel.
 | Component | Status |
 |-----------|--------|
 | JAX CUDA (Blackwell / sm_120) | ✅ Works |
-| OpenMM CUDA (Blackwell / sm_120) | ⚠️ Requires compiling from source with CUDA 12.8+ targeting sm_100 ([details](https://github.com/openmm/openmm/issues/3585)) |
+| OpenMM CUDA (Blackwell / sm_120) | ✅ Works — install `OpenMM-CUDA-12` (`pip install OpenMM-CUDA-12`). Uses NVRTC to JIT-compile kernels for sm_120. |
 | JAX force fields | Harmonic only (no MM3) |
 
 ---

--- a/docs/benchmarks/gpu.md
+++ b/docs/benchmarks/gpu.md
@@ -425,7 +425,7 @@ compiled kernel.
 | Component | Status |
 |-----------|--------|
 | JAX CUDA (Blackwell / sm_120) | ✅ Works |
-| OpenMM CUDA (Blackwell / sm_120) | ✅ Works — install `OpenMM-CUDA-12` (`pip install OpenMM-CUDA-12`). Uses NVRTC to JIT-compile kernels for sm_120. |
+| OpenMM CUDA (Blackwell / sm_120) | ✅ Works — `pip install OpenMM-CUDA-12` (Linux only). Uses NVRTC to JIT-compile kernels for sm_120. |
 | JAX force fields | Harmonic only (no MM3) |
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,10 @@ amber = [
 openmm = [
     "openmm",
 ]
+openmm-cuda = [
+    "openmm",
+    "OpenMM-CUDA-12",
+]
 optimize = [
     "scipy",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ openmm = [
 ]
 openmm-cuda = [
     "openmm",
-    "OpenMM-CUDA-12",
+    "OpenMM-CUDA-12; sys_platform == 'linux'",
 ]
 optimize = [
     "scipy",

--- a/q2mm/backends/mm/openmm.py
+++ b/q2mm/backends/mm/openmm.py
@@ -712,7 +712,7 @@ class OpenMMEngine(MMEngine):
         """
         return np.asarray(molecule.geometry, dtype=float) * unit.angstrom
 
-    def _create_context(self, system: Any) -> tuple[Any, Any]:
+    def _create_context(self, system: Any, *, precision: str | None = None) -> tuple[Any, Any]:
         """Create an OpenMM integrator and context for *system*.
 
         If the selected GPU platform (CUDA/OpenCL) fails (e.g., PTX version
@@ -720,6 +720,9 @@ class OpenMMEngine(MMEngine):
 
         Args:
             system: An ``openmm.System`` object.
+            precision: Override GPU precision (``"single"``, ``"mixed"``,
+                ``"double"``).  When ``None`` (default) uses the
+                engine-level setting or ``"mixed"``.
 
         Returns:
             tuple: ``(integrator, context)`` pair.
@@ -730,7 +733,7 @@ class OpenMMEngine(MMEngine):
         # Set precision for GPU platforms (CUDA/OpenCL).
         gpu_platforms = {"CUDA", "OpenCL"}
         if self._platform_name in gpu_platforms:
-            precision = self._precision or "mixed"
+            precision = precision or self._precision or "mixed"
             prop_key = "CudaPrecision" if self._platform_name == "CUDA" else "OpenCLPrecision"
             try:
                 context = mm.Context(system, integrator, platform, {prop_key: precision})
@@ -1710,7 +1713,9 @@ class OpenMMEngine(MMEngine):
 
             system.addForce(vdw_force)
 
-        integrator, context = self._create_context(system)
+        # Use double precision on GPU so that analytical derivatives
+        # (getParameterDerivatives) are computed in float64.
+        integrator, context = self._create_context(system, precision="double")
         context.setPositions(self._positions(molecule))
 
         return _DiffHandle(
@@ -1760,12 +1765,18 @@ class OpenMMEngine(MMEngine):
         # vdW parameters use per-particle values without global-parameter
         # derivatives.  Supplement with central finite differences.
         # Reuse a single OpenMMHandle to avoid rebuilding the OpenMM
-        # context for each perturbation.
+        # context for each perturbation.  Use double precision on GPU
+        # so the finite differences are not lost to float32 rounding.
         if forcefield.vdws:
             vdw_start = 2 * len(forcefield.bonds) + 2 * len(forcefield.angles) + len(forcefield.torsions)
             vdw_end = vdw_start + 2 * len(forcefield.vdws)
             step = 1e-4
-            handle = self.create_context(molecule, forcefield)
+            saved_precision = self._precision
+            try:
+                self._precision = "double"
+                handle = self.create_context(molecule, forcefield)
+            finally:
+                self._precision = saved_precision
             for i in range(vdw_start, vdw_end):
                 pv_plus = param_vector.copy()
                 pv_plus[i] += step

--- a/q2mm/backends/mm/openmm.py
+++ b/q2mm/backends/mm/openmm.py
@@ -734,6 +734,11 @@ class OpenMMEngine(MMEngine):
         gpu_platforms = {"CUDA", "OpenCL"}
         if self._platform_name in gpu_platforms:
             precision = precision or self._precision or "mixed"
+            _VALID_PRECISIONS = {"single", "mixed", "double"}
+            if precision not in _VALID_PRECISIONS:
+                raise ValueError(
+                    f"Invalid precision {precision!r}. Expected one of: {', '.join(sorted(_VALID_PRECISIONS))}."
+                )
             prop_key = "CudaPrecision" if self._platform_name == "CUDA" else "OpenCLPrecision"
             try:
                 context = mm.Context(system, integrator, platform, {prop_key: precision})

--- a/q2mm/backends/mm/openmm.py
+++ b/q2mm/backends/mm/openmm.py
@@ -756,7 +756,11 @@ class OpenMMEngine(MMEngine):
         return integrator, context
 
     def create_context(
-        self, structure: Q2MMMolecule | str | Path, forcefield: ForceField | None = None
+        self,
+        structure: Q2MMMolecule | str | Path,
+        forcefield: ForceField | None = None,
+        *,
+        precision: str | None = None,
     ) -> OpenMMHandle:
         """Build an OpenMM system and context for a molecule.
 
@@ -769,6 +773,9 @@ class OpenMMEngine(MMEngine):
                 XYZ file.
             forcefield: Force field to apply. Auto-generated from the
                 molecule if ``None``.
+            precision: Override GPU precision (``"single"``, ``"mixed"``,
+                ``"double"``).  When ``None`` (default) uses the
+                engine-level setting.
 
         Returns:
             OpenMMHandle: Reusable handle for energy evaluation and parameter
@@ -1176,7 +1183,7 @@ class OpenMMEngine(MMEngine):
         else:
             cmap_force = None
 
-        integrator, context = self._create_context(system)
+        integrator, context = self._create_context(system, precision=precision)
         context.setPositions(self._positions(molecule))
 
         return OpenMMHandle(
@@ -1771,12 +1778,7 @@ class OpenMMEngine(MMEngine):
             vdw_start = 2 * len(forcefield.bonds) + 2 * len(forcefield.angles) + len(forcefield.torsions)
             vdw_end = vdw_start + 2 * len(forcefield.vdws)
             step = 1e-4
-            saved_precision = self._precision
-            try:
-                self._precision = "double"
-                handle = self.create_context(molecule, forcefield)
-            finally:
-                self._precision = saved_precision
+            handle = self.create_context(molecule, forcefield, precision="double")
             for i in range(vdw_start, vdw_end):
                 pv_plus = param_vector.copy()
                 pv_plus[i] += step

--- a/test/integration/test_engine_contract.py
+++ b/test/integration/test_engine_contract.py
@@ -247,6 +247,23 @@ class TestAnalyticalGradients:
         if not engine.supports_analytical_gradients():
             pytest.skip("engine does not support analytical gradients")
 
+    @staticmethod
+    def _fd_engine(engine: MMEngine) -> MMEngine:
+        """Return an engine suitable for double-precision FD reference.
+
+        CUDA/OpenCL mixed precision loses too many digits for small FD
+        perturbations.  When the engine is OpenMM on a GPU, return a
+        CPU OpenMM engine so the FD baseline is computed in float64.
+        """
+        try:
+            from q2mm.backends.mm.openmm import OpenMMEngine
+
+            if isinstance(engine, OpenMMEngine) and engine._platform_name in {"CUDA", "OpenCL"}:
+                return OpenMMEngine(platform_name="CPU")
+        except ImportError:
+            pass
+        return engine
+
     def test_gradient_has_correct_length(self, engine: MMEngine, h2_displaced: tuple[Q2MMMolecule, ForceField]) -> None:
         self._skip_if_unsupported(engine)
         mol, ff = h2_displaced
@@ -275,6 +292,7 @@ class TestAnalyticalGradients:
         ff = _h2_ff(engine)
         _energy, grad_anal = engine.energy_and_param_grad(mol, ff)
 
+        fd_engine = self._fd_engine(engine)
         params = ff.get_param_vector().copy()
         grad_fd = np.zeros_like(params)
         h = 1e-5
@@ -283,9 +301,9 @@ class TestAnalyticalGradients:
             p_plus[i] += h
             p_minus[i] -= h
             ff.set_param_vector(p_plus)
-            e_plus = engine.energy(mol, ff)
+            e_plus = fd_engine.energy(mol, ff)
             ff.set_param_vector(p_minus)
-            e_minus = engine.energy(mol, ff)
+            e_minus = fd_engine.energy(mol, ff)
             grad_fd[i] = (e_plus - e_minus) / (2 * h)
         ff.set_param_vector(params)
 
@@ -298,6 +316,7 @@ class TestAnalyticalGradients:
         ff = _water_ff(engine)
         _energy, grad_anal = engine.energy_and_param_grad(mol, ff)
 
+        fd_engine = self._fd_engine(engine)
         params = ff.get_param_vector().copy()
         grad_fd = np.zeros_like(params)
         h = 1e-5
@@ -306,9 +325,9 @@ class TestAnalyticalGradients:
             p_plus[i] += h
             p_minus[i] -= h
             ff.set_param_vector(p_plus)
-            e_plus = engine.energy(mol, ff)
+            e_plus = fd_engine.energy(mol, ff)
             ff.set_param_vector(p_minus)
-            e_minus = engine.energy(mol, ff)
+            e_minus = fd_engine.energy(mol, ff)
             grad_fd[i] = (e_plus - e_minus) / (2 * h)
         ff.set_param_vector(params)
 

--- a/test/integration/test_engine_contract.py
+++ b/test/integration/test_engine_contract.py
@@ -258,7 +258,7 @@ class TestAnalyticalGradients:
         try:
             from q2mm.backends.mm.openmm import OpenMMEngine
 
-            if isinstance(engine, OpenMMEngine) and engine._platform_name in {"CUDA", "OpenCL"}:
+            if isinstance(engine, OpenMMEngine) and ("CUDA" in engine.name or "OpenCL" in engine.name):
                 return OpenMMEngine(platform_name="CPU")
         except ImportError:
             pass


### PR DESCRIPTION
## Summary

OpenMM CUDA works on Blackwell (RTX 5090 / sm_120) via the `OpenMM-CUDA-12` pip package — no source build needed. This PR updates docs, adds the optional dependency, and fixes a GPU precision bug in analytical gradients.

## Changes

### Docs
- **`benchmarks/GPU_BENCHMARKS.md`** — replaced "does not support RTX 5090" with working `OpenMM-CUDA-12` install instructions
- **`docs/benchmarks/gpu.md`** — changed compatibility table from ⚠️ to ✅
- **`docs/backends/openmm.md`** — added GPU (CUDA) install section

### Dependencies
- **`pyproject.toml`** — added `openmm-cuda` optional dependency group (`openmm` + `OpenMM-CUDA-12`)

### Bug fix: GPU analytical gradients
- **`q2mm/backends/mm/openmm.py`** — `_create_diff_handle` now creates CUDA/OpenCL contexts with double precision so `getParameterDerivatives()` returns float64 results. The vdW finite-difference fallback in `energy_and_param_grad` also uses double precision.
- **`test/integration/test_engine_contract.py`** — FD reference in gradient-vs-FD tests now uses a CPU engine when the test engine runs on GPU, avoiding float32 energy rounding that made central differences unreliable (12% error on bond k gradient).

## Background

`OpenMM-CUDA-12` provides 4 CUDA plugin `.so` files. OpenMM uses NVRTC to JIT-compile kernels at runtime, so sm_120 works without a source build. The previous PTX error 222 was simply due to missing plugin files, not architecture incompatibility.

## Testing

- All 885 tests pass (106 skipped for unavailable backends)
- Gradient tests verified on both CUDA and CPU platforms
- `mkdocs build --strict` passes

Relates to #194
