### PR TITLE
docs: normalize table labels and chemical formulas

### DIFF
--- a/docs/backends/openmm.md
+++ b/docs/backends/openmm.md
@@ -20,7 +20,7 @@ Or with pip:
 pip install openmm
 ```
 
-For **GPU (CUDA) support**, install the CUDA plugin package:
+For **GPU support** (via CUDA), install the CUDA plugin package:
 
 ```bash
 pip install OpenMM-CUDA-12

--- a/docs/benchmarks/gpu.md
+++ b/docs/benchmarks/gpu.md
@@ -7,11 +7,11 @@ comparison runs rather than on the full benchmark matrices.
 ## Scope
 
 - Hardware: NVIDIA RTX 5090 (Blackwell), float64 throughout
-- Workloads: dedicated JAX and JAX-MD CPU/GPU comparisons on CH3F and
+- Workloads: dedicated JAX and JAX-MD CPU/GPU comparisons on CH₃F and
   Rh-enamide
 - Comparison metric: seconds per evaluation (`s/eval`); total evaluation count
   can differ between devices
-- Related pages: [Small Molecules](small-molecules.md) for the full CH3F matrix
+- Related pages: [Small Molecules](small-molecules.md) for the full CH₃F matrix
   and [Rh-Enamide](rh-enamide.md) for the selected overnight large-system run
 
 ## CPU-vs-GPU comparisons completed so far
@@ -30,15 +30,15 @@ is worthwhile.
 | Rh-enamide | JAX-MD (OPLSAA) | CPU | 75.38 | 316 | 23,819 s | baseline |
 | Rh-enamide | JAX (harmonic) | GPU | 12.60 | 31 | 391 s | 2.08x |
 | Rh-enamide | JAX (harmonic) | CPU | 26.17 | 21 | 550 s | baseline |
-| CH3F | JAX (harmonic) | GPU | 0.054 | 132 | 7.1 s | 0.20x |
-| CH3F | JAX (harmonic) | CPU | 0.011 | 95 | 1.0 s | baseline |
+| CH₃F | JAX (harmonic) | GPU | 0.054 | 132 | 7.1 s | 0.20x |
+| CH₃F | JAX (harmonic) | CPU | 0.011 | 95 | 1.0 s | baseline |
 
 ## Interpretation
 
 - GPU speedup appears once the workload is large enough and the force field is
   complex enough to keep the device busy. The strongest current example is
   JAX-MD on Rh-enamide at 5.61x faster than CPU on a per-evaluation basis.
-- Small systems still favor CPU. CH3F is faster on CPU because kernel-launch
+- Small systems still favor CPU. CH₃F is faster on CPU because kernel-launch
   overhead dominates the actual arithmetic.
 - Compare `s/eval`, not raw evaluation counts. CPU and GPU can take slightly
   different optimization paths because of floating-point reduction-order
@@ -62,11 +62,11 @@ is worthwhile.
     | Consumer GPU | [RTX 5090](https://www.techpowerup.com/gpu-specs/geforce-rtx-5090.c4216) | 1 : 64 |
     | Datacenter GPU | [NVIDIA A100](https://www.nvidia.com/en-us/data-center/a100/) | 1 : 2 |
 
-    That gap is one reason CH3F can still be faster on CPU even when a consumer
+    That gap is one reason CH₃F can still be faster on CPU even when a consumer
     GPU is present: q2mm's Hessian/frequency workflow does not get to use the
     much larger FP32 throughput numbers that GeForce-class cards advertise.
 
-    The current float32 story is also still mixed. CH3F passes comfortably in
+    The current float32 story is also still mixed. CH₃F passes comfortably in
     float32, but the larger Rh-enamide tests do not yet make float32 or mixed
     precision a drop-in replacement for the current default workflow. In the
     archived viability study, full float32 produced about 0.78 cm⁻¹ maximum
@@ -78,7 +78,7 @@ is worthwhile.
 ## Artifacts and provenance
 
 - Dedicated GPU-study notes: `benchmarks/GPU_BENCHMARKS.md`
-- Related CH3F full-matrix artifacts: `benchmark_results/ch3f/`
+- Related CH₃F full-matrix artifacts: `benchmark_results/ch3f/`
 - Related Rh-enamide archive: `benchmarks/rh-enamide/`
 
 ## Reproducing

--- a/docs/benchmarks/index.md
+++ b/docs/benchmarks/index.md
@@ -9,9 +9,9 @@ the benchmark program is complete today.
 
 | Page | Primary question | Current scope | Status |
 |------|------------------|---------------|--------|
-| [Small Molecules](small-molecules.md) | How do the supported backend/form/optimizer combinations compare on a tractable system? | Full CH3F matrix: 24 supported combos across JAX, JAX-MD, OpenMM, and Tinker | **Complete** |
+| [Small Molecules](small-molecules.md) | How do the supported backend/form/optimizer combinations compare on a tractable system? | Full CH₃F matrix: 24 supported combos across JAX, JAX-MD, OpenMM, and Tinker | **Complete** |
 | [Rh-Enamide](rh-enamide.md) | What does q2mm currently achieve on a realistic large-system case study? | Selected overnight GPU matrix: 13 attempted combos on the 182-parameter Rh training set | **Partial** |
-| [GPU Acceleration](gpu.md) | When does GPU acceleration help, and when does CPU still win? | Dedicated CPU-vs-GPU comparisons for CH3F and Rh-enamide on JAX/JAX-MD | **Complete for the current study set** |
+| [GPU Acceleration](gpu.md) | When does GPU acceleration help, and when does CPU still win? | Dedicated CPU-vs-GPU comparisons for CH₃F and Rh-enamide on JAX/JAX-MD | **Complete for the current study set** |
 | [Published FF Validation](published-ff-validation.md) | Can q2mm correctly evaluate a published force field? | Check 1 on the published Rh-enamide force field under OpenMM | **Complete; parity gap unresolved** |
 
 ## How to use this section
@@ -27,7 +27,7 @@ the benchmark program is complete today.
 
 ## What the section demonstrates today
 
-- q2mm has one complete small-system comparison set: the CH3F full matrix.
+- q2mm has one complete small-system comparison set: the CH₃F full matrix.
 - q2mm has a realistic large-system Rh-enamide case study, but not yet a full
   24-combo Rh-enamide matrix.
 - GPU benefit is workload-dependent: it helps on larger JAX/JAX-MD workloads,
@@ -48,7 +48,7 @@ the benchmark program is complete today.
 The docs describe one benchmark program, but the repo currently stores its
 artifacts in more than one historical location:
 
-- Current CH3F full-matrix artifacts: `benchmark_results/ch3f/`
+- Current CH₃F full-matrix artifacts: `benchmark_results/ch3f/`
 - Archived Rh-enamide benchmark artifacts: `benchmarks/rh-enamide/`
 - Dedicated GPU-study notes: `benchmarks/GPU_BENCHMARKS.md`
 - Published-force-field validation artifacts: `test/fixtures/published_ff/` and

--- a/docs/benchmarks/rh-enamide.md
+++ b/docs/benchmarks/rh-enamide.md
@@ -32,7 +32,7 @@ log; failed rows keep their wall-clock failure times for completeness.
 
 | Backend | Form | Optimizer | Status | Result | MAE | Wall clock |
 |---------|------|-----------|--------|--------|----:|-----------:|
-| OpenMM (CUDA) | mm3 | grad-simp | success | 173.1 -> 42.7 RMSD | 31.8 | 112,959.0 s |
+| OpenMM | mm3 | grad-simp | success | 173.1 -> 42.7 RMSD | 31.8 | 112,959.0 s |
 | JAX | harmonic | L-BFGS-B | success | 173.5 -> 57.4 RMSD | 35.0 | 2,278.0 s |
 | JAX | mm3 | L-BFGS-B | success | 173.1 -> 61.5 RMSD | 48.5 | 1,975.2 s |
 | JAX | mm3 | Nelder-Mead | success | 173.1 -> 66.6 RMSD | 54.9 | 591.4 s |

--- a/docs/benchmarks/small-molecules.md
+++ b/docs/benchmarks/small-molecules.md
@@ -2,13 +2,13 @@
 
 This page answers one question: how do the currently supported backend, form,
 and optimizer combinations compare on a small, fully tractable benchmark? The
-system is CH3F (5 atoms, 8 fitted parameters) against B3LYP/6-31+G(d) QM
+system is CH₃F (5 atoms, 8 fitted parameters) against B3LYP/6-31+G(d) QM
 frequencies. Unlike the Rh-Enamide page, this page is the full supported
 matrix, so it is the right place to compare combinations directly.
 
 ## Scope
 
-- System: CH3F (1 molecule, 5 atoms, 8 parameters)
+- System: CH₃F (1 molecule, 5 atoms, 8 parameters)
 - QM reference: B3LYP/6-31+G(d)
 - Matrix size: 24 supported combos
 - Backends/forms: JAX and OpenMM on harmonic + MM3, JAX-MD on harmonic, Tinker
@@ -16,7 +16,7 @@ matrix, so it is the right place to compare combinations directly.
 - Starting point: JAX/JAX-MD/OpenMM begin at 156.9 cm⁻¹ RMSD; Tinker begins at
   157.2 cm⁻¹ because its MM3 baseline is evaluated through a separate backend
 
-## Full CH3F matrix
+## Full CH₃F matrix
 
 Default rows are grouped by functional form and then by final RMSD. Use the
 filters and sortable headers to narrow form/backend/device/optimizer
@@ -26,28 +26,28 @@ force-field model.
 
 <div class="benchmark-table-anchor" data-benchmark-table="small-molecules"></div>
 
-| Form | Backend | Device | Optimizer | Final RMSD (cm⁻¹) | Final MAE | Time | Evals/s |
+| Form | Backend | Device | Optimizer | Final RMSD (cm⁻¹) | Final MAE | Time | eval/s |
 |------|---------|--------|-----------|-------------------:|----------:|-----:|--------:|
 | harmonic | JAX-MD | GPU | Powell | < 0.1 | < 0.1 | 6.3 s | 398.2 |
 | harmonic | JAX | GPU | Powell | < 0.1 | < 0.1 | 6.3 s | 401.1 |
-| harmonic | OpenMM | GPU (CUDA) | Powell | < 0.1 | < 0.1 | 43.9 s | 98.4 |
+| harmonic | OpenMM | GPU | Powell | < 0.1 | < 0.1 | 43.9 s | 98.4 |
 | harmonic | JAX-MD | GPU | L-BFGS-B | 538.9 | 269.3 | 5.4 s | 23.1 |
 | harmonic | JAX | GPU | L-BFGS-B | 540.2 | 271.4 | 6.4 s | 23.6 |
 | harmonic | JAX | GPU | grad-simp | 811.8 | 579.1 | 9.9 s | 397.6 |
 | harmonic | JAX-MD | GPU | grad-simp | 811.8 | 579.1 | 10.5 s | 390.2 |
-| harmonic | OpenMM | GPU (CUDA) | grad-simp | 812.4 | 582.0 | 22.6 s | 99.3 |
+| harmonic | OpenMM | GPU | grad-simp | 812.4 | 582.0 | 22.6 s | 99.3 |
 | harmonic | JAX | GPU | Nelder-Mead | 1037.9 | 888.8 | 3.0 s | 394.9 |
 | harmonic | JAX-MD | GPU | Nelder-Mead | 1037.9 | 888.8 | 3.1 s | 385.7 |
-| harmonic | OpenMM | GPU (CUDA) | Nelder-Mead | 1040.5 | 892.1 | 9.8 s | 100.4 |
+| harmonic | OpenMM | GPU | Nelder-Mead | 1040.5 | 892.1 | 9.8 s | 100.4 |
 | mm3 | JAX | GPU | Powell | 4.0 | 1.9 | 30.6 s | 393.6 |
-| mm3 | OpenMM | GPU (CUDA) | L-BFGS-B | 30.4 | 25.7 | 21.9 s | 5.7 |
+| mm3 | OpenMM | GPU | L-BFGS-B | 30.4 | 25.7 | 21.9 s | 5.7 |
 | mm3 | Tinker | CPU | L-BFGS-B | 114.1 | 93.4 | 104.7 s | 4.1 |
 | mm3 | JAX | GPU | Nelder-Mead | 540.1 | 271.3 | 36.5 s | 394.7 |
 | mm3 | Tinker | CPU | Powell | 555.7 | 291.2 | 1172.5 s | 4.1 |
 | mm3 | Tinker | CPU | Nelder-Mead | 563.3 | 299.5 | 168.6 s | 4.1 |
-| mm3 | OpenMM | GPU (CUDA) | Nelder-Mead | 564.2 | 299.9 | 9.5 s | 95.5 |
-| mm3 | OpenMM | GPU (CUDA) | Powell | 575.7 | 311.9 | 137.6 s | 98.7 |
-| mm3 | OpenMM | GPU (CUDA) | grad-simp | 580.8 | 317.3 | 27.5 s | 97.9 |
+| mm3 | OpenMM | GPU | Nelder-Mead | 564.2 | 299.9 | 9.5 s | 95.5 |
+| mm3 | OpenMM | GPU | Powell | 575.7 | 311.9 | 137.6 s | 98.7 |
+| mm3 | OpenMM | GPU | grad-simp | 580.8 | 317.3 | 27.5 s | 97.9 |
 | mm3 | JAX | GPU | L-BFGS-B | 586.7 | 321.7 | 3.3 s | 23.2 |
 | mm3 | Tinker | CPU | grad-simp | 833.4 | 612.3 | 779.6 s | 4.2 |
 | mm3 | JAX | GPU | grad-simp | 834.5 | 613.2 | 11.0 s | 393.4 |


### PR DESCRIPTION
## Summary

Normalize inconsistent table labels and chemical formulas across all benchmark docs.

## Changes

| File | What changed |
|------|-------------|
| `docs/benchmarks/small-molecules.md` | `GPU (CUDA)` → `GPU` (7 rows), `Evals/s` → `eval/s` (header), `CH3F` → `CH₃F` (3 prose) |
| `docs/benchmarks/gpu.md` | `CH3F` → `CH₃F` (7 prose occurrences, paths unchanged) |
| `docs/benchmarks/rh-enamide.md` | `OpenMM (CUDA)` → `OpenMM` in Backend column |
| `docs/benchmarks/index.md` | `CH3F` → `CH₃F` (4 prose occurrences, path unchanged) |
| `docs/backends/openmm.md` | `GPU (CUDA) support` → `GPU support (via CUDA)` |

## Rationale

- **GPU (CUDA) vs GPU**: Both JAX and OpenMM run on the same RTX 5090 via CUDA. The metadata naming difference (`JAX (gpu)` vs `OpenMM (CUDA)`) leaked into docs as `GPU` vs `GPU (CUDA)`. Now consistently `GPU`.
- **Evals/s vs eval/s**: Normalized to lowercase `eval/s` for consistency with `s/eval` and `ms/eval` used elsewhere.
- **CH3F vs CH₃F**: Unicode subscripts (`CH₃F`) are the standard chemical notation and already used in `tutorial.md` and `backends/index.md`. Now consistent everywhere.

## What was NOT changed

- File paths: `benchmark_results/ch3f/` stays lowercase ASCII
- CLI args: `--system ch3f` stays unchanged
- Code references in Python source files
- The underlying `_parse_engine_name()` logic in `q2mm/diagnostics/benchmark.py` (already correct internally)

## Testing

- `mkdocs build` succeeds with no errors
- Grep confirms zero remaining `CH3F`, `GPU (CUDA)`, `OpenMM (CUDA)`, or `Evals/s` in `docs/`
