### PR TITLE
fix: force CPU-only test execution by default (#217)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,17 @@ python -m ruff format --check q2mm test scripts examples
 python -m pytest test/ -x -q -m "not (openmm or tinker or jax or jax_md or psi4)"
 ```
 
+By default, all tests run on **CPU only** — no GPU memory is allocated.
+This prevents JAX CUDA initialization (~25 GiB VRAM) and OpenMM CUDA
+platform selection from locking up the developer's machine.
+
+To opt into GPU execution for benchmarks or GPU-specific tests:
+
+```bash
+python -m pytest --gpu                 # CLI flag
+Q2MM_USE_GPU=1 python -m pytest        # environment variable
+```
+
 ### Backend Tests (require Docker)
 
 ```bash

--- a/q2mm/backends/base.py
+++ b/q2mm/backends/base.py
@@ -54,6 +54,23 @@ class QMEngine(ABC):
     All QM backends (Psi4, Gaussian, ORCA, etc.) must implement this interface.
     """
 
+    @classmethod
+    def deps_available(cls) -> bool:
+        """Check if this engine's dependencies are installed.
+
+        Lightweight class-level check that does **not** instantiate the
+        engine or trigger heavy initialization (e.g. CUDA/XLA).  Used by
+        :func:`~q2mm.backends.registry._check_available` during test
+        collection to avoid GPU memory allocation.
+
+        Subclasses should override this to return a cheap ``_HAS_*`` flag.
+
+        Returns:
+            bool: ``True`` if all required packages are importable.
+
+        """
+        return False
+
     @abstractmethod
     def energy(self, structure: Q2MMMolecule, method: str = "b3lyp", basis: str = "def2-svp") -> float:
         """Calculate single-point energy in Hartrees.
@@ -165,6 +182,24 @@ class MMEngine(ABC):
     - ``hessian()`` returns Hartree/Bohr² (atomic units)
     - ``frequencies()`` returns cm⁻¹
     """
+
+    @classmethod
+    def deps_available(cls) -> bool:
+        """Check if this engine's dependencies are installed.
+
+        Lightweight class-level check that does **not** instantiate the
+        engine or trigger heavy initialization (e.g. CUDA/XLA, OpenMM
+        platform detection).  Used by
+        :func:`~q2mm.backends.registry._check_available` during test
+        collection to avoid GPU memory allocation.
+
+        Subclasses should override this to return a cheap ``_HAS_*`` flag.
+
+        Returns:
+            bool: ``True`` if all required packages are importable.
+
+        """
+        return False
 
     @abstractmethod
     def energy(self, structure: Q2MMMolecule, forcefield: ForceField) -> float:

--- a/q2mm/backends/mm/jax_engine.py
+++ b/q2mm/backends/mm/jax_engine.py
@@ -582,6 +582,11 @@ class JaxEngine(MMEngine):
         """
         return _HAS_JAX
 
+    @classmethod
+    def deps_available(cls) -> bool:
+        """Check if JAX is importable without triggering CUDA init."""
+        return _HAS_JAX
+
     def supports_runtime_params(self) -> bool:
         """Whether parameters can be updated without rebuilding the system.
 

--- a/q2mm/backends/mm/jax_md_engine.py
+++ b/q2mm/backends/mm/jax_md_engine.py
@@ -599,6 +599,11 @@ class JaxMDEngine(MMEngine):
         """Return whether JAX-MD dependencies are installed."""
         return _HAS_JAX_MD
 
+    @classmethod
+    def deps_available(cls) -> bool:
+        """Check if JAX-MD is importable without triggering CUDA init."""
+        return _HAS_JAX_MD
+
     def supports_runtime_params(self) -> bool:
         """Return True — JAX-MD supports runtime parameter updates."""
         return True

--- a/q2mm/backends/mm/openmm.py
+++ b/q2mm/backends/mm/openmm.py
@@ -325,7 +325,7 @@ def detect_best_platform() -> str:
     _ensure_openmm()
     import os
 
-    env_platform = os.environ.get("OPENMM_DEFAULT_PLATFORM")
+    env_platform = os.environ.get("OPENMM_DEFAULT_PLATFORM", "").strip()
     if env_platform:
         return env_platform
     available = {mm.Platform.getPlatform(i).getName() for i in range(mm.Platform.getNumPlatforms())}

--- a/q2mm/backends/mm/openmm.py
+++ b/q2mm/backends/mm/openmm.py
@@ -304,7 +304,11 @@ _PLATFORM_PRIORITY = ("CUDA", "OpenCL", "CPU", "Reference")
 def detect_best_platform() -> str:
     """Return the name of the fastest available OpenMM platform.
 
-    Platform preference order: CUDA > OpenCL > CPU > Reference.
+    If the ``OPENMM_DEFAULT_PLATFORM`` environment variable is set, its
+    value is returned directly (no validation against installed
+    platforms).  This allows test harnesses to force CPU-only execution.
+
+    Otherwise, platform preference order: CUDA > OpenCL > CPU > Reference.
 
     Logs a warning when CUDA is unavailable and the function falls back
     to OpenCL on a system with an NVIDIA GPU — OpenCL on modern NVIDIA
@@ -319,6 +323,11 @@ def detect_best_platform() -> str:
 
     """
     _ensure_openmm()
+    import os
+
+    env_platform = os.environ.get("OPENMM_DEFAULT_PLATFORM")
+    if env_platform:
+        return env_platform
     available = {mm.Platform.getPlatform(i).getName() for i in range(mm.Platform.getNumPlatforms())}
     for name in _PLATFORM_PRIORITY:
         if name in available:
@@ -703,6 +712,11 @@ class OpenMMEngine(MMEngine):
             bool: ``True`` if the ``openmm`` package is importable.
 
         """
+        return _HAS_OPENMM
+
+    @classmethod
+    def deps_available(cls) -> bool:
+        """Check if OpenMM is importable without platform detection."""
         return _HAS_OPENMM
 
     def supports_runtime_params(self) -> bool:

--- a/q2mm/backends/mm/tinker.py
+++ b/q2mm/backends/mm/tinker.py
@@ -182,8 +182,16 @@ class TinkerEngine(MMEngine):
 
     @classmethod
     def deps_available(cls) -> bool:
-        """Check if Tinker binaries can be found on this system."""
-        return _find_tinker_dir() is not None
+        """Check if Tinker binaries and MM3 parameter file can be found."""
+        tinker_dir = _find_tinker_dir()
+        if tinker_dir is None:
+            return False
+        # __init__ also requires mm3.prm — mirror that check here.
+        candidates = [
+            os.path.join(os.path.dirname(tinker_dir), "params", "mm3.prm"),
+            os.path.join(tinker_dir, "mm3.prm"),
+        ]
+        return any(os.path.isfile(c) for c in candidates)
 
     def _write_tinker_xyz(
         self, structure: str | Q2MMMolecule, forcefield: ForceField | dict[str, int] | str | None, workdir: str

--- a/q2mm/backends/mm/tinker.py
+++ b/q2mm/backends/mm/tinker.py
@@ -180,6 +180,11 @@ class TinkerEngine(MMEngine):
         except FileNotFoundError:
             return False
 
+    @classmethod
+    def deps_available(cls) -> bool:
+        """Check if Tinker binaries can be found on this system."""
+        return _find_tinker_dir() is not None
+
     def _write_tinker_xyz(
         self, structure: str | Q2MMMolecule, forcefield: ForceField | dict[str, int] | str | None, workdir: str
     ) -> str:

--- a/q2mm/backends/qm/psi4.py
+++ b/q2mm/backends/qm/psi4.py
@@ -137,6 +137,11 @@ class Psi4Engine(QMEngine):
         """
         return _HAS_PSI4
 
+    @classmethod
+    def deps_available(cls) -> bool:
+        """Check if Psi4 is importable."""
+        return _HAS_PSI4
+
     def _load_molecule(self, structure: str | tuple[list[str], np.ndarray]) -> object:
         """Load a molecule from an XYZ file path or ``(atoms, coords)`` tuple.
 

--- a/q2mm/backends/registry.py
+++ b/q2mm/backends/registry.py
@@ -118,9 +118,17 @@ def _discover() -> None:
 
 
 def _check_available(cls: type) -> bool:
-    """Instantiate an engine and call ``is_available()`` safely."""
+    """Check whether an engine's dependencies are installed.
+
+    Prefers the lightweight :meth:`deps_available` classmethod which
+    avoids ``__init__`` side effects (JAX CUDA initialization, OpenMM
+    platform detection).  Falls back to instantiation for engines that
+    have not been updated.
+    """
     try:
-        return cls().is_available()
+        if hasattr(cls, "deps_available"):
+            return cls.deps_available()
+        return cls().is_available()  # pragma: no cover — legacy fallback
     except Exception:
         return False
 

--- a/q2mm/backends/registry.py
+++ b/q2mm/backends/registry.py
@@ -126,9 +126,9 @@ def _check_available(cls: type) -> bool:
     have not been updated.
     """
     try:
-        if hasattr(cls, "deps_available"):
+        if "deps_available" in cls.__dict__:
             return cls.deps_available()
-        return cls().is_available()  # pragma: no cover — legacy fallback
+        return cls().is_available()
     except Exception:
         return False
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -17,6 +17,15 @@ slower tiers::
     pytest --run-medium        # fast + medium (~49s)
     pytest --run-slow          # everything (~330s)
 
+GPU enforcement
+---------------
+By default, all backends are forced to CPU to prevent GPU memory
+allocation from locking up the local machine.  Use ``--gpu`` or set
+``Q2MM_USE_GPU=1`` to opt into GPU execution::
+
+    pytest --gpu               # allow GPU backends
+    Q2MM_USE_GPU=1 pytest      # same via env var
+
 Backend markers
 ---------------
 Tests can be tagged with ``@pytest.mark.openmm``, ``@pytest.mark.tinker``,
@@ -89,6 +98,13 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=False,
         help="Include slow tests (>10s each); implies --run-medium",
     )
+    parser.addoption(
+        "--gpu",
+        action="store_true",
+        default=False,
+        help="Allow GPU backends (JAX CUDA, OpenMM CUDA). Without this flag, "
+        "all tests run on CPU to avoid locking up the local machine.",
+    )
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -104,18 +120,22 @@ def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line("markers", "jax_md: requires JAX-MD backend")
     config.addinivalue_line("markers", "psi4: requires Psi4 QM backend")
 
-    # Prevent JAX from allocating GPU memory when JAX tests are excluded.
-    # JAX initialises CUDA at import time, consuming ~25 GiB of VRAM even
-    # when no JAX tests will run.  Setting JAX_PLATFORMS=cpu before import
-    # keeps the GPU free for other work.
+    # Force CPU-only unless the user explicitly opts into GPU execution.
+    # JAX initializes CUDA at import time, consuming ~25 GiB of VRAM.
+    # OpenMM defaults to the "best" platform (CUDA > OpenCL > CPU).
+    # Both are dangerous when automated tools invoke pytest without
+    # knowing they need CPU-only configuration.
     import os
-    import re
 
-    markexpr = getattr(config.option, "markexpr", "") or ""
-    # Match "not jax" or "not (...jax...)" but not "not slow and jax"
-    jax_excluded = bool(re.search(r"\bnot\s+jax\b", markexpr) or re.search(r"\bnot\s*\(.*\bjax\b", markexpr))
-    if jax_excluded and "JAX_PLATFORMS" not in os.environ:
-        os.environ["JAX_PLATFORMS"] = "cpu"
+    gpu_opt_in = getattr(config.option, "gpu", False) or os.environ.get("Q2MM_USE_GPU", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+    if not gpu_opt_in:
+        os.environ.setdefault("JAX_PLATFORMS", "cpu")
+        os.environ.setdefault("OPENMM_DEFAULT_PLATFORM", "CPU")
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -20,8 +20,10 @@ slower tiers::
 GPU enforcement
 ---------------
 By default, all backends are forced to CPU to prevent GPU memory
-allocation from locking up the local machine.  Use ``--gpu`` or set
-``Q2MM_USE_GPU=1`` to opt into GPU execution::
+allocation from locking up the local machine.  This applies only when
+``JAX_PLATFORMS`` and ``OPENMM_DEFAULT_PLATFORM`` are not already set
+in the environment.  Use ``--gpu`` or set ``Q2MM_USE_GPU=1`` to opt
+into GPU execution::
 
     pytest --gpu               # allow GPU backends
     Q2MM_USE_GPU=1 pytest      # same via env var
@@ -103,7 +105,8 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         action="store_true",
         default=False,
         help="Allow GPU backends (JAX CUDA, OpenMM CUDA). Without this flag, "
-        "all tests run on CPU to avoid locking up the local machine.",
+        "tests default to CPU unless JAX_PLATFORMS or OPENMM_DEFAULT_PLATFORM "
+        "is already set in the environment.",
     )
 
 

--- a/test/test_openmm_platform.py
+++ b/test/test_openmm_platform.py
@@ -30,14 +30,13 @@ def _mock_platforms(names: list[str]) -> tuple:
     return len(platforms), lambda i: platforms[i]
 
 
-@pytest.fixture(autouse=True)
-def _clear_platform_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Remove OPENMM_DEFAULT_PLATFORM so tests exercise real detection logic."""
-    monkeypatch.delenv("OPENMM_DEFAULT_PLATFORM", raising=False)
-
-
 class TestDetectBestPlatform:
     """Tests for detect_best_platform()."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_platform_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Remove OPENMM_DEFAULT_PLATFORM so tests exercise real detection."""
+        monkeypatch.delenv("OPENMM_DEFAULT_PLATFORM", raising=False)
 
     def test_prefers_cuda_over_cpu(self) -> None:
         num, get = _mock_platforms(["Reference", "CPU", "CUDA"])

--- a/test/test_openmm_platform.py
+++ b/test/test_openmm_platform.py
@@ -30,6 +30,12 @@ def _mock_platforms(names: list[str]) -> tuple:
     return len(platforms), lambda i: platforms[i]
 
 
+@pytest.fixture(autouse=True)
+def _clear_platform_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove OPENMM_DEFAULT_PLATFORM so tests exercise real detection logic."""
+    monkeypatch.delenv("OPENMM_DEFAULT_PLATFORM", raising=False)
+
+
 class TestDetectBestPlatform:
     """Tests for detect_best_platform()."""
 
@@ -67,6 +73,16 @@ class TestDetectBestPlatform:
 
     def test_priority_constant_has_expected_order(self) -> None:
         assert _PLATFORM_PRIORITY == ("CUDA", "OpenCL", "CPU", "Reference")
+
+    def test_env_var_overrides_detection(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """OPENMM_DEFAULT_PLATFORM bypasses platform scanning entirely."""
+        monkeypatch.setenv("OPENMM_DEFAULT_PLATFORM", "CPU")
+        num, get = _mock_platforms(["Reference", "CPU", "CUDA"])
+        with (
+            patch.object(openmm.Platform, "getNumPlatforms", return_value=num),
+            patch.object(openmm.Platform, "getPlatform", side_effect=get),
+        ):
+            assert detect_best_platform() == "CPU"
 
 
 class TestPrecisionValidation:

--- a/test/test_registry.py
+++ b/test/test_registry.py
@@ -159,3 +159,32 @@ class TestCheckAvailable:
                 return False
 
         assert _check_available(LegacyUnavailable) is False
+
+    def test_subclass_without_override_falls_back(self) -> None:
+        """Engine subclass inheriting base deps_available() uses instantiation."""
+        from q2mm.backends.base import MMEngine
+
+        class CustomEngine(MMEngine):
+            @property
+            def name(self) -> str:
+                return "custom"
+
+            def is_available(self) -> bool:
+                return True
+
+            def energy(self, *a: object, **kw: object) -> None:
+                pass
+
+            def gradient(self, *a: object, **kw: object) -> None:
+                pass
+
+            def hessian(self, *a: object, **kw: object) -> None:
+                pass
+
+            def frequencies(self, *a: object, **kw: object) -> None:
+                pass
+
+            def minimize(self, *a: object, **kw: object) -> None:
+                pass
+
+        assert _check_available(CustomEngine) is True

--- a/test/test_registry.py
+++ b/test/test_registry.py
@@ -109,16 +109,53 @@ class TestCheckAvailable:
 
         assert _check_available(OpenMMEngine) is True
 
+    def test_check_available_prefers_deps_available(self) -> None:
+        """_check_available should call deps_available() and never __init__."""
+
+        class LightweightEngine:
+            init_called = False
+
+            def __init__(self) -> None:
+                LightweightEngine.init_called = True
+
+            @classmethod
+            def deps_available(cls) -> bool:
+                return True
+
+            def is_available(self) -> bool:
+                return True
+
+        assert _check_available(LightweightEngine) is True
+        assert not LightweightEngine.init_called
+
+    def test_check_available_deps_available_false(self) -> None:
+        class UnavailableEngine:
+            @classmethod
+            def deps_available(cls) -> bool:
+                return False
+
+        assert _check_available(UnavailableEngine) is False
+
     def test_check_available_with_broken_class(self) -> None:
         class BrokenEngine:
-            def is_available(self) -> bool:
+            @classmethod
+            def deps_available(cls) -> bool:
                 raise RuntimeError("boom")
 
         assert _check_available(BrokenEngine) is False
 
-    def test_check_available_with_unavailable_class(self) -> None:
-        class UnavailableEngine:
+    def test_check_available_legacy_fallback(self) -> None:
+        """Classes without deps_available fall back to instantiation."""
+
+        class LegacyEngine:
+            def is_available(self) -> bool:
+                return True
+
+        assert _check_available(LegacyEngine) is True
+
+    def test_check_available_legacy_unavailable(self) -> None:
+        class LegacyUnavailable:
             def is_available(self) -> bool:
                 return False
 
-        assert _check_available(UnavailableEngine) is False
+        assert _check_available(LegacyUnavailable) is False


### PR DESCRIPTION
## Summary

Prevent default `pytest` runs from consuming GPU resources. Plain `pytest` was triggering JAX CUDA initialization (~25 GiB VRAM) and OpenMM CUDA platform selection because engine availability checks instantiated engine classes, and the JAX CPU guard only fired with specific `-m` flags.

Closes #217

## Changes

| Layer | What changed |
|-------|-------------|
| `test/conftest.py` | Unconditionally set `JAX_PLATFORMS=cpu` + `OPENMM_DEFAULT_PLATFORM=CPU`; add `--gpu` flag and `Q2MM_USE_GPU=1` env var for opt-in GPU use |
| `q2mm/backends/registry.py` | `_check_available()` calls `cls.deps_available()` (cheap classmethod) instead of `cls()` which triggered GPU init |
| `q2mm/backends/base.py` | Add `deps_available()` classmethod to `QMEngine` and `MMEngine` base classes |
| `q2mm/backends/mm/openmm.py` | `detect_best_platform()` honors `OPENMM_DEFAULT_PLATFORM` env var; add `deps_available()` override |
| `q2mm/backends/mm/jax_engine.py` | Add `deps_available()` returning `_HAS_JAX` (uses `find_spec`, no CUDA init) |
| `q2mm/backends/mm/jax_md_engine.py` | Add `deps_available()` returning `_HAS_JAX_MD` |
| `q2mm/backends/mm/tinker.py` | Add `deps_available()` using `_find_tinker_dir()` (filesystem check, no heavy init) |
| `q2mm/backends/qm/psi4.py` | Add `deps_available()` returning `_HAS_PSI4` |
| `test/test_openmm_platform.py` | Add env var override test; fixture to clear `OPENMM_DEFAULT_PLATFORM` for detection tests |
| `test/test_registry.py` | Tests for `deps_available` preference, legacy fallback, broken/unavailable engines |
| `AGENTS.md` | Document CPU-default behavior and `--gpu` opt-in |

## Root cause

Three issues combined:
1. **JAX guard was conditional** -- only fired when `-m "not jax"` was in the mark expression, so plain `pytest` skipped the guard entirely
2. **`_check_available()` instantiated engines** -- `cls()` triggered `JaxEngine.__init__()` → `import jax` → XLA/CUDA init
3. **No `OPENMM_DEFAULT_PLATFORM` support** -- `detect_best_platform()` always selected CUDA when available

## Testing

- 765 tests pass, 0 failures, 20 skipped
- Lint + format clean (`ruff check` + `ruff format --check`)
- New tests verify `deps_available()` is preferred over instantiation, env var override works, and legacy fallback still functions
