### PR TITLE
fix: resolve gradient metadata from evaluators, not hardcoded (#216)

### DIFF
--- a/q2mm/diagnostics/benchmark.py
+++ b/q2mm/diagnostics/benchmark.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from q2mm.diagnostics.systems import SystemData
     from q2mm.models.forcefield import ForceField
     from q2mm.models.molecule import Q2MMMolecule
+    from q2mm.optimizers.objective import ObjectiveFunction
 
 
 @functools.lru_cache(maxsize=1)
@@ -98,34 +99,41 @@ def _collect_environment() -> dict[str, Any]:
 
 def _resolve_gradients(
     jac_mode: str | None,
-    engine: MMEngine,
+    objective: ObjectiveFunction,
     method: str = "L-BFGS-B",
 ) -> dict[str, str]:
     """Determine per-evaluator gradient mode from jac config and engine.
 
-    Returns a dict mapping evaluator category to its gradient source:
-    ``"analytical"``, ``"finite-diff"``, or ``"n/a"`` (derivative-free).
+    Queries ``objective.per_evaluator_gradient_support()`` to determine
+    which evaluator categories support analytical gradients on the current
+    engine.  Returns a dict mapping each active category to its gradient
+    source: ``"analytical"``, ``"finite-diff"``, or ``"n/a"``.
 
-    Energy evaluators can use analytical gradients when the engine
-    supports them and jac_mode is ``"auto"`` or ``"analytical"``.
-    Frequency evaluators always use finite-diff (issue #216).
-    Derivative-free optimizers get ``"n/a"`` for all evaluators.
+    Args:
+        jac_mode: Jacobian strategy (``"auto"``, ``"analytical"``, or
+            ``None`` for scipy finite-differences).
+        objective: The objective function whose evaluators are queried.
+        method: Optimizer method name.  Derivative-free methods
+            (``"Nelder-Mead"``, ``"Powell"``) get ``"n/a"`` for all.
+
     """
     _DERIVATIVE_FREE = {"Nelder-Mead", "Powell"}
+    support = objective.per_evaluator_gradient_support()
 
     if method in _DERIVATIVE_FREE:
-        return {"energy": "n/a", "frequency": "n/a"}
+        return {cat: "n/a" for cat in support}
 
     # jac_mode=None means scipy computes FD gradients internally
     if jac_mode is None:
-        return {"energy": "finite-diff", "frequency": "finite-diff"}
+        return {cat: "finite-diff" for cat in support}
 
-    energy_grad = "finite-diff"
-    if jac_mode in ("auto", "analytical"):
-        if engine.supports_analytical_gradients():
-            energy_grad = "analytical"
-
-    return {"energy": energy_grad, "frequency": "finite-diff"}
+    result: dict[str, str] = {}
+    for cat, has_analytical in support.items():
+        if jac_mode in ("auto", "analytical") and has_analytical:
+            result[cat] = "analytical"
+        else:
+            result[cat] = "finite-diff"
+    return result
 
 
 # ── Engine display name → (engine_key, ff_label) mapping ────────────
@@ -660,7 +668,7 @@ def run_combo(
         eps = loop.eps if uses_scipy_fd else None
 
         # Per-evaluator gradient resolution
-        gradients = _resolve_gradients(jac_mode, obj.engine, method=loop.full_method)
+        gradients = _resolve_gradients(jac_mode, obj, method=loop.full_method)
     else:
         from q2mm.optimizers.scipy_opt import ScipyOptimizer
 
@@ -683,7 +691,7 @@ def run_combo(
         eps = opt_result.eps
 
         # Per-evaluator gradient resolution
-        gradients = _resolve_gradients(jac_mode, obj.engine, method=optimizer_method)
+        gradients = _resolve_gradients(jac_mode, obj, method=optimizer_method)
 
     # Record optimizer settings in metadata
     result.metadata["jac_mode"] = jac_mode

--- a/q2mm/diagnostics/benchmark.py
+++ b/q2mm/diagnostics/benchmark.py
@@ -102,12 +102,12 @@ def _resolve_gradients(
     objective: ObjectiveFunction,
     method: str = "L-BFGS-B",
 ) -> dict[str, str]:
-    """Determine per-evaluator gradient mode from jac config and engine.
+    """Determine per-evaluator gradient mode from jac config and objective.
 
     Queries ``objective.per_evaluator_gradient_support()`` to determine
-    which evaluator categories support analytical gradients on the current
-    engine.  Returns a dict mapping each active category to its gradient
-    source: ``"analytical"``, ``"finite-diff"``, or ``"n/a"``.
+    which evaluator categories support analytical gradients on the
+    objective's engine.  Returns a dict mapping each active category to
+    its gradient source: ``"analytical"``, ``"finite-diff"``, or ``"n/a"``.
 
     Args:
         jac_mode: Jacobian strategy (``"auto"``, ``"analytical"``, or

--- a/q2mm/optimizers/objective.py
+++ b/q2mm/optimizers/objective.py
@@ -1290,6 +1290,28 @@ class ObjectiveFunction:
 
         return total_grad
 
+    def per_evaluator_gradient_support(self) -> dict[str, bool]:
+        """Return per-category analytical gradient support for the current engine.
+
+        Queries each evaluator's :meth:`supports_analytical_gradient` for
+        the categories that have at least one reference value.  The result
+        reflects the **actual** gradient dispatch path used by
+        :meth:`gradient` — no hardcoded assumptions.
+
+        Returns:
+            Mapping from evaluator category (``"energy"``, ``"frequency"``,
+            etc.) to ``True`` if analytical gradients are available, ``False``
+            if finite-difference fallback will be used.
+
+        """
+        categories: dict[str, bool] = {}
+        for ref in self.reference.values:
+            cat = self._kind_to_category(ref.kind)
+            if cat not in categories:
+                evaluator = self._get_evaluator(cat)
+                categories[cat] = evaluator.supports_analytical_gradient(self.engine)
+        return dict(sorted(categories.items()))
+
     def _finite_difference_gradient(
         self,
         param_vector: np.ndarray,

--- a/test/test_optimizer_jac.py
+++ b/test/test_optimizer_jac.py
@@ -14,6 +14,7 @@ import pytest
 
 from q2mm.optimizers.scipy_opt import ScipyOptimizer
 from q2mm.diagnostics.benchmark import _resolve_gradients
+from q2mm.optimizers.objective import ObjectiveFunction, ReferenceData
 
 
 class _MockObjective:
@@ -154,39 +155,136 @@ class TestOptimizationResultFields:
 class TestResolveGradients:
     """Verify _resolve_gradients produces correct per-evaluator gradient maps."""
 
-    def test_auto_with_analytical_support(self) -> None:
+    @staticmethod
+    def _make_objective(
+        *, engine_supports_grad: bool, kinds: tuple[str, ...] = ("energy", "frequency")
+    ) -> ObjectiveFunction:
+        """Build a minimal ObjectiveFunction with real evaluators and mock engine."""
         engine = MagicMock()
-        engine.supports_analytical_gradients.return_value = True
-        result = _resolve_gradients("auto", engine)
+        engine.supports_analytical_gradients.return_value = engine_supports_grad
+        ff = MagicMock()
+        ref = ReferenceData()
+        for kind in kinds:
+            if kind == "energy":
+                ref.add_energy(0.0)
+            elif kind == "frequency":
+                ref.add_frequency(100.0, data_idx=0)
+            elif kind == "bond_length":
+                ref.add_bond_length(1.5, atom_indices=(0, 1))
+            elif kind == "hessian_element":
+                ref.add_hessian_element(0.1, row=0, col=0)
+        return ObjectiveFunction(ff, engine, [], ref)
+
+    def test_auto_with_analytical_support(self) -> None:
+        obj = self._make_objective(engine_supports_grad=True)
+        result = _resolve_gradients("auto", obj)
         assert result == {"energy": "analytical", "frequency": "finite-diff"}
 
     def test_auto_without_analytical_support(self) -> None:
-        engine = MagicMock()
-        engine.supports_analytical_gradients.return_value = False
-        result = _resolve_gradients("auto", engine)
+        obj = self._make_objective(engine_supports_grad=False)
+        result = _resolve_gradients("auto", obj)
         assert result == {"energy": "finite-diff", "frequency": "finite-diff"}
 
     def test_jac_none_is_fd(self) -> None:
-        engine = MagicMock()
-        engine.supports_analytical_gradients.return_value = True
-        result = _resolve_gradients(None, engine)
+        obj = self._make_objective(engine_supports_grad=True)
+        result = _resolve_gradients(None, obj)
         assert result == {"energy": "finite-diff", "frequency": "finite-diff"}
 
     def test_analytical_with_support(self) -> None:
-        engine = MagicMock()
-        engine.supports_analytical_gradients.return_value = True
-        result = _resolve_gradients("analytical", engine)
+        obj = self._make_objective(engine_supports_grad=True)
+        result = _resolve_gradients("analytical", obj)
         assert result == {"energy": "analytical", "frequency": "finite-diff"}
 
     def test_derivative_free_method_overrides_jac(self) -> None:
         """Even if jac_mode='auto', a derivative-free method gets n/a."""
-        engine = MagicMock()
-        engine.supports_analytical_gradients.return_value = True
-        result = _resolve_gradients("auto", engine, method="Powell")
+        obj = self._make_objective(engine_supports_grad=True)
+        result = _resolve_gradients("auto", obj, method="Powell")
         assert result == {"energy": "n/a", "frequency": "n/a"}
 
     def test_nelder_mead_is_derivative_free(self) -> None:
-        engine = MagicMock()
-        engine.supports_analytical_gradients.return_value = True
-        result = _resolve_gradients("auto", engine, method="Nelder-Mead")
+        obj = self._make_objective(engine_supports_grad=True)
+        result = _resolve_gradients("auto", obj, method="Nelder-Mead")
         assert result == {"energy": "n/a", "frequency": "n/a"}
+
+    def test_energy_only_objective(self) -> None:
+        """When objective has only energy refs, frequency is absent from output."""
+        obj = self._make_objective(engine_supports_grad=True, kinds=("energy",))
+        result = _resolve_gradients("auto", obj)
+        assert result == {"energy": "analytical"}
+
+    def test_frequency_only_objective(self) -> None:
+        """When objective has only frequency refs, energy is absent from output."""
+        obj = self._make_objective(engine_supports_grad=True, kinds=("frequency",))
+        result = _resolve_gradients("auto", obj)
+        assert result == {"frequency": "finite-diff"}
+
+    def test_geometry_refs_always_fd(self) -> None:
+        """Geometry evaluator doesn't support analytical gradients."""
+        obj = self._make_objective(engine_supports_grad=True, kinds=("energy", "bond_length"))
+        result = _resolve_gradients("auto", obj)
+        assert result == {"energy": "analytical", "geometry": "finite-diff"}
+
+    def test_hessian_refs_always_fd(self) -> None:
+        """Hessian element evaluator doesn't support analytical gradients."""
+        obj = self._make_objective(engine_supports_grad=True, kinds=("energy", "hessian_element"))
+        result = _resolve_gradients("auto", obj)
+        assert result == {"energy": "analytical", "hessian": "finite-diff"}
+
+
+class TestPerEvaluatorGradientSupport:
+    """Verify ObjectiveFunction.per_evaluator_gradient_support()."""
+
+    @staticmethod
+    def _make_objective(*, engine_supports_grad: bool, kinds: tuple[str, ...]) -> ObjectiveFunction:
+        engine = MagicMock()
+        engine.supports_analytical_gradients.return_value = engine_supports_grad
+        ref = ReferenceData()
+        for kind in kinds:
+            if kind == "energy":
+                ref.add_energy(0.0)
+            elif kind == "frequency":
+                ref.add_frequency(100.0, data_idx=0)
+            elif kind == "bond_length":
+                ref.add_bond_length(1.5, atom_indices=(0, 1))
+            elif kind == "hessian_element":
+                ref.add_hessian_element(0.1, row=0, col=0)
+        return ObjectiveFunction(MagicMock(), engine, [], ref)
+
+    def test_energy_and_frequency_with_analytical_engine(self) -> None:
+        obj = self._make_objective(engine_supports_grad=True, kinds=("energy", "frequency"))
+        result = obj.per_evaluator_gradient_support()
+        assert result == {"energy": True, "frequency": False}
+
+    def test_energy_and_frequency_without_analytical_engine(self) -> None:
+        obj = self._make_objective(engine_supports_grad=False, kinds=("energy", "frequency"))
+        result = obj.per_evaluator_gradient_support()
+        assert result == {"energy": False, "frequency": False}
+
+    def test_energy_only(self) -> None:
+        obj = self._make_objective(engine_supports_grad=True, kinds=("energy",))
+        result = obj.per_evaluator_gradient_support()
+        assert result == {"energy": True}
+
+    def test_frequency_only(self) -> None:
+        obj = self._make_objective(engine_supports_grad=True, kinds=("frequency",))
+        result = obj.per_evaluator_gradient_support()
+        assert result == {"frequency": False}
+
+    def test_geometry_always_false(self) -> None:
+        obj = self._make_objective(engine_supports_grad=True, kinds=("bond_length",))
+        result = obj.per_evaluator_gradient_support()
+        assert result == {"geometry": False}
+
+    def test_hessian_always_false(self) -> None:
+        obj = self._make_objective(engine_supports_grad=True, kinds=("hessian_element",))
+        result = obj.per_evaluator_gradient_support()
+        assert result == {"hessian": False}
+
+    def test_result_is_sorted_by_category(self) -> None:
+        """Categories are returned in sorted order for deterministic metadata."""
+        obj = self._make_objective(
+            engine_supports_grad=True,
+            kinds=("frequency", "energy", "hessian_element", "bond_length"),
+        )
+        result = obj.per_evaluator_gradient_support()
+        assert list(result.keys()) == ["energy", "frequency", "geometry", "hessian"]


### PR DESCRIPTION
## Summary

Fixes #216 — `_resolve_gradients()` in benchmark metadata hardcoded which evaluator categories support analytical gradients instead of querying the actual evaluators. This meant metadata could lie if evaluator capabilities changed.

## Changes

### `q2mm/optimizers/objective.py`
- Added `per_evaluator_gradient_support()` method to `ObjectiveFunction`
- Queries each evaluator's `supports_analytical_gradient(engine)` for categories that have actual references
- Returns `dict[str, bool]` — single source of truth for gradient dispatch

### `q2mm/diagnostics/benchmark.py`
- Refactored `_resolve_gradients()` to accept `ObjectiveFunction` instead of `MMEngine`
- Delegates per-evaluator capability check to the new method
- Updated both call sites (cycling optimizer and scipy optimizer paths)

### `test/test_optimizer_jac.py`
- Updated `TestResolveGradients` to use real `ObjectiveFunction` with mock engines
- Added 5 new tests: energy-only, frequency-only, geometry, hessian, and all-category objectives
- Added `TestPerEvaluatorGradientSupport` with 7 tests for the new method

## Before / After

**Before**: `_resolve_gradients()` hardcoded `{"energy": ..., "frequency": "finite-diff"}`, ignoring geometry/eigenmatrix/hessian categories and duplicating evaluator logic.

**After**: queries each evaluator's actual `supports_analytical_gradient(engine)` — only includes categories with references, automatically covers all current and future evaluator types.

## Test Results

All 777 core tests pass (11 new tests added).
