### PR TITLE
feat(seminario): implement QFUERZA hybrid initialization

### DIFF
--- a/docs/how-it-works/theory.md
+++ b/docs/how-it-works/theory.md
@@ -81,7 +81,7 @@ from q2mm.models.seminario import estimate_force_constants
 # Standard Seminario/FUERZA (default)
 ff = estimate_force_constants(molecule)
 
-# QFUERZA: substitutes 0.5 mdyn/rad² for hydrogen angle bends
+# QFUERZA: substitutes 0.5 mdyn·Å/rad² for hydrogen angle bends
 ff = estimate_force_constants(molecule, strategy="qfuerza")
 ```
 

--- a/docs/how-it-works/theory.md
+++ b/docs/how-it-works/theory.md
@@ -73,6 +73,18 @@ to starting from generic approximations.
 The implementation lives in
 [`q2mm.models.seminario`](../reference/q2mm/models/seminario.md).
 
+To use QFUERZA initialization:
+
+```python
+from q2mm.models.seminario import estimate_force_constants
+
+# Standard Seminario/FUERZA (default)
+ff = estimate_force_constants(molecule)
+
+# QFUERZA: substitutes 0.5 mdyn/rad² for hydrogen angle bends
+ff = estimate_force_constants(molecule, strategy="qfuerza")
+```
+
 ---
 
 ## Stage 2: transition state eigenvalue treatment

--- a/q2mm/models/seminario.py
+++ b/q2mm/models/seminario.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 # See: Scott & Radom, J. Phys. Chem. 1996, 100, 16502-16513.
 DEFAULT_DFT_SCALING = 0.963
 
-# QFUERZA empirical default for hydrogen angle bends (mdyn/rad²).
+# QFUERZA empirical default for hydrogen angle bends (mdyn·Å/rad²).
 # Farrugia et al., J. Chem. Theory Comput. 2026, 22, 469-476, Table 1.
 QFUERZA_H_ANGLE_DEFAULT_MDYNA = 0.5
 QFUERZA_H_ANGLE_DEFAULT_CANONICAL = QFUERZA_H_ANGLE_DEFAULT_MDYNA * MDYNA_RAD2_TO_KCALMOLRAD2
@@ -311,6 +311,9 @@ def estimate_force_constants(
         ForceField with estimated parameters
 
     """
+    if strategy not in ("fuerza", "qfuerza"):
+        raise ValueError(f"Unsupported strategy {strategy!r}; expected 'fuerza' or 'qfuerza'")
+
     molecules = _coerce_molecules(molecule)
     if any(item.hessian is None for item in molecules):
         raise ValueError("Molecule must have a Hessian attached. Use molecule.with_hessian(hess)")
@@ -415,7 +418,7 @@ def estimate_force_constants(
                 angle_param.force_constant = QFUERZA_H_ANGLE_DEFAULT_CANONICAL
                 logger.info(
                     f"  Angle {angle_param.key}: QFUERZA H-angle substitution — "
-                    f"{QFUERZA_H_ANGLE_DEFAULT_MDYNA} mdyn/rad² "
+                    f"{QFUERZA_H_ANGLE_DEFAULT_MDYNA} mdyn·Å/rad² "
                     f"(FUERZA was {fuerza_value:.4f} kcal/(mol·rad²))"
                 )
             else:

--- a/q2mm/models/seminario.py
+++ b/q2mm/models/seminario.py
@@ -21,6 +21,7 @@ from q2mm.constants import BOHR_TO_ANG
 from q2mm.models.units import (
     AU_BOND_K_TO_CANONICAL,
     AU_ANGLE_K_TO_CANONICAL,
+    MDYNA_RAD2_TO_KCALMOLRAD2,
 )
 from q2mm.models.molecule import Q2MMMolecule
 from q2mm.models.forcefield import AngleParam, BondParam, ForceField
@@ -40,6 +41,16 @@ logger = logging.getLogger(__name__)
 # Default DFT Hessian scaling factor (B3LYP/6-31G* level).
 # See: Scott & Radom, J. Phys. Chem. 1996, 100, 16502-16513.
 DEFAULT_DFT_SCALING = 0.963
+
+# QFUERZA empirical default for hydrogen angle bends (mdyn/rad²).
+# Farrugia et al., J. Chem. Theory Comput. 2026, 22, 469-476, Table 1.
+QFUERZA_H_ANGLE_DEFAULT_MDYNA = 0.5
+QFUERZA_H_ANGLE_DEFAULT_CANONICAL = QFUERZA_H_ANGLE_DEFAULT_MDYNA * MDYNA_RAD2_TO_KCALMOLRAD2
+
+
+def _is_hydrogen_angle(elements: tuple[str, str, str]) -> bool:
+    """Return True if either outer atom of an angle is hydrogen."""
+    return elements[0] == "H" or elements[2] == "H"
 
 
 def _coerce_molecules(
@@ -271,6 +282,7 @@ def estimate_force_constants(
     au_hessian: bool = True,
     invalid_policy: Literal["keep", "skip"] = "keep",
     ts_method: Literal["C", "D"] | None = None,
+    strategy: Literal["fuerza", "qfuerza"] = "fuerza",
 ) -> ForceField:
     """Estimate force constants from one or more QM Hessians using Seminario.
 
@@ -290,6 +302,10 @@ def estimate_force_constants(
             Norrby 2015).  ``"D"`` keeps the natural eigenvalue (Method D).
             ``None`` (default) uses the Hessian as-is, which is correct for
             ground-state molecules.
+        strategy: Initialization strategy. ``"fuerza"`` (default) uses pure
+            Seminario projection.  ``"qfuerza"`` substitutes empirical defaults
+            for hydrogen angle bends, where FUERZA overestimates by ~2×
+            (Farrugia et al. JCTC 2026).
 
     Returns:
         ForceField with estimated parameters
@@ -393,11 +409,21 @@ def estimate_force_constants(
         if equilibria:
             angle_param.equilibrium = float(np.mean(equilibria))
         if force_constants:
-            angle_param.force_constant = float(np.mean(force_constants))
-            logger.info(
-                f"  Angle {angle_param.key}: k={angle_param.force_constant:.4f}, "
-                f"theta0={angle_param.equilibrium:.1f} deg"
-            )
+            fuerza_value = float(np.mean(force_constants))
+
+            if strategy == "qfuerza" and _is_hydrogen_angle(angle_param.elements):
+                angle_param.force_constant = QFUERZA_H_ANGLE_DEFAULT_CANONICAL
+                logger.info(
+                    f"  Angle {angle_param.key}: QFUERZA H-angle substitution — "
+                    f"{QFUERZA_H_ANGLE_DEFAULT_MDYNA} mdyn/rad² "
+                    f"(FUERZA was {fuerza_value:.4f} kcal/(mol·rad²))"
+                )
+            else:
+                angle_param.force_constant = fuerza_value
+                logger.info(
+                    f"  Angle {angle_param.key}: k={angle_param.force_constant:.4f}, "
+                    f"theta0={angle_param.equilibrium:.1f} deg"
+                )
         else:
             logger.warning(
                 f"  Angle {angle_param.key}: no valid force constants found, keeping existing force constant"
@@ -423,6 +449,7 @@ def estimate_force_constants_method_e(
     au_hessian: bool = True,
     invalid_policy: Literal["keep", "skip"] = "keep",
     fc_threshold: float = 0.0,
+    strategy: Literal["fuerza", "qfuerza"] = "fuerza",
 ) -> tuple[ForceField, dict]:
     """Estimate force constants using Method E (hybrid D/C).
 
@@ -446,6 +473,8 @@ def estimate_force_constants_method_e(
         invalid_policy: How to handle negative projected force constants.
         fc_threshold: Force constants at or below this value are
             considered problematic and replaced with Method C values.
+        strategy: Initialization strategy (``"fuerza"`` or ``"qfuerza"``).
+            Passed through to ``estimate_force_constants()``.
 
     Returns:
         Tuple of:
@@ -461,6 +490,7 @@ def estimate_force_constants_method_e(
         zero_torsions=zero_torsions,
         au_hessian=au_hessian,
         invalid_policy=invalid_policy,
+        strategy=strategy,
     )
 
     ff_d = estimate_force_constants(molecule, ts_method="D", **common_kwargs)

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -19,7 +19,11 @@ from q2mm.models.forcefield import (
     VdwParam,
     _extract_element,
 )
-from q2mm.models.seminario import estimate_force_constants
+from q2mm.models.seminario import (
+    estimate_force_constants,
+    _is_hydrogen_angle,
+    QFUERZA_H_ANGLE_DEFAULT_CANONICAL,
+)
 from q2mm.io.tinker import _tinker_import_ff
 
 # Fixture paths (test-specific, not shared)
@@ -1093,6 +1097,100 @@ class TestSeminario:
         mol = Q2MMMolecule.from_xyz(CH3F_XYZ)
         with pytest.raises(ValueError, match="Hessian"):
             estimate_force_constants(mol)
+
+
+class TestQFUERZA:
+    """Tests for QFUERZA hybrid initialization (issue #208)."""
+
+    @pytest.fixture
+    def ch3f_mol_with_hess(self) -> Q2MMMolecule:
+        mol = Q2MMMolecule.from_xyz(CH3F_XYZ)
+        hess = np.load(CH3F_HESS)
+        return mol.with_hessian(hess)
+
+    @pytest.fixture
+    def water_mol_with_hess(self) -> Q2MMMolecule:
+        from test._shared import make_water
+
+        mol = make_water()
+        n = len(mol.symbols)
+        rng = np.random.default_rng(42)
+        h = rng.standard_normal((3 * n, 3 * n))
+        h = (h + h.T) / 2
+        return mol.with_hessian(h)
+
+    # -- _is_hydrogen_angle helper --
+
+    @pytest.mark.parametrize(
+        "elements,expected",
+        [
+            (("H", "O", "H"), True),
+            (("H", "C", "H"), True),
+            (("H", "C", "F"), True),
+            (("F", "C", "H"), True),
+            (("C", "O", "C"), False),
+            (("C", "C", "C"), False),
+            (("N", "C", "O"), False),
+        ],
+    )
+    def test_is_hydrogen_angle(self, elements: tuple, expected: bool) -> None:
+        assert _is_hydrogen_angle(elements) == expected
+
+    # -- strategy="fuerza" regression --
+
+    def test_fuerza_strategy_unchanged(self, ch3f_mol_with_hess: Q2MMMolecule) -> None:
+        """strategy='fuerza' gives identical results to no-strategy call."""
+        ff_default = estimate_force_constants(ch3f_mol_with_hess)
+        ff_fuerza = estimate_force_constants(ch3f_mol_with_hess, strategy="fuerza")
+
+        for b_def, b_fur in zip(ff_default.bonds, ff_fuerza.bonds):
+            assert b_def.force_constant == pytest.approx(b_fur.force_constant)
+        for a_def, a_fur in zip(ff_default.angles, ff_fuerza.angles):
+            assert a_def.force_constant == pytest.approx(a_fur.force_constant)
+
+    # -- strategy="qfuerza" substitution --
+
+    def test_qfuerza_substitutes_h_angles(self, water_mol_with_hess: Q2MMMolecule) -> None:
+        """QFUERZA replaces the H-O-H angle force constant with the empirical default."""
+        ff = estimate_force_constants(water_mol_with_hess, strategy="qfuerza")
+        for angle in ff.angles:
+            if _is_hydrogen_angle(angle.elements):
+                assert angle.force_constant == pytest.approx(QFUERZA_H_ANGLE_DEFAULT_CANONICAL)
+
+    def test_qfuerza_keeps_bonds_unchanged(self, ch3f_mol_with_hess: Q2MMMolecule) -> None:
+        """QFUERZA does not alter bond force constants."""
+        ff_fuerza = estimate_force_constants(ch3f_mol_with_hess, strategy="fuerza")
+        ff_qfuerza = estimate_force_constants(ch3f_mol_with_hess, strategy="qfuerza")
+
+        for b_fur, b_qf in zip(ff_fuerza.bonds, ff_qfuerza.bonds):
+            assert b_fur.force_constant == pytest.approx(b_qf.force_constant)
+
+    def test_qfuerza_does_not_substitute_non_h_angles(self, ch3f_mol_with_hess: Q2MMMolecule) -> None:
+        """Non-hydrogen angles are not substituted by QFUERZA."""
+        ff_fuerza = estimate_force_constants(ch3f_mol_with_hess, strategy="fuerza")
+        ff_qfuerza = estimate_force_constants(ch3f_mol_with_hess, strategy="qfuerza")
+
+        for a_fur, a_qf in zip(ff_fuerza.angles, ff_qfuerza.angles):
+            if not _is_hydrogen_angle(a_fur.elements):
+                assert a_fur.force_constant == pytest.approx(a_qf.force_constant)
+
+    def test_qfuerza_ch3f_all_h_angles_substituted(self, ch3f_mol_with_hess: Q2MMMolecule) -> None:
+        """CH₃F has H-C-F and H-C-H angles — all have H outer atoms."""
+        ff = estimate_force_constants(ch3f_mol_with_hess, strategy="qfuerza")
+
+        for angle in ff.angles:
+            if _is_hydrogen_angle(angle.elements):
+                assert angle.force_constant == pytest.approx(QFUERZA_H_ANGLE_DEFAULT_CANONICAL), (
+                    f"H-angle {angle.key} was not substituted"
+                )
+
+    def test_qfuerza_equilibria_unchanged(self, ch3f_mol_with_hess: Q2MMMolecule) -> None:
+        """QFUERZA only changes force constants, not equilibrium values."""
+        ff_fuerza = estimate_force_constants(ch3f_mol_with_hess, strategy="fuerza")
+        ff_qfuerza = estimate_force_constants(ch3f_mol_with_hess, strategy="qfuerza")
+
+        for a_fur, a_qf in zip(ff_fuerza.angles, ff_qfuerza.angles):
+            assert a_fur.equilibrium == pytest.approx(a_qf.equilibrium)
 
 
 # ---- Saver functional form validation ----

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -1153,9 +1153,10 @@ class TestQFUERZA:
     def test_qfuerza_substitutes_h_angles(self, water_mol_with_hess: Q2MMMolecule) -> None:
         """QFUERZA replaces the H-O-H angle force constant with the empirical default."""
         ff = estimate_force_constants(water_mol_with_hess, strategy="qfuerza")
-        for angle in ff.angles:
-            if _is_hydrogen_angle(angle.elements):
-                assert angle.force_constant == pytest.approx(QFUERZA_H_ANGLE_DEFAULT_CANONICAL)
+        h_angles = [a for a in ff.angles if _is_hydrogen_angle(a.elements)]
+        assert len(h_angles) > 0, "Expected at least one H-angle in water"
+        for angle in h_angles:
+            assert angle.force_constant == pytest.approx(QFUERZA_H_ANGLE_DEFAULT_CANONICAL)
 
     def test_qfuerza_keeps_bonds_unchanged(self, ch3f_mol_with_hess: Q2MMMolecule) -> None:
         """QFUERZA does not alter bond force constants."""
@@ -1165,14 +1166,24 @@ class TestQFUERZA:
         for b_fur, b_qf in zip(ff_fuerza.bonds, ff_qfuerza.bonds):
             assert b_fur.force_constant == pytest.approx(b_qf.force_constant)
 
-    def test_qfuerza_does_not_substitute_non_h_angles(self, ch3f_mol_with_hess: Q2MMMolecule) -> None:
+    def test_qfuerza_does_not_substitute_non_h_angles(self) -> None:
         """Non-hydrogen angles are not substituted by QFUERZA."""
-        ff_fuerza = estimate_force_constants(ch3f_mol_with_hess, strategy="fuerza")
-        ff_qfuerza = estimate_force_constants(ch3f_mol_with_hess, strategy="qfuerza")
+        # Use SN2 TS which has F-C-Cl (non-H) angles
+        mol = Q2MMMolecule.from_xyz(TS_XYZ, bond_tolerance=1.5)
+        hess = np.load(TS_HESS)
+        mol = mol.with_hessian(hess)
 
-        for a_fur, a_qf in zip(ff_fuerza.angles, ff_qfuerza.angles):
-            if not _is_hydrogen_angle(a_fur.elements):
-                assert a_fur.force_constant == pytest.approx(a_qf.force_constant)
+        ff_fuerza = estimate_force_constants(mol, strategy="fuerza")
+        ff_qfuerza = estimate_force_constants(mol, strategy="qfuerza")
+
+        non_h_angles = [
+            (a_fur, a_qf)
+            for a_fur, a_qf in zip(ff_fuerza.angles, ff_qfuerza.angles)
+            if not _is_hydrogen_angle(a_fur.elements)
+        ]
+        assert len(non_h_angles) > 0, "Expected at least one non-H angle in SN2 TS"
+        for a_fur, a_qf in non_h_angles:
+            assert a_fur.force_constant == pytest.approx(a_qf.force_constant)
 
     def test_qfuerza_ch3f_all_h_angles_substituted(self, ch3f_mol_with_hess: Q2MMMolecule) -> None:
         """CH₃F has H-C-F and H-C-H angles — all have H outer atoms."""


### PR DESCRIPTION
## Summary

Implement the QFUERZA hybrid initialization strategy from Farrugia et al. (JCTC 2025, 22, 469-476). QFUERZA improves on standard Seminario/FUERZA by substituting an empirical default (0.5 mdyn/rad²) for hydrogen angle bends, where FUERZA overestimates by ~2x.

Closes #208

## Changes

### `q2mm/models/seminario.py`
- Add `_is_hydrogen_angle()` helper — returns True if either outer atom is H
- Add `QFUERZA_H_ANGLE_DEFAULT_MDYNA` (0.5) and `QFUERZA_H_ANGLE_DEFAULT_CANONICAL` constants
- Add `strategy` parameter to `estimate_force_constants()`: `"fuerza"` (default, unchanged) or `"qfuerza"`
- Thread `strategy` through `estimate_force_constants_method_e()`
- QFUERZA substitution happens after Seminario projection with diagnostic logging

### `test/test_models.py`
- 13 new tests in `TestQFUERZA` class:
  - 7 parametrized `_is_hydrogen_angle()` cases (H-O-H, H-C-F, C-O-C, etc.)
  - Regression: `strategy="fuerza"` identical to default
  - Substitution: QFUERZA replaces H-angle force constants on water and CH3F
  - Preservation: bonds, non-H angles, and equilibrium values unchanged

### `docs/how-it-works/theory.md`
- Added usage example showing `strategy="qfuerza"` in Stage 1 section

## Testing

- 816 core tests pass, 0 regressions
- Lint + format clean
