### PR TITLE
fix: stabilize benchmark history directory path

### DIFF
--- a/q2mm/diagnostics/cli.py
+++ b/q2mm/diagnostics/cli.py
@@ -39,6 +39,20 @@ def _generate_run_id(system: str) -> str:
     return generate_run_id(system)
 
 
+def _find_history_dir(output_dir: Path) -> Path:
+    """Locate the canonical ``benchmarks/history/`` directory.
+
+    Walks up from *output_dir* looking for a parent named ``benchmarks``.
+    If found, returns ``<benchmarks>/history``.  Otherwise falls back to
+    ``output_dir.parent / "history"`` for custom output paths.
+    """
+    candidate = output_dir.resolve()
+    for part in (candidate, *candidate.parents):
+        if part.name == "benchmarks":
+            return part / "history"
+    return output_dir.parent / "history"
+
+
 def _discover_backends() -> list[tuple[str, type, str]]:
     """Discover available MM backends at runtime via the engine registry.
 
@@ -305,7 +319,7 @@ def _run_matrix(
             "n_combos": len(results),
         }
         summary = build_run_summary(results, system=system_key, run_id=run_id, config=config)
-        history_dir = output_dir.parent / "history"
+        history_dir = _find_history_dir(output_dir)
         history_path = history_dir / f"{run_id}.json"
         summary.to_json(history_path)
         print(f"  History saved to: {history_path}")

--- a/scripts/gen_benchmark_history.py
+++ b/scripts/gen_benchmark_history.py
@@ -63,6 +63,119 @@ def _format_delta(current: float | None, previous: float | None) -> str:
     return f"{sign}{delta:.1f}"
 
 
+def _render_system_section(lines: list[str], system: str, runs: list[dict]) -> None:
+    """Render RMSD and timing tables for a single benchmark system."""
+    lines.append(f"## {system}\n")
+
+    if len(runs) < 2:
+        lines.append(f"Only {len(runs)} run(s) recorded for **{system}** — need at least 2 for comparison.\n")
+        return
+
+    # --- RMSD comparison grid ---
+    lines.append("### RMSD Comparison\n")
+    lines.append(
+        "Each cell shows the optimized RMSD for that combo. "
+        "The **Δ** column shows the change from the previous run. "
+        "Lower RMSD is better.\n"
+    )
+
+    # Collect all combo stems across runs for this system
+    all_stems: list[str] = []
+    seen: set[str] = set()
+    for run in runs:
+        for stem in run.get("combos", {}):
+            if stem not in seen:
+                all_stems.append(stem)
+                seen.add(stem)
+
+    # Group by backend for readability
+    by_backend: dict[str, list[str]] = {}
+    for stem in all_stems:
+        parts = stem.split("_")
+        if len(parts) >= 2:
+            backend = parts[1]
+        else:
+            backend = "other"
+        by_backend.setdefault(backend, []).append(stem)
+
+    for backend_key in ["jax", "jax-md", "openmm", "tinker"]:
+        stems = by_backend.get(backend_key, [])
+        if not stems:
+            continue
+
+        label = BACKEND_LABELS.get(backend_key, backend_key)
+        lines.append(f"#### {label}\n")
+
+        header = "| Combo |"
+        sep = "|-------|"
+        for i, run in enumerate(runs, 1):
+            sha = _short_sha(run.get("git_sha"))
+            header += f" `{sha}` |"
+            sep += "--------:|"
+            if i > 1:
+                header += " Δ |"
+                sep += "---:|"
+
+        lines.append(header)
+        lines.append(sep)
+
+        for stem in sorted(stems):
+            parts = stem.split("_")
+            display = "_".join(parts[1:]) if len(parts) >= 2 else stem
+
+            row = f"| `{display}` |"
+            prev_rmsd: float | None = None
+
+            for i, run in enumerate(runs):
+                combo = run.get("combos", {}).get(stem, {})
+                rmsd = combo.get("rmsd")
+
+                if rmsd is not None:
+                    row += f" {rmsd:.1f} |"
+                elif combo.get("status") == "failed":
+                    row += " ❌ |"
+                else:
+                    row += " — |"
+
+                if i > 0:
+                    delta = _format_delta(rmsd, prev_rmsd)
+                    if delta and delta != "=":
+                        if delta.startswith("-"):
+                            row += f" **{delta}** |"
+                        elif delta.startswith("+"):
+                            row += f" {delta} |"
+                        else:
+                            row += f" {delta} |"
+                    else:
+                        row += f" {delta} |"
+
+                prev_rmsd = rmsd
+
+            lines.append(row)
+
+        lines.append("")
+
+    # --- Timing comparison ---
+    lines.append("### Timing\n")
+    lines.append(
+        "Optimizer time (seconds) per combo. Timing depends on "
+        "hardware and system load, so small variations are expected.\n"
+    )
+
+    lines.append("| Run | Commit | Total Time (s) | Avg Time/Combo (s) |")
+    lines.append("|-----|--------|---------------:|-------------------:|")
+
+    for i, run in enumerate(runs, 1):
+        sha = _short_sha(run.get("git_sha"))
+        combos = run.get("combos", {})
+        times = [c.get("time_s") for c in combos.values() if c.get("time_s") is not None]
+        total = sum(times)
+        avg = total / len(times) if times else 0
+        lines.append(f"| {i} | `{sha}` | {total:.0f} | {avg:.1f} |")
+
+    lines.append("")
+
+
 def _generate_page(runs: list[dict]) -> str:
     """Build the Markdown content for the history page."""
     lines: list[str] = []
@@ -102,122 +215,16 @@ def _generate_page(runs: list[dict]) -> str:
 
     lines.append("")
 
-    # --- RMSD comparison grid ---
-    if len(runs) >= 2:
-        lines.append("## RMSD Comparison\n")
-        lines.append(
-            "Each cell shows the optimized RMSD for that combo. "
-            "The **Δ** column shows the change from the previous run. "
-            "Lower RMSD is better.\n"
-        )
+    # --- Group runs by system ---
+    by_system: dict[str, list[dict]] = {}
+    for run in runs:
+        system = run.get("system", "unknown")
+        by_system.setdefault(system, []).append(run)
 
-        # Collect all combo stems across all runs
-        all_stems: list[str] = []
-        seen: set[str] = set()
-        for run in runs:
-            for stem in run.get("combos", {}):
-                if stem not in seen:
-                    all_stems.append(stem)
-                    seen.add(stem)
-
-        # Group by backend for readability
-        by_backend: dict[str, list[str]] = {}
-        for stem in all_stems:
-            # Extract backend from stem: ch3f_{backend}_{form}_{device}_{opt}[_{jac}]
-            # Stems use hyphens (e.g. "jax-md"), so split carefully
-            parts = stem.split("_")
-            if len(parts) >= 2:
-                backend = parts[1]
-                # jax-md is a single hyphenated token after splitting on _
-            else:
-                backend = "other"
-            by_backend.setdefault(backend, []).append(stem)
-
-        for backend_key in ["jax", "jax-md", "openmm", "tinker"]:
-            stems = by_backend.get(backend_key, [])
-            if not stems:
-                continue
-
-            label = BACKEND_LABELS.get(backend_key, backend_key)
-            lines.append(f"### {label}\n")
-
-            # Build header: Combo | Run 1 | Run 2 | Δ(1→2) | ...
-            header = "| Combo |"
-            sep = "|-------|"
-            for i, run in enumerate(runs, 1):
-                sha = _short_sha(run.get("git_sha"))
-                header += f" `{sha}` |"
-                sep += "--------:|"
-                if i > 1:
-                    header += " Δ |"
-                    sep += "---:|"
-
-            lines.append(header)
-            lines.append(sep)
-
-            for stem in sorted(stems):
-                # Build a short display name from the stem
-                # Remove the system prefix (e.g. "ch3f_")
-                parts = stem.split("_")
-                if len(parts) >= 2:
-                    display = "_".join(parts[1:])
-                else:
-                    display = stem
-
-                row = f"| `{display}` |"
-                prev_rmsd: float | None = None
-
-                for i, run in enumerate(runs):
-                    combo = run.get("combos", {}).get(stem, {})
-                    rmsd = combo.get("rmsd")
-
-                    if rmsd is not None:
-                        row += f" {rmsd:.1f} |"
-                    elif combo.get("status") == "failed":
-                        row += " ❌ |"
-                    else:
-                        row += " — |"
-
-                    if i > 0:
-                        delta = _format_delta(rmsd, prev_rmsd)
-                        if delta and delta != "=":
-                            # Highlight improvements (negative) vs regressions (positive)
-                            if delta.startswith("-"):
-                                row += f" **{delta}** |"
-                            elif delta.startswith("+"):
-                                row += f" {delta} |"
-                            else:
-                                row += f" {delta} |"
-                        else:
-                            row += f" {delta} |"
-
-                    prev_rmsd = rmsd
-
-                lines.append(row)
-
-            lines.append("")
-
-    # --- Timing comparison ---
-    if len(runs) >= 2:
-        lines.append("## Timing Comparison\n")
-        lines.append(
-            "Optimizer time (seconds) per combo. Timing depends on "
-            "hardware and system load, so small variations are expected.\n"
-        )
-
-        # Just show a summary: total time per run
-        lines.append("| Run | Commit | Total Time (s) | Avg Time/Combo (s) |")
-        lines.append("|-----|--------|---------------:|-------------------:|")
-
-        for i, run in enumerate(runs, 1):
-            sha = _short_sha(run.get("git_sha"))
-            combos = run.get("combos", {})
-            times = [c.get("time_s") for c in combos.values() if c.get("time_s") is not None]
-            total = sum(times)
-            avg = total / len(times) if times else 0
-            lines.append(f"| {i} | `{sha}` | {total:.0f} | {avg:.1f} |")
-
-        lines.append("")
+    # Render RMSD + timing sections per system
+    for system_key in sorted(by_system):
+        system_runs = by_system[system_key]
+        _render_system_section(lines, system_key, system_runs)
 
     return "\n".join(lines)
 

--- a/test/test_history.py
+++ b/test/test_history.py
@@ -149,3 +149,45 @@ class TestGenerateRunId:
         time.sleep(1.1)
         r2 = generate_run_id("ch3f")
         assert r1 != r2
+
+
+class TestFindHistoryDir:
+    """Tests for _find_history_dir()."""
+
+    def test_finds_benchmarks_parent(self, tmp_path: Path) -> None:
+        """Should walk up to find benchmarks/ and return benchmarks/history."""
+        from q2mm.diagnostics.cli import _find_history_dir
+
+        benchmarks = tmp_path / "benchmarks"
+        output = benchmarks / "ch3f" / "results"
+        output.mkdir(parents=True)
+        result = _find_history_dir(output)
+        assert result == benchmarks / "history"
+
+    def test_deeply_nested(self, tmp_path: Path) -> None:
+        """Should work even with deeply nested output paths."""
+        from q2mm.diagnostics.cli import _find_history_dir
+
+        benchmarks = tmp_path / "benchmarks"
+        output = benchmarks / "ch3f" / "deep" / "nested"
+        output.mkdir(parents=True)
+        result = _find_history_dir(output)
+        assert result == benchmarks / "history"
+
+    def test_fallback_without_benchmarks(self, tmp_path: Path) -> None:
+        """Should fall back to output_dir.parent/history if no benchmarks/ ancestor."""
+        from q2mm.diagnostics.cli import _find_history_dir
+
+        output = tmp_path / "custom" / "results"
+        output.mkdir(parents=True)
+        result = _find_history_dir(output)
+        assert result == tmp_path / "custom" / "history"
+
+    def test_output_is_benchmarks_itself(self, tmp_path: Path) -> None:
+        """When output_dir IS benchmarks/, should return benchmarks/history."""
+        from q2mm.diagnostics.cli import _find_history_dir
+
+        benchmarks = tmp_path / "benchmarks"
+        benchmarks.mkdir()
+        result = _find_history_dir(benchmarks)
+        assert result == benchmarks / "history"


### PR DESCRIPTION
## Summary

Fix benchmark history directory path derivation so snapshots always land in benchmarks/history/ regardless of the --output flag, and group the docs page generator by molecular system.

### Changes

- **cli.py**: Add _find_history_dir() — walks up from output dir to find benchmarks/ ancestor, returns benchmarks/history/. Falls back to output_dir.parent/"history" for custom paths outside the benchmarks tree.
- **gen_benchmark_history.py**: Refactor to group runs by system field with separate RMSD comparison tables and timing tables per system (CH3F and Rh-enamide no longer intermingle).
- **test_history.py**: 4 new tests covering ancestor walk, deep nesting, fallback, and self-reference cases.

### Root Cause

The CLI computed history_dir = output_dir.parent / "history", so running with --output benchmarks/ch3f/results placed snapshots in benchmarks/ch3f/history/ instead of the canonical benchmarks/history/. These orphaned files were invisible to the docs generator.

### Testing

- 566 core tests pass (562 existing + 4 new)
- Lint and format clean
