### PR TITLE
docs: add differentiability-status matrix to architecture.md

### DIFF
--- a/docs/how-it-works/architecture.md
+++ b/docs/how-it-works/architecture.md
@@ -316,11 +316,12 @@ flowchart TD
 
 ## Differentiability status
 
-Q2MM's long-term goal is end-to-end analytical optimisation: every
+Q2MM's long-term goal is end-to-end analytical optimization: every
 reference-to-loss contribution expressed as a pure, JIT-compiled JAX
 computation so that `jax.value_and_grad` gives exact parameter gradients
-in one XLA kernel.  The table below records what is delivered today
-versus what is still tracked.
+within one JIT-compiled XLA program/call, avoiding Python↔JAX
+round-trips. The table below records what is delivered today versus
+what is still tracked.
 
 ### Reference kinds
 
@@ -329,10 +330,12 @@ Columns:
 - **Python path** — does `ObjectiveFunction` already score this kind via
   its Python evaluators?
 - **Analytical ∂L/∂p** — is the residual differentiable through the
-  category's per-category evaluator on the Python path?
+  category's per-category evaluator on the Python path? This assumes a
+  backend that provides the required analytical Jacobians/Hessian-gradient
+  support (for example JAX); otherwise the Python path falls back to
+  finite-difference gradients.
 - **In JIT loss** — does `jaxloss.JaxLoss` score this kind inside the
   JIT-compiled graph (auto-diff through `value_and_grad`)?
-- **Tracker** — issue for any remaining gap.
 
 | Reference kind     | Python path | Analytical ∂L/∂p | In JIT loss | Notes |
 | ------------------ | :---------: | :--------------: | :---------: | ----- |
@@ -341,17 +344,17 @@ Columns:
 | `hessian_element`  | ✅ | ✅ | ✅ | Packed `row * 3N + col` index into `jax.hessian` output. |
 | `eig_diagonal`     | ✅ | ✅ | ✅ | Diagonal of `Vᵀ H V` in QM eigenbasis. |
 | `eig_offdiagonal`  | ✅ | ✅ | ✅ | Off-diagonal of `Vᵀ H V`; same packed index. |
-| `bond_length`      | ✅ | partial | ❌ | Geometry requires differentiable inner-minimisation. Tracked in [#243] (spike) / [#152] (umbrella). |
-| `bond_angle`       | ✅ | partial | ❌ | Same as `bond_length`. |
-| `torsion_angle`    | ✅ | partial | ❌ | Same as `bond_length`. |
+| `bond_length`      | ✅ | ❌ | ❌ | Direct geometry observables are differentiable w.r.t. coordinates, but end-to-end `∂L/∂p` on the current Python path requires differentiable inner minimization. Tracked in [#243] (spike) / [#152] (umbrella). |
+| `bond_angle`       | ✅ | ❌ | ❌ | Same as `bond_length`. |
+| `torsion_angle`    | ✅ | ❌ | ❌ | Same as `bond_length`. |
 
-### Optimisers
+### Optimizers
 
 Columns:
 
 - **Uses JIT loss** — pulls gradients from `JaxLoss` rather than the
   Python-side evaluators.
-- **Full XLA loop** — the entire optimiser iteration lives inside
+- **Full XLA loop** — the entire optimizer iteration lives inside
   `jax.jit` (no Python ↔ XLA round-trips per step).
 - **Multi-start in XLA** — N-start search fused into one kernel via
   `jax.vmap` (vs. Python `for`-loop orchestration).
@@ -359,9 +362,13 @@ Columns:
 | Optimizer                  | Uses JIT loss | Full XLA loop | Multi-start in XLA |
 | -------------------------- | :-----------: | :-----------: | :----------------: |
 | `ScipyOptimizer`           | ❌ | ❌ | ❌ |
-| `OptimizationLoop` (cycling) | ❌ | ❌ | ❌ |
+| `OptimizationLoop` (cycling) | ✅ when configured [^cycling-jit] | ❌ | ❌ |
 | `OptaxOptimizer`           | ✅ | ❌ (Python step loop) | ❌ |
 | `JaxOptOptimizer` (`lbfgs`, `lbfgsb` [^lbfgsb-cpu], `gradient_descent`) | ✅ | ✅ | ❌ |
+
+[^cycling-jit]: `OptimizationLoop` uses `JaxLoss` only when its
+    full-space phase is configured with `full_method="jaxopt:*"` or
+    `full_method="optax:*"`; otherwise it uses the Python-side evaluators.
 
 [^lbfgsb-cpu]: `jaxopt:lbfgsb` raises `RuntimeError` on non-CPU backends —
     the upstream jaxopt LBFGSB kernel uses XLA argsort/scatter primitives

--- a/docs/how-it-works/architecture.md
+++ b/docs/how-it-works/architecture.md
@@ -314,6 +314,77 @@ flowchart TD
 
 ---
 
+## Differentiability status
+
+Q2MM's long-term goal is end-to-end analytical optimisation: every
+reference-to-loss contribution expressed as a pure, JIT-compiled JAX
+computation so that `jax.value_and_grad` gives exact parameter gradients
+in one XLA kernel.  The table below records what is delivered today
+versus what is still tracked.
+
+### Reference kinds
+
+Columns:
+
+- **Python path** — does `ObjectiveFunction` already score this kind via
+  its Python evaluators?
+- **Analytical ∂L/∂p** — is the residual differentiable through the
+  category's per-category evaluator on the Python path?
+- **In JIT loss** — does `jaxloss.JaxLoss` score this kind inside the
+  JIT-compiled graph (auto-diff through `value_and_grad`)?
+- **Tracker** — issue for any remaining gap.
+
+| Reference kind     | Python path | Analytical ∂L/∂p | In JIT loss | Notes |
+| ------------------ | :---------: | :--------------: | :---------: | ----- |
+| `energy`           | ✅ | ✅ | ✅ | `energy_fn(params, coords)` directly. |
+| `frequency`        | ✅ | ✅ | ✅ | `_jax_frequencies_from_hessian` + autodiff through `eigh`. |
+| `hessian_element`  | ✅ | ✅ | ✅ | Packed `row * 3N + col` index into `jax.hessian` output. |
+| `eig_diagonal`     | ✅ | ✅ | ✅ | Diagonal of `Vᵀ H V` in QM eigenbasis. |
+| `eig_offdiagonal`  | ✅ | ✅ | ✅ | Off-diagonal of `Vᵀ H V`; same packed index. |
+| `bond_length`      | ✅ | partial | ❌ | Geometry requires differentiable inner-minimisation. Tracked in [#243] (spike) / [#152] (umbrella). |
+| `bond_angle`       | ✅ | partial | ❌ | Same as `bond_length`. |
+| `torsion_angle`    | ✅ | partial | ❌ | Same as `bond_length`. |
+
+### Optimisers
+
+Columns:
+
+- **Uses JIT loss** — pulls gradients from `JaxLoss` rather than the
+  Python-side evaluators.
+- **Full XLA loop** — the entire optimiser iteration lives inside
+  `jax.jit` (no Python ↔ XLA round-trips per step).
+- **Multi-start in XLA** — N-start search fused into one kernel via
+  `jax.vmap` (vs. Python `for`-loop orchestration).
+
+| Optimizer                  | Uses JIT loss | Full XLA loop | Multi-start in XLA |
+| -------------------------- | :-----------: | :-----------: | :----------------: |
+| `ScipyOptimizer`           | ❌ | ❌ | ❌ |
+| `OptimizationLoop` (cycling) | ❌ | ❌ | ❌ |
+| `OptaxOptimizer`           | ✅ | ❌ (Python step loop) | ❌ |
+| `JaxOptOptimizer` (`lbfgs`, `lbfgsb` [^lbfgsb-cpu], `gradient_descent`) | ✅ | ✅ | ❌ |
+
+[^lbfgsb-cpu]: `jaxopt:lbfgsb` raises `RuntimeError` on non-CPU backends —
+    the upstream jaxopt LBFGSB kernel uses XLA argsort/scatter primitives
+    that dtype-mismatch on GPU. Use `lbfgs` on GPU.
+
+### Performance levers still open
+
+| Lever                                   | Status | Tracker |
+| --------------------------------------- | :----: | ------- |
+| `vmap` over molecules in `JaxLoss._loss_fn` | Python-unrolled | [#244] / [#176] |
+| Multi-start as one XLA kernel (`vmap` over init params) | Not started | [#176] |
+| Basin-hopping as a `lax.while_loop` primitive | Not started | — |
+| TS curvature inversion (QFUERZA) inside JIT | Python-side only | [#245] |
+| Parameter constraints (equivalences, type limits) as JAX projections | Enforced in `ForceField`, not in the JIT graph | — |
+
+[#152]: https://github.com/ericchansen/q2mm/issues/152
+[#176]: https://github.com/ericchansen/q2mm/issues/176
+[#243]: https://github.com/ericchansen/q2mm/issues/243
+[#244]: https://github.com/ericchansen/q2mm/issues/244
+[#245]: https://github.com/ericchansen/q2mm/issues/245
+
+---
+
 ## Design invariants
 
 1. **Canonical units everywhere inside the pipeline.** No format-specific unit


### PR DESCRIPTION
## Summary

Adds a new **Differentiability status** section to `docs/how-it-works/architecture.md` that records what the end-to-end analytical path covers today and what remains tracked.

## Why

Closes Phase 1b of the `feat/jaxopt-optimizer` roadmap. #242 landed the JIT loss + full-XLA jaxopt loop, but the architecture doc did not reflect the new coverage matrix, leaving readers to infer it from scattered PR bodies.

## What's in the table

- **Reference kinds** — one row per `ReferenceValue.kind`, columns for Python path / analytical ∂L/∂p / in-JIT coverage. Geometry kinds are flagged as Python-only and point to #243 / #152.
- **Optimisers** — `Scipy`, `OptimizationLoop`, `Optax`, `JaxOpt` columns for "uses JIT loss", "full XLA loop", "multi-start in XLA". Footnotes the `jaxopt:lbfgsb` GPU limitation.
- **Performance levers still open** — `vmap` over molecules (#244), multi-start-as-`vmap` (#176), basin-hopping as `lax.while_loop`, TS curvature inside JIT (#245), parameter constraints as JAX projections.

## Validation

- `uv run --no-sync properdocs build -f properdocs.yml` → clean build (pre-existing unrelated anchor warning in `tutorial.md`).
- New section is a pure addition before **Design invariants**; no existing prose modified.

## Tracker impact

No issues closed by this PR — it documents status rather than changing behaviour. Phase 1b in the session plan now marked DONE once this lands.
