### PR TITLE
docs: Phase 4a — geometry-refs implicit-diff spike

### DIFF
--- a/docs/how-it-works/architecture.md
+++ b/docs/how-it-works/architecture.md
@@ -344,7 +344,7 @@ Columns:
 | `hessian_element`  | ✅ | ✅ | ✅ | Packed `row * 3N + col` index into `jax.hessian` output. |
 | `eig_diagonal`     | ✅ | ✅ | ✅ | Diagonal of `Vᵀ H V` in QM eigenbasis. |
 | `eig_offdiagonal`  | ✅ | ✅ | ✅ | Off-diagonal of `Vᵀ H V`; same packed index. |
-| `bond_length`      | ✅ | ❌ | ❌ | Direct geometry observables are differentiable w.r.t. coordinates, but end-to-end `∂L/∂p` on the current Python path requires differentiable inner minimization. Tracked in [#243] (spike) / [#152] (umbrella). |
+| `bond_length`      | ✅ | ❌ | ❌ | Direct geometry observables are differentiable w.r.t. coordinates, but end-to-end `∂L/∂p` on the current Python path requires differentiable inner minimization. Approach chosen in the [geometry-refs spike](./geometry-refs-spike.md); full implementation tracked in [#243] (spike) / [#152] (umbrella). |
 | `bond_angle`       | ✅ | ❌ | ❌ | Same as `bond_length`. |
 | `torsion_angle`    | ✅ | ❌ | ❌ | Same as `bond_length`. |
 

--- a/docs/how-it-works/geometry-refs-spike.md
+++ b/docs/how-it-works/geometry-refs-spike.md
@@ -72,7 +72,7 @@ def relax_bwd(saved, g):
     H = jax.hessian(energy, argnums=0)(x, p)                 # ∂²E/∂x²
     M = jax.jacfwd(jax.grad(energy, argnums=0), argnums=1)(x, p)  # ∂²E/∂x∂p
     lam = jnp.linalg.solve(H.T, g)
-    return (−(lam @ M),)
+    return (-(lam @ M),)
 
 relax.defvjp(relax_fwd, relax_bwd)
 ```

--- a/docs/how-it-works/geometry-refs-spike.md
+++ b/docs/how-it-works/geometry-refs-spike.md
@@ -1,0 +1,192 @@
+# Geometry references via implicit differentiation — spike report
+
+## What this page is
+
+Geometry reference kinds (`bond_length`, `bond_angle`, `torsion_angle`)
+are the last ❌ in the [differentiability matrix][matrix]. Their gradient
+is non-trivial because the observed bond length, angle, or dihedral is
+measured on a *relaxed* geometry `x*(p) = argmin_x E(x; p)` — the output
+of an inner optimization. Computing `∂L/∂p` therefore requires `∂x*/∂p`,
+which is not a plain autodiff problem.
+
+This page documents the short exploration ("spike") that chose an
+approach before writing the full Phase 4b implementation. The script
+that produced the numbers in the tables below lives at
+[`scripts/spike_geom_implicit_diff.py`][script].
+
+## The problem, stated explicitly
+
+For a geometry reference kind, the pipeline is:
+
+1. Fix the force-field parameters `p`.
+2. Run an inner minimizer to find `x*(p) = argmin_x E(x; p)`.
+3. Compute the observable on that relaxed geometry,
+   e.g. `b(x*) = ||x_2* − x_1*||`.
+4. Compare to the reference: `L(p) = (b(x*(p)) − b_ref)²`.
+
+Computing `∂L/∂p` by simply autodiffing through the inner minimizer
+would mean differentiating through every step of LBFGS — memory- and
+compile-time-expensive, and brittle.
+
+The standard trick is the **implicit function theorem** applied to the
+stationarity condition `∇_x E(x*; p) = 0`:
+
+```
+∂x*/∂p = −[∂²E/∂x²(x*)]⁻¹ · [∂²E/∂x∂p(x*)]
+```
+
+This lets autodiff skip the solver's internals entirely and compute the
+gradient from two second-derivative objects evaluated once at the
+converged `x*`.
+
+## Two realistic ways to implement it
+
+### Option A — `jaxopt.LBFGS(..., implicit_diff=True)`
+
+```python
+from jaxopt import LBFGS
+
+solver = LBFGS(fun=energy, tol=1e-10, maxiter=200, implicit_diff=True)
+
+def relax(p):
+    x0 = initial_guess(p)
+    return solver.run(x0, p).params
+```
+
+`jaxopt` installs a `custom_vjp` behind the scenes that implements the
+implicit-function formula. `relax` is then a regular JAX function:
+JIT-compilable, `vmap`-able, composable with `jax.value_and_grad`.
+
+### Option B — hand-rolled `jax.custom_vjp`
+
+```python
+@jax.custom_vjp
+def relax(p):
+    x0 = initial_guess(p)
+    return run_inner_minimizer(energy, x0, p).x   # any minimizer
+
+def relax_fwd(p): x = relax(p); return x, (x, p)
+
+def relax_bwd(saved, g):
+    x, p = saved
+    H = jax.hessian(energy, argnums=0)(x, p)                 # ∂²E/∂x²
+    M = jax.jacfwd(jax.grad(energy, argnums=0), argnums=1)(x, p)  # ∂²E/∂x∂p
+    lam = jnp.linalg.solve(H.T, g)
+    return (−(lam @ M),)
+
+relax.defvjp(relax_fwd, relax_bwd)
+```
+
+The math is identical — just more surface area to own.
+
+## Empirical comparison
+
+Run on a 1D triatomic A–B–C system with two harmonic bonds and an
+external force on atom C. The relaxed geometry has a closed form:
+`b_12* = r1 + F/k1`, `b_23* = r2 + F/k2`, so we can compute the exact
+loss gradient by hand and measure errors against it. Parameters for the
+test: `p = (k1=2, r1=1.5, k2=3, r2=1.2)`, `refs = (1.6, 1.3)`,
+`F = 0.1`. All runs on CPU in float64.
+
+### Gradient accuracy vs inner solver tolerance
+
+| inner tol | method     |  max `|err|` | rel err   |
+| :-------: | :--------- | :----------: | :-------: |
+| `1e-3`    | A (jaxopt) | `9.7e-17`    | `3.4e-15` |
+| `1e-3`    | B (custom) | `4.7e-16`    | `3.5e-15` |
+| `1e-12`   | A (jaxopt) | `9.7e-17`    | `3.4e-15` |
+| `1e-12`   | B (custom) | `4.7e-16`    | `3.5e-15` |
+| `1e-3`    | FD (`ε=1e-3`)  | `8.2e-11`  | `5.6e-8`  |
+| `1e-3`    | FD (`ε=1e-5`)  | `1.8e-12`  | `1.2e-9`  |
+
+Both implicit-diff options hit machine precision. Inner tolerance has
+no effect on outer gradient accuracy for this well-conditioned convex
+system — because the implicit-function formula only needs
+`∇_x E(x*) ≈ 0`, which LBFGS satisfies quickly. Finite differences, by
+contrast, inherit truncation + cancellation error and are at best
+~9 orders of magnitude worse.
+
+### Wall time
+
+| method     | inner tol | ms / gradient (CPU, float64) |
+| :--------- | :-------: | :--------------------------: |
+| A (jaxopt) | `1e-6`    | 0.019                        |
+| B (custom) | `1e-6`    | 0.033                        |
+| A (jaxopt) | `1e-10`   | 0.033                        |
+| B (custom) | `1e-10`   | 0.029                        |
+
+Both are well under 0.1 ms per gradient for the 4-parameter toy
+system, and the differences are within run-to-run jitter. Neither is
+the bottleneck in any realistic q2mm objective.
+
+### Hessian ill-conditioning
+
+As `k1 → 0`, the Hessian `∂²E/∂x²` becomes nearly singular. Both
+approaches depend on the same `H⁻¹ g` solve, so both degrade together.
+
+| `k1`    | `cond(H)` | A err    | B err    |
+| :------ | :-------: | :------: | :------: |
+| `2e+0`  | `8.6`     | `9.7e-17`| `4.7e-16`|
+| `1e-1`  | `1.2e+2`  | `9.3e-13`| `1.5e-14`|
+| `1e-3`  | `1.2e+4`  | `1.5e-5` | `8.5e-6` |
+| `1e-5`  | `1.2e+6`  | `2.0e+13`| `2.0e+13`|
+
+Neither option has an advantage — ill-conditioning is a mathematical
+property of the test system, not an implementation choice.
+
+## Decision: Option A
+
+- **Already a dependency.** `jaxopt` is used by `JaxOptOptimizer` and
+  `JaxMultiStartOptimizer`; adopting it for the inner loop adds zero
+  new dependencies.
+- **Less code to own.** The custom VJP in Option B is ~20 lines that do
+  the same thing `jaxopt`'s `implicit_diff` does.
+- **Same accuracy.** At machine precision, both match the closed-form
+  exactly.
+- **Same performance.** Both are well under 0.1 ms per gradient on the
+  toy system, within run-to-run jitter of each other.
+- **Composable.** `jax.jit(jax.vmap(jax.grad(loss)))` works out of the
+  box, as it already does for the existing `JaxOptOptimizer`.
+
+## Implications for Phase 4b
+
+1. `q2mm/optimizers/jaxloss.py` — add a `geometry` category that calls
+   an inner `jaxopt.LBFGS(..., implicit_diff=True)` over the energy
+   function (`energy_fn(p, coords)` is already available on the
+   backend handle).
+2. Drop the `to_jax_spec()` guard that raises on geometry-only
+   objectives; wire `has_geometry_refs` to return `True`.
+3. Use `jax.jacrev` to differentiate the observable (bond length,
+   angle, dihedral) with respect to the relaxed coordinates —
+   straightforward JAX, no new math.
+
+## Watch-outs carried forward to Phase 4b
+
+- **Non-convergence.** The spike used a convex quadratic where LBFGS
+  always converges. Real MM energies are anharmonic and can have flat
+  or multi-basin landscapes; an inner solver can time out or get stuck.
+  Phase 4b should surface an `ok` flag alongside `x*` and fall back to
+  the initial coordinates + a penalty residual when the inner solver
+  fails to converge.
+- **Ill-conditioning.** When `H` is near-singular, the implicit-diff
+  Jacobian blows up exactly as the table above shows. A small Tikhonov
+  regularization `H ← H + ε·I` (with `ε` chosen by residual heuristics)
+  keeps the gradient finite at the cost of a small bias. Decide during
+  Phase 4b whether to surface this as a knob or apply it silently for
+  `cond(H) > 10⁴`.
+- **Jacobian of observables.** Bond length and angle use `arccos`, which
+  has infinite derivative at `±1`. Collinear three-atom geometries will
+  produce NaN gradients. Clip the cosine input to `[-1 + 1e-12,
+  1 - 1e-12]` before `arccos`.
+
+## Reproducing the numbers
+
+```bash
+JAX_PLATFORMS=cpu .venv/bin/python scripts/spike_geom_implicit_diff.py
+```
+
+Runs in under a minute on any developer laptop and prints all three
+tables above.
+
+[matrix]: ./architecture.md#differentiability-status
+[script]: https://github.com/ericchansen/q2mm/blob/master/scripts/spike_geom_implicit_diff.py

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -36,6 +36,7 @@ nav:
     - Architecture: how-it-works/architecture.md
     - Data Types: how-it-works/data-types.md
     - Optimization Guide: how-it-works/optimization-guide.md
+    - Geometry-refs implicit-diff spike: how-it-works/geometry-refs-spike.md
   - Backend Engines:
     - Overview: backends/index.md
     - OpenMM: backends/openmm.md

--- a/scripts/spike_geom_implicit_diff.py
+++ b/scripts/spike_geom_implicit_diff.py
@@ -208,9 +208,10 @@ def run_accuracy_table() -> None:
         loss_b = jax.jit(make_loss(make_option_b(tol=tol), refs))
         g_a = jax.grad(loss_a)(p)
         g_b = jax.grad(loss_b)(p)
+        denom = jnp.maximum(jnp.abs(g_exact), 1e-30)
         for name, g in [("A: jaxopt", g_a), ("B: custom", g_b)]:
             err = float(jnp.max(jnp.abs(g - g_exact)))
-            rel = float(jnp.max(jnp.abs((g - g_exact) / g_exact)))
+            rel = float(jnp.max(jnp.abs(g - g_exact) / denom))
             print(f"{tol:>10.0e} | {name:>10} | {err:>12.3e} | {rel:>12.3e}")
 
     print()
@@ -223,7 +224,8 @@ def run_accuracy_table() -> None:
             dp[i] = eps
             g_fd[i] = (loss_ref(p + dp) - loss_ref(p - dp)) / (2 * eps)
         err = float(np.max(np.abs(g_fd - np.asarray(g_exact))))
-        rel = float(np.max(np.abs((g_fd - np.asarray(g_exact)) / np.asarray(g_exact))))
+        denom = np.maximum(np.abs(np.asarray(g_exact)), 1e-30)
+        rel = float(np.max(np.abs(g_fd - np.asarray(g_exact)) / denom))
         print(f"{eps:>10.0e} | {'FD':>10} | {err:>12.3e} | {rel:>12.3e}")
 
 
@@ -261,14 +263,18 @@ def run_conditioning_table() -> None:
     print(header)
     print("-" * len(header))
 
+    grad_a = jax.jit(jax.grad(make_loss(make_option_a(tol=1e-10), refs)))
+    grad_b = jax.jit(jax.grad(make_loss(make_option_b(tol=1e-10), refs)))
+    hess_fn = jax.jit(jax.hessian(energy, argnums=0))
+
     for k1 in [2.0, 0.1, 1e-3, 1e-5]:
         p = jnp.array([k1, 1.5, 3.0, 1.2])
         g_exact = closed_form_grad(p, refs)
         x_star = closed_form_geometry(p)
-        h_mat = jax.hessian(energy, argnums=0)(x_star, p)
+        h_mat = hess_fn(x_star, p)
         cond = float(jnp.linalg.cond(h_mat))
-        g_a = jax.grad(jax.jit(make_loss(make_option_a(tol=1e-10), refs)))(p)
-        g_b = jax.grad(jax.jit(make_loss(make_option_b(tol=1e-10), refs)))(p)
+        g_a = grad_a(p)
+        g_b = grad_b(p)
         err_a = float(jnp.max(jnp.abs(g_a - g_exact)))
         err_b = float(jnp.max(jnp.abs(g_b - g_exact)))
         print(f"{k1:>10.1e} | {cond:>12.3e} | {err_a:>12.3e} | {err_b:>12.3e}")

--- a/scripts/spike_geom_implicit_diff.py
+++ b/scripts/spike_geom_implicit_diff.py
@@ -1,0 +1,287 @@
+"""Geometry-refs spike: compare implicit-diff approaches for inner minimization.
+
+Runs both Option A (:class:`jaxopt.LBFGS` with ``implicit_diff=True``) and
+Option B (hand-rolled :func:`jax.custom_vjp` via the implicit function theorem)
+on a triatomic toy system whose relaxed geometry has a closed form. Emits
+three tables (accuracy, timing, ill-conditioning) that back the decision
+documented in ``docs/how-it-works/geometry-refs-spike.md``.
+
+Run with::
+
+    JAX_PLATFORMS=cpu .venv/bin/python scripts/spike_geom_implicit_diff.py
+
+Test system: 1D linear triatomic A-B-C with atom A fixed at the origin::
+
+    E(x_B, x_C; k1, r1, k2, r2) =
+        0.5 * k1 * (x_B - r1)^2
+      + 0.5 * k2 * ((x_C - x_B) - r2)^2
+      - F * x_C                                   (external force on atom C)
+
+Closed-form relaxed geometry (from stationarity)::
+
+    b_12* = x_B*              = r1 + F / k1
+    b_23* = x_C* - x_B*       = r2 + F / k2
+
+Observables: bond lengths ``b_12`` and ``b_23``.
+Loss: ``L(p) = (b_12* - b1_ref)^2 + (b_23* - b2_ref)^2``.
+
+Because the closed form is known, every gradient number in the spike
+tables can be checked against an exact analytical derivative.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Callable
+
+# Default to CPU for reproducible spike numbers; override with JAX_PLATFORMS=cuda.
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.scipy.optimize import minimize as jax_minimize
+from jaxopt import LBFGS
+
+jax.config.update("jax_enable_x64", True)
+
+FORCE = 0.1  # external force on atom C, in arbitrary units
+
+
+# -----------------------------------------------------------------------------
+# Toy system
+# -----------------------------------------------------------------------------
+
+
+def energy(x: jnp.ndarray, p: jnp.ndarray) -> jnp.ndarray:
+    """Harmonic two-bond potential plus external force on atom C."""
+    k1, r1, k2, r2 = p
+    x_B, x_C = x[0], x[1]
+    return 0.5 * k1 * (x_B - r1) ** 2 + 0.5 * k2 * ((x_C - x_B) - r2) ** 2 - FORCE * x_C
+
+
+def observables(x: jnp.ndarray) -> jnp.ndarray:
+    """Return ``(b_12, b_23)`` bond lengths from atomic coordinates."""
+    return jnp.array([x[0], x[1] - x[0]])
+
+
+def closed_form_geometry(p: jnp.ndarray) -> jnp.ndarray:
+    """Closed-form relaxed geometry ``(x_B*, x_C*)`` derived from stationarity."""
+    k1, r1, k2, r2 = p
+    x_B = r1 + FORCE / k1
+    x_C = x_B + r2 + FORCE / k2
+    return jnp.array([x_B, x_C])
+
+
+def closed_form_grad(p: jnp.ndarray, refs: jnp.ndarray) -> jnp.ndarray:
+    """Closed-form loss gradient ``∂L/∂p`` for the bond-length objective."""
+    k1, r1, k2, r2 = p
+    b12 = r1 + FORCE / k1
+    b23 = r2 + FORCE / k2
+    d12 = 2.0 * (b12 - refs[0])
+    d23 = 2.0 * (b23 - refs[1])
+    return jnp.array(
+        [
+            d12 * (-FORCE / k1**2),  # ∂L/∂k1
+            d12,  # ∂L/∂r1
+            d23 * (-FORCE / k2**2),  # ∂L/∂k2
+            d23,  # ∂L/∂r2
+        ]
+    )
+
+
+# -----------------------------------------------------------------------------
+# Option A: jaxopt.LBFGS with implicit_diff=True
+# -----------------------------------------------------------------------------
+
+
+def make_option_a(tol: float = 1e-10, maxiter: int = 200) -> Callable[[jnp.ndarray], jnp.ndarray]:
+    """Build a relaxed-geometry function using jaxopt's built-in implicit diff."""
+    solver = LBFGS(fun=energy, tol=tol, maxiter=maxiter, implicit_diff=True)
+
+    def relax(p: jnp.ndarray) -> jnp.ndarray:
+        x0 = jnp.array([1.0, 2.0])
+        return solver.run(x0, p).params
+
+    return relax
+
+
+# -----------------------------------------------------------------------------
+# Option B: hand-rolled custom_vjp via the implicit function theorem
+# -----------------------------------------------------------------------------
+
+
+def make_option_b(tol: float = 1e-10, maxiter: int = 200) -> Callable[[jnp.ndarray], jnp.ndarray]:
+    """Build a relaxed-geometry function with a hand-rolled ``custom_vjp``."""
+
+    @jax.custom_vjp
+    def relax(p: jnp.ndarray) -> jnp.ndarray:
+        x0 = jnp.array([1.0, 2.0])
+        res = jax_minimize(
+            lambda x: energy(x, p),
+            x0,
+            method="BFGS",
+            tol=tol,
+            options={"maxiter": maxiter},
+        )
+        return res.x
+
+    def relax_fwd(p: jnp.ndarray) -> tuple[jnp.ndarray, tuple[jnp.ndarray, jnp.ndarray]]:
+        x = relax(p)
+        return x, (x, p)
+
+    def relax_bwd(saved: tuple[jnp.ndarray, jnp.ndarray], g: jnp.ndarray) -> tuple[jnp.ndarray]:
+        x, p = saved
+        # H = ∂²E/∂x² at x*   (n_x × n_x)
+        h_mat = jax.hessian(energy, argnums=0)(x, p)
+        # M = ∂²E/∂x∂p at x*  (n_x × n_p)
+        m_mat = jax.jacfwd(jax.grad(energy, argnums=0), argnums=1)(x, p)
+        # Implicit function theorem: dx*/dp = -H⁻¹ M.
+        # VJP: (dL/dp) = g · (dx*/dp) = -g · H⁻¹ · M.
+        # Solve Hᵀ λ = g, then dL/dp = -λᵀ M.
+        lam = jnp.linalg.solve(h_mat.T, g)
+        return (-(lam @ m_mat),)
+
+    relax.defvjp(relax_fwd, relax_bwd)
+    return relax
+
+
+# -----------------------------------------------------------------------------
+# Pipeline: loss(p) = ||obs(relax(p)) - refs||²
+# -----------------------------------------------------------------------------
+
+
+def make_loss(
+    relax_fn: Callable[[jnp.ndarray], jnp.ndarray], refs: jnp.ndarray
+) -> Callable[[jnp.ndarray], jnp.ndarray]:
+    """Build a scalar loss ``L(p) = Σ (obs(x*(p)) - refs)²`` around a relaxer."""
+
+    def loss(p: jnp.ndarray) -> jnp.ndarray:
+        x_star = relax_fn(p)
+        obs = observables(x_star)
+        return jnp.sum((obs - refs) ** 2)
+
+    return loss
+
+
+# -----------------------------------------------------------------------------
+# Benchmark harness
+# -----------------------------------------------------------------------------
+
+
+def _time_grad(
+    grad_fn: Callable[[jnp.ndarray], jnp.ndarray],
+    p: jnp.ndarray,
+    n_warmup: int = 3,
+    n_iter: int = 20,
+) -> tuple[jnp.ndarray, float]:
+    """Time a JIT-compiled gradient function. Returns (last_grad, ms_per_call)."""
+    for _ in range(n_warmup):
+        jax.block_until_ready(grad_fn(p))
+    t0 = time.perf_counter()
+    g = grad_fn(p)
+    for _ in range(n_iter - 1):
+        g = grad_fn(p)
+    jax.block_until_ready(g)
+    elapsed = (time.perf_counter() - t0) / n_iter
+    return g, elapsed * 1e3
+
+
+def run_accuracy_table() -> None:
+    """Print Table 1: gradient accuracy vs inner solver tolerance."""
+    p = jnp.array([2.0, 1.5, 3.0, 1.2])
+    refs = jnp.array([1.6, 1.3])
+    g_exact = closed_form_grad(p, refs)
+
+    print("=" * 78)
+    print("TABLE 1: Gradient accuracy vs inner solver tolerance")
+    print("=" * 78)
+    print(f"Reference (closed form): {np.asarray(g_exact)}")
+    print()
+    header = f"{'tol':>10} | {'method':>10} | {'max |err|':>12} | {'rel err':>12}"
+    print(header)
+    print("-" * len(header))
+
+    for tol in [1e-3, 1e-6, 1e-9, 1e-12]:
+        loss_a = jax.jit(make_loss(make_option_a(tol=tol), refs))
+        loss_b = jax.jit(make_loss(make_option_b(tol=tol), refs))
+        g_a = jax.grad(loss_a)(p)
+        g_b = jax.grad(loss_b)(p)
+        for name, g in [("A: jaxopt", g_a), ("B: custom", g_b)]:
+            err = float(jnp.max(jnp.abs(g - g_exact)))
+            rel = float(jnp.max(jnp.abs((g - g_exact) / g_exact)))
+            print(f"{tol:>10.0e} | {name:>10} | {err:>12.3e} | {rel:>12.3e}")
+
+    print()
+    print("Finite-difference baseline (full-pipeline FD, end-to-end):")
+    loss_ref = jax.jit(make_loss(make_option_a(tol=1e-12), refs))
+    for eps in [1e-3, 1e-5, 1e-7]:
+        g_fd = np.zeros(4)
+        for i in range(4):
+            dp = np.zeros(4)
+            dp[i] = eps
+            g_fd[i] = (loss_ref(p + dp) - loss_ref(p - dp)) / (2 * eps)
+        err = float(np.max(np.abs(g_fd - np.asarray(g_exact))))
+        rel = float(np.max(np.abs((g_fd - np.asarray(g_exact)) / np.asarray(g_exact))))
+        print(f"{eps:>10.0e} | {'FD':>10} | {err:>12.3e} | {rel:>12.3e}")
+
+
+def run_timing_table() -> None:
+    """Print Table 2: wall-time per gradient evaluation."""
+    p = jnp.array([2.0, 1.5, 3.0, 1.2])
+    refs = jnp.array([1.6, 1.3])
+
+    print()
+    print("=" * 78)
+    print("TABLE 2: Wall-time per gradient evaluation (JIT'd, 20 iterations)")
+    print("=" * 78)
+    header = f"{'method':>12} | {'tol':>8} | {'ms/grad':>10}"
+    print(header)
+    print("-" * len(header))
+
+    for tol in [1e-6, 1e-10]:
+        grad_a = jax.jit(jax.grad(make_loss(make_option_a(tol=tol), refs)))
+        grad_b = jax.jit(jax.grad(make_loss(make_option_b(tol=tol), refs)))
+        _, ms_a = _time_grad(grad_a, p)
+        _, ms_b = _time_grad(grad_b, p)
+        print(f"{'A: jaxopt':>12} | {tol:>8.0e} | {ms_a:>10.3f}")
+        print(f"{'B: custom':>12} | {tol:>8.0e} | {ms_b:>10.3f}")
+
+
+def run_conditioning_table() -> None:
+    """Print Table 3: Hessian ill-conditioning sensitivity (shrink ``k_1`` → 0)."""
+    refs = jnp.array([1.6, 1.3])
+
+    print()
+    print("=" * 78)
+    print("TABLE 3: Hessian ill-conditioning (shrink k_1 -> 0)")
+    print("=" * 78)
+    header = f"{'k1':>10} | {'cond(H)':>12} | {'A err':>12} | {'B err':>12}"
+    print(header)
+    print("-" * len(header))
+
+    for k1 in [2.0, 0.1, 1e-3, 1e-5]:
+        p = jnp.array([k1, 1.5, 3.0, 1.2])
+        g_exact = closed_form_grad(p, refs)
+        x_star = closed_form_geometry(p)
+        h_mat = jax.hessian(energy, argnums=0)(x_star, p)
+        cond = float(jnp.linalg.cond(h_mat))
+        g_a = jax.grad(jax.jit(make_loss(make_option_a(tol=1e-10), refs)))(p)
+        g_b = jax.grad(jax.jit(make_loss(make_option_b(tol=1e-10), refs)))(p)
+        err_a = float(jnp.max(jnp.abs(g_a - g_exact)))
+        err_b = float(jnp.max(jnp.abs(g_b - g_exact)))
+        print(f"{k1:>10.1e} | {cond:>12.3e} | {err_a:>12.3e} | {err_b:>12.3e}")
+
+
+def main() -> None:
+    """Entry point: run all three spike tables."""
+    print(f"JAX devices: {jax.devices()}")
+    print()
+    run_accuracy_table()
+    run_timing_table()
+    run_conditioning_table()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Phase 4a of the roadmap — geometry-refs implicit-diff spike

The last remaining ❌ in the [differentiability matrix](https://github.com/ericchansen/q2mm/blob/master/docs/how-it-works/architecture.md#differentiability-status) is the geometry category (`bond_length`, `bond_angle`, `torsion_angle`), which needs the gradient of the relaxed geometry `x*(p)` with respect to the force-field parameters. Naive autodiff through the inner minimizer is expensive and brittle; the implicit function theorem gives a closed-form VJP that avoids it.

This PR is the **spike** that picks the implementation approach **before** Phase 4b writes the full production path. It does not change any runtime code — it's a runnable prototype plus a memo.

### What's in this PR

- `scripts/spike_geom_implicit_diff.py` — runnable prototype comparing two approaches on a triatomic toy system whose relaxed geometry has a closed form, so every gradient can be checked against an exact analytical derivative.
- `docs/how-it-works/geometry-refs-spike.md` — memo with three tables (accuracy vs inner tol, wall time, Hessian ill-conditioning) and the Phase 4b decision.
- `docs/how-it-works/architecture.md` — link the geometry-refs rows of the differentiability matrix to the spike.
- `properdocs.yml` — add the spike page to the nav.

### Decision

**Option A — `jaxopt.LBFGS(..., implicit_diff=True)`.**

Already a dependency. Zero custom VJP code to own. Same machine-precision accuracy as a hand-rolled `jax.custom_vjp`. Composable with the existing `jax.jit` / `jax.vmap` patterns used by `JaxOptOptimizer` and `JaxMultiStartOptimizer`.

### Summary of numbers (CPU, float64, 4-param toy)

| comparison                   | result |
| :---                         | :---   |
| A vs closed-form             | max err `9.7e-17` |
| B (custom_vjp) vs closed-form | max err `4.7e-16` |
| FD (`ε=1e-5`) vs closed-form | max err `1.8e-12` |
| A wall time                  | ~20–30 µs / gradient |
| B wall time                  | ~20–30 µs / gradient |

Inner-solver tolerance (`1e-3` → `1e-12`) does not affect outer gradient accuracy on a convex quadratic — both approaches rely only on `∇_x E(x*) ≈ 0`. Both degrade identically when `H` becomes ill-conditioned (it's a mathematical property, not an implementation choice).

### Watch-outs carried forward to Phase 4b

- Inner-solver non-convergence → needs `ok` flag + penalty fallback.
- Hessian ill-conditioning (`cond(H) > 1e4`) → Tikhonov regularization.
- `arccos` at boundary → clip cos input to `[-1+ε, 1-ε]` for collinear geometries.

### Testing

- `ruff check` + `ruff format --check` clean.
- Core test suite: 606 passed, 261 skipped, 333 deselected.
- Spike script runs end-to-end in < 1 minute on CPU.

Refs #152, #243
