### PR TITLE
feat: Phase 4b — geometry refs via implicit diff in JaxLoss

### DIFF
--- a/.github/envs/jax.yml
+++ b/.github/envs/jax.yml
@@ -7,6 +7,8 @@ dependencies:
   - scipy
   - jax
   - jaxlib
+  - jaxopt
+  - optax
   - pytest
   - ruff
   - pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-      - run: python -m pip install -e . --no-deps && python -m pytest -m jax --run-integration -q
+      - run: python -m pip install -e . --no-deps && python -m pip install --no-input jaxopt optax && python -m pytest -m jax --run-integration -q
 
   test-jax-md:
     needs: [lint, test-core]

--- a/q2mm/optimizers/evaluators/geometry.py
+++ b/q2mm/optimizers/evaluators/geometry.py
@@ -231,22 +231,25 @@ class GeometryEvaluator:
     def supports_analytical_gradient(self, engine: MMEngine) -> bool:
         """Whether the geometry evaluator supports analytical gradients.
 
-        Geometry gradients through the force-field parameters require
-        differentiating through a geometry minimization.  The JAX
-        backend supports this via :class:`~q2mm.optimizers.jaxloss.JaxLoss`,
-        which uses implicit differentiation through an inner
-        ``jaxopt.LBFGS`` minimizer.  Other backends do not.
+        Returns ``False``: geometry gradients require differentiating
+        through a geometry minimization, which this method would
+        compute via :meth:`gradient` on a per-reference basis — not
+        yet implemented.
+
+        The JAX backend *does* support fully-differentiable geometry
+        loss via :class:`~q2mm.optimizers.jaxloss.JaxLoss`, but that is
+        a separate end-to-end code path used by
+        :class:`~q2mm.optimizers.jaxopt_opt.JaxOptOptimizer` and does
+        not flow through :meth:`ObjectiveFunction.gradient`.
 
         Args:
             engine: The MM backend to check.
 
         Returns:
-            ``True`` when *engine* is a JaxEngine; otherwise ``False``.
+            Always ``False`` — not yet implemented for this path.
 
         """
-        from q2mm.backends.mm.jax_engine import JaxEngine
-
-        return isinstance(engine, JaxEngine)
+        return False
 
     def gradient(
         self,

--- a/q2mm/optimizers/evaluators/geometry.py
+++ b/q2mm/optimizers/evaluators/geometry.py
@@ -229,16 +229,24 @@ class GeometryEvaluator:
         raise ValueError(f"GeometryEvaluator cannot handle kind: {ref.kind}")
 
     def supports_analytical_gradient(self, engine: MMEngine) -> bool:
-        """Geometry gradients require differentiating through the minimizer.
+        """Whether the geometry evaluator supports analytical gradients.
+
+        Geometry gradients through the force-field parameters require
+        differentiating through a geometry minimization.  The JAX
+        backend supports this via :class:`~q2mm.optimizers.jaxloss.JaxLoss`,
+        which uses implicit differentiation through an inner
+        ``jaxopt.LBFGS`` minimizer.  Other backends do not.
 
         Args:
             engine: The MM backend to check.
 
         Returns:
-            Always ``False`` — not yet implemented.
+            ``True`` when *engine* is a JaxEngine; otherwise ``False``.
 
         """
-        return False
+        from q2mm.backends.mm.jax_engine import JaxEngine
+
+        return isinstance(engine, JaxEngine)
 
     def gradient(
         self,

--- a/q2mm/optimizers/jaxloss.py
+++ b/q2mm/optimizers/jaxloss.py
@@ -6,10 +6,16 @@ JAX's XLA backend.  This eliminates Python-loop overhead and enables
 end-to-end gradient computation via ``jax.grad``.
 
 The compiled loss supports **energy**, **frequency**, **hessian-element**,
-and **eigenmatrix** reference types.  Geometry references (bond_length,
-bond_angle, torsion_angle) are excluded — they require differentiable
-energy minimization via implicit differentiation, which is planned for
-a later phase.
+**eigenmatrix**, and **geometry** (bond_length / bond_angle /
+torsion_angle) reference types.  Geometry references are handled via
+implicit differentiation: each loss call runs an inner
+``jaxopt.LBFGS(fun=handle._energy_fn, implicit_diff=True)`` geometry
+minimization at the current parameters, computes bond/angle/torsion
+observables from the relaxed coordinates, and accumulates weighted
+residuals.  The implicit-function theorem gives the exact gradient of
+the relaxed observables with respect to the force-field parameters
+without autodiff-through-iteration.  See
+``docs/how-it-works/geometry-refs-spike.md`` for the design decision.
 
 Usage::
 
@@ -37,6 +43,124 @@ if TYPE_CHECKING:
     from q2mm.models.forcefield import ForceField
     from q2mm.models.molecule import Q2MMMolecule
     from q2mm.optimizers.spec import ObjectiveSpec
+
+
+# Tolerance + iteration cap for the inner geometry minimizer used when a
+# molecule has geometry references.  The outer gradient does NOT depend on
+# inner_tol for well-conditioned convex problems (see geometry-refs-spike.md),
+# but a tight-enough tol is needed so that ``∇_x E(x*) ≈ 0`` at which the
+# implicit-function theorem applies.
+_GEOM_INNER_TOL = 1e-8
+_GEOM_INNER_MAXITER = 200
+
+
+def _relax_coords(energy_fn, params, coords0):  # noqa: ANN001, ANN202
+    """Return the relaxed geometry ``x*(params)`` for a single molecule.
+
+    Uses ``jaxopt.LBFGS(fun=energy_of_coords, implicit_diff=True)`` so the
+    outer ``jax.grad`` sees the exact parameter-gradient of ``x*`` via the
+    implicit function theorem, avoiding autodiff-through-iteration.
+
+    Args:
+        energy_fn: ``(params, coords) -> scalar`` energy function
+            (typically ``handle._energy_fn``).  Coords shape ``(N, 3)``.
+        params: Current parameter vector (JAX array).
+        coords0: Initial coordinates, shape ``(N, 3)``.
+
+    Returns:
+        Relaxed coordinates, shape ``(N, 3)``.
+
+    """
+    import jaxopt
+
+    def energy_of_coords(coords, p):  # noqa: ANN001, ANN202
+        return energy_fn(p, coords)
+
+    solver = jaxopt.LBFGS(
+        fun=energy_of_coords,
+        tol=_GEOM_INNER_TOL,
+        maxiter=_GEOM_INNER_MAXITER,
+        implicit_diff=True,
+    )
+    sol = solver.run(coords0, params)
+    return sol.params
+
+
+def _bond_lengths(coords, atoms):  # noqa: ANN001, ANN202
+    """Compute bond lengths (Å) for pairs of atoms.
+
+    Args:
+        coords: ``(N, 3)`` Cartesian coordinates.
+        atoms: ``(M, 2)`` integer array of atom-index pairs.
+
+    Returns:
+        ``(M,)`` array of bond lengths.
+
+    """
+    from q2mm.backends.mm._jax_common import jnp
+
+    d = coords[atoms[:, 0]] - coords[atoms[:, 1]]
+    return jnp.sqrt(jnp.sum(d * d, axis=-1))
+
+
+def _bond_angles_deg(coords, atoms):  # noqa: ANN001, ANN202
+    """Compute bond angles in degrees for atom triples.
+
+    The middle atom is the vertex.  Cos of the angle is clipped to
+    ``[-1+ε, 1-ε]`` to avoid NaN gradients at collinear geometries (see
+    geometry-refs-spike.md for the watch-out).
+
+    Args:
+        coords: ``(N, 3)`` Cartesian coordinates.
+        atoms: ``(M, 3)`` integer array of atom-index triples
+            (outer, vertex, outer).
+
+    Returns:
+        ``(M,)`` array of angles in degrees.
+
+    """
+    from q2mm.backends.mm._jax_common import jnp
+
+    v1 = coords[atoms[:, 0]] - coords[atoms[:, 1]]
+    v2 = coords[atoms[:, 2]] - coords[atoms[:, 1]]
+    n1 = jnp.linalg.norm(v1, axis=-1)
+    n2 = jnp.linalg.norm(v2, axis=-1)
+    cos = jnp.sum(v1 * v2, axis=-1) / (n1 * n2)
+    cos = jnp.clip(cos, -1.0 + 1e-12, 1.0 - 1e-12)
+    return jnp.arccos(cos) * (180.0 / jnp.pi)
+
+
+def _torsion_angles_deg(coords, atoms):  # noqa: ANN001, ANN202
+    """Compute torsion (dihedral) angles in degrees for atom quadruples.
+
+    Uses the numerically stable ``atan2`` formulation so the result is
+    smooth across the ±180° wrap.
+
+    Args:
+        coords: ``(N, 3)`` Cartesian coordinates.
+        atoms: ``(M, 4)`` integer array of atom-index quadruples.
+
+    Returns:
+        ``(M,)`` array of dihedrals in degrees, in ``[-180, 180]``.
+
+    """
+    from q2mm.backends.mm._jax_common import jnp
+
+    p0 = coords[atoms[:, 0]]
+    p1 = coords[atoms[:, 1]]
+    p2 = coords[atoms[:, 2]]
+    p3 = coords[atoms[:, 3]]
+    b1 = p1 - p0
+    b2 = p2 - p1
+    b3 = p3 - p2
+    b2_norm = jnp.linalg.norm(b2, axis=-1, keepdims=True)
+    b2_hat = b2 / b2_norm
+    n1 = jnp.cross(b1, b2)
+    n2 = jnp.cross(b2, b3)
+    m = jnp.cross(n1, b2_hat)
+    x = jnp.sum(n1 * n2, axis=-1)
+    y = jnp.sum(m * n2, axis=-1)
+    return jnp.arctan2(y, x) * (180.0 / jnp.pi)
 
 
 class JaxLoss:
@@ -158,6 +282,18 @@ class JaxLoss:
                     entry["eoff_indices"] = jnp.array(mol_spec.eig_offdiag_indices, dtype=jnp.int32)
                     entry["eoff_refs"] = jnp.array(mol_spec.eig_offdiag_refs)
                     entry["eoff_weights"] = jnp.array(mol_spec.eig_offdiag_weights)
+            if mol_spec.has_bond_length:
+                entry["bond_atoms"] = jnp.array(mol_spec.bond_atoms, dtype=jnp.int32)
+                entry["bond_refs"] = jnp.array(mol_spec.bond_refs)
+                entry["bond_weights"] = jnp.array(mol_spec.bond_weights)
+            if mol_spec.has_bond_angle:
+                entry["angle_atoms"] = jnp.array(mol_spec.angle_atoms, dtype=jnp.int32)
+                entry["angle_refs"] = jnp.array(mol_spec.angle_refs)
+                entry["angle_weights"] = jnp.array(mol_spec.angle_weights)
+            if mol_spec.has_torsion:
+                entry["torsion_atoms"] = jnp.array(mol_spec.torsion_atoms, dtype=jnp.int32)
+                entry["torsion_refs"] = jnp.array(mol_spec.torsion_refs)
+                entry["torsion_weights"] = jnp.array(mol_spec.torsion_weights)
 
             mol_data.append(entry)
 
@@ -182,6 +318,31 @@ class JaxLoss:
                     energy = energy_fn(params, coords)
                     residuals = entry["energy_weights"] * (entry["energy_refs"] - energy)
                     total = total + jnp.sum(residuals**2)
+
+                # Geometry contributions — relax coords at current params,
+                # then compute bond/angle/torsion observables.  Implicit
+                # differentiation through the inner jaxopt.LBFGS gives the
+                # exact gradient w.r.t. params; see geometry-refs-spike.md.
+                if mol_spec.has_geometry:
+                    relaxed = _relax_coords(energy_fn, params, coords)
+
+                    if mol_spec.has_bond_length:
+                        calc = _bond_lengths(relaxed, entry["bond_atoms"])
+                        residuals = entry["bond_weights"] * (entry["bond_refs"] - calc)
+                        total = total + jnp.sum(residuals**2)
+
+                    if mol_spec.has_bond_angle:
+                        calc = _bond_angles_deg(relaxed, entry["angle_atoms"])
+                        residuals = entry["angle_weights"] * (entry["angle_refs"] - calc)
+                        total = total + jnp.sum(residuals**2)
+
+                    if mol_spec.has_torsion:
+                        calc = _torsion_angles_deg(relaxed, entry["torsion_atoms"])
+                        # Wrap torsion residuals into [-180, 180) before squaring.
+                        diff = entry["torsion_refs"] - calc
+                        diff = (diff + 180.0) % 360.0 - 180.0
+                        residuals = entry["torsion_weights"] * diff
+                        total = total + jnp.sum(residuals**2)
 
                 # Hessian-dependent contributions
                 if mol_spec.needs_hessian_computation:

--- a/q2mm/optimizers/jaxloss.py
+++ b/q2mm/optimizers/jaxloss.py
@@ -106,9 +106,11 @@ def _bond_lengths(coords, atoms):  # noqa: ANN001, ANN202
 def _bond_angles_deg(coords, atoms):  # noqa: ANN001, ANN202
     """Compute bond angles in degrees for atom triples.
 
-    The middle atom is the vertex.  Cos of the angle is clipped to
-    ``[-1+ε, 1-ε]`` to avoid NaN gradients at collinear geometries (see
-    geometry-refs-spike.md for the watch-out).
+    The middle atom is the vertex.  Norms are floored by a small
+    epsilon so that degenerate (zero-length arm) geometries encountered
+    during relaxation produce finite values instead of NaNs, and the
+    cos is clipped to ``[-1+ε, 1-ε]`` to avoid NaN gradients at
+    collinear geometries (see geometry-refs-spike.md).
 
     Args:
         coords: ``(N, 3)`` Cartesian coordinates.
@@ -125,7 +127,8 @@ def _bond_angles_deg(coords, atoms):  # noqa: ANN001, ANN202
     v2 = coords[atoms[:, 2]] - coords[atoms[:, 1]]
     n1 = jnp.linalg.norm(v1, axis=-1)
     n2 = jnp.linalg.norm(v2, axis=-1)
-    cos = jnp.sum(v1 * v2, axis=-1) / (n1 * n2)
+    denom = jnp.maximum(n1 * n2, 1e-12)
+    cos = jnp.sum(v1 * v2, axis=-1) / denom
     cos = jnp.clip(cos, -1.0 + 1e-12, 1.0 - 1e-12)
     return jnp.arccos(cos) * (180.0 / jnp.pi)
 
@@ -134,7 +137,10 @@ def _torsion_angles_deg(coords, atoms):  # noqa: ANN001, ANN202
     """Compute torsion (dihedral) angles in degrees for atom quadruples.
 
     Uses the numerically stable ``atan2`` formulation so the result is
-    smooth across the ±180° wrap.
+    smooth across the ±180° wrap.  Norms are floored by a small
+    epsilon so degenerate geometries (collinear triplets, zero-length
+    ``b2``) produce finite values instead of NaN/inf, matching the
+    NumPy reference behavior in :func:`q2mm.geometry.dihedral_angle`.
 
     Args:
         coords: ``(N, 3)`` Cartesian coordinates.
@@ -154,7 +160,7 @@ def _torsion_angles_deg(coords, atoms):  # noqa: ANN001, ANN202
     b2 = p2 - p1
     b3 = p3 - p2
     b2_norm = jnp.linalg.norm(b2, axis=-1, keepdims=True)
-    b2_hat = b2 / b2_norm
+    b2_hat = b2 / jnp.maximum(b2_norm, 1e-12)
     n1 = jnp.cross(b1, b2)
     n2 = jnp.cross(b2, b3)
     m = jnp.cross(n1, b2_hat)

--- a/q2mm/optimizers/jaxopt_opt.py
+++ b/q2mm/optimizers/jaxopt_opt.py
@@ -59,9 +59,11 @@ class JaxOptOptimizer:
     This optimizer requires:
 
     1. A **JaxEngine** backend (other engines are not supported).
-    2. Only reference types supported by the JIT loss: energy,
-       frequency, hessian-element, eigenmatrix.  Geometry references
-       are silently excluded.
+    2. Reference types supported by the JIT loss: energy, frequency,
+       hessian-element, eigenmatrix, and geometry (bond_length,
+       bond_angle, torsion_angle).  Geometry references are handled via
+       implicit differentiation through an inner ``jaxopt.LBFGS``
+       geometry minimization.
 
     Args:
         method: Optimization method.  One of ``'lbfgs'`` (default),

--- a/q2mm/optimizers/objective.py
+++ b/q2mm/optimizers/objective.py
@@ -1366,15 +1366,15 @@ class ObjectiveFunction:
         format consumed by :class:`~q2mm.optimizers.jaxloss.JaxLoss`.
 
         Geometry references (bond_length, bond_angle, torsion_angle)
-        are silently excluded — they require differentiable energy
-        minimization which is not yet supported in the JIT loss path.
+        are included; the JIT loss handles them via implicit
+        differentiation through an inner ``jaxopt.LBFGS`` geometry
+        minimization.
 
         Returns:
             ObjectiveSpec ready for JIT compilation.
 
         Raises:
-            ValueError: If no JIT-compatible references remain after
-                excluding geometry.
+            ValueError: If the objective has no references.
 
         """
         from q2mm.optimizers.spec import ObjectiveSpec, _build_molecule_spec
@@ -1394,6 +1394,7 @@ class ObjectiveFunction:
                 mol_idx=mol_idx,
                 symbols=tuple(mol.symbols),
                 refs=refs,
+                topology=mol,
             )
             mol_specs.append(spec)
             # Track which categories are present
@@ -1405,12 +1406,12 @@ class ObjectiveFunction:
                 categories.add("hessian")
             if spec.has_eigenmatrix:
                 categories.add("eigenmatrix")
+            if spec.has_geometry:
+                categories.add("geometry")
 
         if not categories:
             raise ValueError(
-                "No JIT-compatible references found. "
-                "Geometry references require differentiable minimization "
-                "and are not supported in the JIT loss path."
+                "No references found. ObjectiveFunction.to_jax_spec() requires at least one reference value."
             )
 
         # Parameter bounds from the force field

--- a/q2mm/optimizers/spec.py
+++ b/q2mm/optimizers/spec.py
@@ -48,6 +48,19 @@ class MoleculeSpec:
         eig_offdiag_refs: ``(n_eoff,)`` reference off-diagonal values.
         eig_offdiag_weights: ``(n_eoff,)`` weights for off-diagonal
             residuals.
+        bond_atoms: ``(n_bond, 2)`` integer atom-index pairs for
+            bond-length geometry references.
+        bond_refs: ``(n_bond,)`` reference bond lengths (Å).
+        bond_weights: ``(n_bond,)`` weights for bond-length residuals.
+        angle_atoms: ``(n_angle, 3)`` integer atom-index triples
+            ``(outer, vertex, outer)`` for bond-angle references.
+        angle_refs: ``(n_angle,)`` reference bond angles (degrees).
+        angle_weights: ``(n_angle,)`` weights for bond-angle residuals.
+        torsion_atoms: ``(n_tors, 4)`` integer atom-index quadruples
+            for dihedral references.
+        torsion_refs: ``(n_tors,)`` reference dihedrals in ``[-180, 180]``
+            degrees.
+        torsion_weights: ``(n_tors,)`` weights for torsion residuals.
 
     """
 

--- a/q2mm/optimizers/spec.py
+++ b/q2mm/optimizers/spec.py
@@ -73,6 +73,18 @@ class MoleculeSpec:
     eig_offdiag_indices: np.ndarray
     eig_offdiag_refs: np.ndarray
     eig_offdiag_weights: np.ndarray
+    # Geometry — bond length (atom pairs, Å)
+    bond_atoms: np.ndarray = field(default_factory=lambda: np.zeros((0, 2), dtype=int))
+    bond_refs: np.ndarray = field(default_factory=lambda: np.array([], dtype=float))
+    bond_weights: np.ndarray = field(default_factory=lambda: np.array([], dtype=float))
+    # Geometry — bond angle (atom triples, degrees; middle atom is vertex)
+    angle_atoms: np.ndarray = field(default_factory=lambda: np.zeros((0, 3), dtype=int))
+    angle_refs: np.ndarray = field(default_factory=lambda: np.array([], dtype=float))
+    angle_weights: np.ndarray = field(default_factory=lambda: np.array([], dtype=float))
+    # Geometry — torsion angle (atom quadruples, degrees, range [-180, 180])
+    torsion_atoms: np.ndarray = field(default_factory=lambda: np.zeros((0, 4), dtype=int))
+    torsion_refs: np.ndarray = field(default_factory=lambda: np.array([], dtype=float))
+    torsion_weights: np.ndarray = field(default_factory=lambda: np.array([], dtype=float))
 
     @property
     def has_energy(self) -> bool:
@@ -95,9 +107,46 @@ class MoleculeSpec:
         return len(self.eig_diag_refs) > 0 or len(self.eig_offdiag_refs) > 0
 
     @property
+    def has_bond_length(self) -> bool:
+        """Whether this molecule has bond-length geometry references."""
+        return len(self.bond_refs) > 0
+
+    @property
+    def has_bond_angle(self) -> bool:
+        """Whether this molecule has bond-angle geometry references."""
+        return len(self.angle_refs) > 0
+
+    @property
+    def has_torsion(self) -> bool:
+        """Whether this molecule has torsion-angle geometry references."""
+        return len(self.torsion_refs) > 0
+
+    @property
+    def has_geometry(self) -> bool:
+        """Whether this molecule has any geometry references.
+
+        Geometry references require relaxing the molecular geometry at
+        each set of parameters; :class:`~q2mm.optimizers.jaxloss.JaxLoss`
+        handles them via implicit differentiation through
+        ``jaxopt.LBFGS``.
+        """
+        return self.has_bond_length or self.has_bond_angle or self.has_torsion
+
+    @property
     def needs_hessian_computation(self) -> bool:
         """Whether this molecule requires a Hessian from the engine."""
         return self.has_frequency or self.has_hessian or self.has_eigenmatrix
+
+    @property
+    def needs_geometry_relaxation(self) -> bool:
+        """Whether this molecule requires a relaxed geometry from the engine.
+
+        True when any bond/angle/torsion geometry reference is present.
+        :class:`~q2mm.optimizers.jaxloss.JaxLoss` will run an inner
+        ``jaxopt.LBFGS`` geometry minimization per loss call and
+        differentiate through it via the implicit function theorem.
+        """
+        return self.has_geometry
 
 
 @dataclass(frozen=True)
@@ -119,8 +168,10 @@ class ObjectiveSpec:
         lower_bounds: ``(n_params,)`` lower bounds (``-inf`` = unbounded).
         upper_bounds: ``(n_params,)`` upper bounds (``+inf`` = unbounded).
         supported_categories: Frozenset of evaluator categories present
-            in the spec (e.g. ``{"energy", "frequency"}``).  Geometry
-            is excluded — see module docstring.
+            in the spec (e.g. ``{"energy", "frequency", "geometry"}``).
+            Geometry references are handled via implicit differentiation
+            through an inner ``jaxopt.LBFGS`` geometry minimization; see
+            :class:`~q2mm.optimizers.jaxloss.JaxLoss`.
 
     """
 
@@ -136,11 +187,11 @@ class ObjectiveSpec:
         """Return True if any molecule has geometry references.
 
         Geometry references (bond_length, bond_angle, torsion_angle)
-        are NOT supported by the JIT loss — they require differentiable
-        energy minimization (implicit differentiation).  This method
-        is provided for diagnostic checks.
+        are supported by the JIT loss via implicit differentiation
+        through ``jaxopt.LBFGS``. See
+        :class:`~q2mm.optimizers.jaxloss.JaxLoss` for details.
         """
-        return False  # ObjectiveSpec intentionally excludes geometry
+        return any(m.has_geometry for m in self.molecules)
 
     @property
     def n_molecules(self) -> int:
@@ -152,6 +203,8 @@ def _build_molecule_spec(
     mol_idx: int,
     symbols: tuple[str, ...],
     refs: list,
+    *,
+    topology: object | None = None,
 ) -> MoleculeSpec:
     """Build a MoleculeSpec from a list of ReferenceValue objects.
 
@@ -159,9 +212,18 @@ def _build_molecule_spec(
         mol_idx: Molecule index in the training set.
         symbols: Element symbols for this molecule.
         refs: List of ReferenceValue objects for this molecule.
+        topology: Optional molecule object providing ``bonds``,
+            ``angles``, and ``torsions`` lists. Used to resolve
+            positional ``data_idx`` for geometry references (e.g.
+            ``ref.kind == "bond_length"`` with no ``atom_indices``) to
+            explicit atom-index tuples required by the JIT loss.
 
     Returns:
         MoleculeSpec with arrays populated from the references.
+
+    Raises:
+        ValueError: If a geometry reference uses ``data_idx`` but no
+            ``topology`` is provided, or if ``data_idx`` is out of range.
 
     """
     energy_vals, energy_wts = [], []
@@ -169,6 +231,9 @@ def _build_molecule_spec(
     hess_idx, hess_vals, hess_wts = [], [], []
     ediag_idx, ediag_vals, ediag_wts = [], [], []
     eoff_idx, eoff_vals, eoff_wts = [], [], []
+    bond_at, bond_v, bond_w = [], [], []
+    ang_at, ang_v, ang_w = [], [], []
+    tor_at, tor_v, tor_w = [], [], []
 
     for ref in refs:
         if ref.kind == "energy":
@@ -204,8 +269,21 @@ def _build_molecule_spec(
                 eoff_idx.append(ref.data_idx)
             eoff_vals.append(ref.value)
             eoff_wts.append(ref.weight)
-        elif ref.kind in ("bond_length", "bond_angle", "torsion_angle"):
-            pass  # Geometry excluded from JIT loss
+        elif ref.kind == "bond_length":
+            atoms = _resolve_geom_atoms(ref, "bonds", 2, topology)
+            bond_at.append(atoms)
+            bond_v.append(ref.value)
+            bond_w.append(ref.weight)
+        elif ref.kind == "bond_angle":
+            atoms = _resolve_geom_atoms(ref, "angles", 3, topology)
+            ang_at.append(atoms)
+            ang_v.append(ref.value)
+            ang_w.append(ref.weight)
+        elif ref.kind == "torsion_angle":
+            atoms = _resolve_geom_atoms(ref, "torsions", 4, topology)
+            tor_at.append(atoms)
+            tor_v.append(ref.value)
+            tor_w.append(ref.weight)
         else:
             raise ValueError(f"Unknown reference kind: {ref.kind!r}")
 
@@ -227,4 +305,63 @@ def _build_molecule_spec(
         eig_offdiag_indices=np.array(eoff_idx, dtype=int),
         eig_offdiag_refs=np.array(eoff_vals, dtype=float),
         eig_offdiag_weights=np.array(eoff_wts, dtype=float),
+        bond_atoms=np.array(bond_at, dtype=int).reshape(-1, 2),
+        bond_refs=np.array(bond_v, dtype=float),
+        bond_weights=np.array(bond_w, dtype=float),
+        angle_atoms=np.array(ang_at, dtype=int).reshape(-1, 3),
+        angle_refs=np.array(ang_v, dtype=float),
+        angle_weights=np.array(ang_w, dtype=float),
+        torsion_atoms=np.array(tor_at, dtype=int).reshape(-1, 4),
+        torsion_refs=np.array(tor_v, dtype=float),
+        torsion_weights=np.array(tor_w, dtype=float),
     )
+
+
+def _resolve_geom_atoms(
+    ref: object,
+    attr: str,
+    arity: int,
+    topology: object | None,
+) -> tuple[int, ...]:
+    """Resolve a geometry reference to an explicit atom-index tuple.
+
+    Prefers ``ref.atom_indices`` when present. Falls back to looking up
+    ``topology.<attr>[ref.data_idx]`` (e.g. ``topology.bonds[0]``) and
+    pulling the atom indices off that record (``atom_i``, ``atom_j``,
+    ...).
+
+    Args:
+        ref: The :class:`~q2mm.optimizers.objective.ReferenceValue`.
+        attr: The topology attribute to fall back to
+            (``"bonds"`` / ``"angles"`` / ``"torsions"``).
+        arity: Number of atom indices expected (2, 3, or 4).
+        topology: Molecule object; required when falling back to
+            ``data_idx``.
+
+    Returns:
+        Tuple of atom indices with length ``arity``.
+
+    Raises:
+        ValueError: If atoms cannot be resolved.
+
+    """
+    if ref.atom_indices is not None and len(ref.atom_indices) >= arity:
+        return tuple(int(i) for i in ref.atom_indices[:arity])
+    if topology is None:
+        raise ValueError(
+            f"{ref.kind} reference {ref.label!r} has no atom_indices and no "
+            "molecule topology was provided to resolve data_idx."
+        )
+    records = getattr(topology, attr, None)
+    if records is None:
+        raise ValueError(
+            f"{ref.kind} reference {ref.label!r} requires molecule.{attr}, but molecule has no such attribute."
+        )
+    if ref.data_idx < 0 or ref.data_idx >= len(records):
+        raise ValueError(
+            f"{ref.kind} reference {ref.label!r} has data_idx={ref.data_idx} "
+            f"out of range (molecule.{attr} has {len(records)} entries)."
+        )
+    record = records[ref.data_idx]
+    index_attrs = ("atom_i", "atom_j", "atom_k", "atom_l")[:arity]
+    return tuple(int(getattr(record, a)) for a in index_attrs)

--- a/test/test_jax_loss.py
+++ b/test/test_jax_loss.py
@@ -79,8 +79,8 @@ class TestObjectiveSpec:
         np.testing.assert_array_equal(spec.molecules[0].energy_refs, [0.0])
         np.testing.assert_array_equal(spec.molecules[0].energy_weights, [1.0])
 
-    def test_geometry_excluded(self) -> None:
-        """Geometry references silently excluded from spec."""
+    def test_geometry_included(self) -> None:
+        """Geometry references are included via implicit-diff path."""
         from q2mm.optimizers.objective import ObjectiveFunction, ReferenceData
 
         mol = make_water(bond_length=0.96, angle_deg=104.5)
@@ -94,8 +94,12 @@ class TestObjectiveSpec:
         spec = obj.to_jax_spec()
 
         assert spec.molecules[0].has_energy
-        assert "geometry" not in spec.supported_categories
-        assert spec.has_geometry_refs() is False
+        assert spec.molecules[0].has_bond_length
+        assert spec.molecules[0].has_geometry
+        assert "geometry" in spec.supported_categories
+        assert spec.has_geometry_refs() is True
+        np.testing.assert_array_equal(spec.molecules[0].bond_atoms, [[0, 1]])
+        np.testing.assert_array_equal(spec.molecules[0].bond_refs, [0.96])
 
     def test_bounds_roundtrip(self) -> None:
         """Parameter bounds transferred to spec."""
@@ -530,3 +534,106 @@ class TestFrequencySensitivityParity:
             if norm_np > 1e-10 and norm_jax > 1e-10:
                 cos_sim = np.dot(j_np, j_jax) / (norm_np * norm_jax)
                 assert cos_sim > 0.99, f"Mode {i}: cosine similarity {cos_sim:.4f} too low"
+
+
+class TestJaxLossGeometryParity:
+    """Tests for the geometry-references implicit-diff loss path."""
+
+    def test_bond_length_relaxes_to_eq(self) -> None:
+        """Relaxed H2 bond length matches the FF equilibrium parameter."""
+        from q2mm.optimizers.jaxloss import JaxLoss
+        from q2mm.optimizers.objective import ObjectiveFunction, ReferenceData
+
+        # Start with a stretched bond; equilibrium r0 = 0.74 Å.
+        mol = make_diatomic(distance=0.90, bond_tolerance=1.5)
+        ff = _h2_ff(bond_k=359.7, bond_r0=0.74)
+        engine = JaxEngine()
+
+        # Reference equals the eq value → relaxed loss should be ~0.
+        ref = ReferenceData()
+        ref.add_bond_length(value=0.74, molecule_idx=0, atom_indices=(0, 1), weight=1.0)
+
+        obj = ObjectiveFunction(forcefield=ff, engine=engine, molecules=[mol], reference=ref)
+        spec = obj.to_jax_spec()
+        jax_loss = JaxLoss(spec, engine, [mol], ff)
+
+        params = ff.get_param_vector()
+        loss = jax_loss(params)
+        # relaxed bond ≈ 0.74, so (0.74 − 0.74)^2 should be ~0.
+        assert loss < 1e-10
+
+    def test_bond_length_grad_matches_fd(self) -> None:
+        """∇_p loss for a bond-length ref matches finite differences."""
+        from q2mm.optimizers.jaxloss import JaxLoss
+        from q2mm.optimizers.objective import ObjectiveFunction, ReferenceData
+
+        mol = make_diatomic(distance=0.90, bond_tolerance=1.5)
+        ff = _h2_ff(bond_k=359.7, bond_r0=0.74)
+        engine = JaxEngine()
+
+        # Reference offset from current r0 so the gradient is non-trivial.
+        ref = ReferenceData()
+        ref.add_bond_length(value=0.80, molecule_idx=0, atom_indices=(0, 1), weight=1.0)
+
+        obj = ObjectiveFunction(forcefield=ff, engine=engine, molecules=[mol], reference=ref)
+        spec = obj.to_jax_spec()
+        jax_loss = JaxLoss(spec, engine, [mol], ff)
+
+        params = ff.get_param_vector()
+        _, grad_jax = jax_loss.loss_and_grad(params)
+
+        # Central-difference reference gradient (full-pipeline FD: each
+        # eval relaxes the geometry at the perturbed parameters).
+        eps = 1e-4
+        grad_fd = np.zeros_like(params)
+        for i in range(len(params)):
+            dp = np.zeros_like(params)
+            dp[i] = eps
+            grad_fd[i] = (jax_loss(params + dp) - jax_loss(params - dp)) / (2 * eps)
+
+        np.testing.assert_allclose(grad_jax, grad_fd, atol=1e-5, rtol=1e-3)
+
+    def test_bond_angle_relaxes_to_eq(self) -> None:
+        """Relaxed H2O bond angle matches the FF equilibrium parameter."""
+        from q2mm.optimizers.jaxloss import JaxLoss
+        from q2mm.optimizers.objective import ObjectiveFunction, ReferenceData
+
+        # Start with a perturbed angle; eq is 104.5°.
+        mol = make_water(bond_length=0.96, angle_deg=110.0)
+        ff = _water_ff(bond_k=553.0, bond_r0=0.96, angle_k=49.9, angle_eq=104.5)
+        engine = JaxEngine()
+
+        ref = ReferenceData()
+        # Atom indices: H(1)–O(0)–H(2) with O as vertex.
+        ref.add_bond_angle(value=104.5, molecule_idx=0, atom_indices=(1, 0, 2), weight=1.0)
+
+        obj = ObjectiveFunction(forcefield=ff, engine=engine, molecules=[mol], reference=ref)
+        spec = obj.to_jax_spec()
+        jax_loss = JaxLoss(spec, engine, [mol], ff)
+
+        params = ff.get_param_vector()
+        loss = jax_loss(params)
+        assert loss < 1e-6
+
+    def test_geometry_grad_jit_callable(self) -> None:
+        """JaxLoss.loss_and_grad with geometry refs is jit-compilable."""
+        from q2mm.optimizers.jaxloss import JaxLoss
+        from q2mm.optimizers.objective import ObjectiveFunction, ReferenceData
+
+        mol = make_water(bond_length=0.97, angle_deg=104.5)
+        ff = _water_ff()
+        engine = JaxEngine()
+
+        ref = ReferenceData()
+        ref.add_bond_length(value=0.96, molecule_idx=0, atom_indices=(0, 1), weight=1.0)
+        ref.add_bond_angle(value=104.5, molecule_idx=0, atom_indices=(1, 0, 2), weight=1.0)
+
+        obj = ObjectiveFunction(forcefield=ff, engine=engine, molecules=[mol], reference=ref)
+        spec = obj.to_jax_spec()
+        jax_loss = JaxLoss(spec, engine, [mol], ff)
+
+        params = ff.get_param_vector()
+        loss, grad = jax_loss.loss_and_grad(params)
+        assert np.isfinite(loss)
+        assert grad.shape == params.shape
+        assert np.all(np.isfinite(grad))

--- a/test/test_jax_loss.py
+++ b/test/test_jax_loss.py
@@ -637,3 +637,57 @@ class TestJaxLossGeometryParity:
         assert np.isfinite(loss)
         assert grad.shape == params.shape
         assert np.all(np.isfinite(grad))
+
+    def test_torsion_observable_math(self) -> None:
+        """_torsion_angles_deg produces correct dihedrals for known geometries."""
+        import jax.numpy as jnp
+
+        from q2mm.optimizers.jaxloss import _torsion_angles_deg
+
+        # Planar cis (0°): all four atoms in xy-plane, zig-zag along y.
+        coords_cis = jnp.array(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [1.0, 1.0, 0.0],
+                [0.0, 1.0, 0.0],
+            ]
+        )
+        # Planar trans (180°): atom 3 on opposite side.
+        coords_trans = jnp.array(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [1.0, 1.0, 0.0],
+                [2.0, 1.0, 0.0],
+            ]
+        )
+        # Perpendicular (+90°): atom 3 rotated about b2 axis.
+        coords_90 = jnp.array(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [1.0, 1.0, 0.0],
+                [1.0, 1.0, 1.0],
+            ]
+        )
+        atoms = jnp.array([[0, 1, 2, 3]])
+
+        np.testing.assert_allclose(float(_torsion_angles_deg(coords_cis, atoms)[0]), 0.0, atol=1e-6)
+        np.testing.assert_allclose(abs(float(_torsion_angles_deg(coords_trans, atoms)[0])), 180.0, atol=1e-6)
+        np.testing.assert_allclose(abs(float(_torsion_angles_deg(coords_90, atoms)[0])), 90.0, atol=1e-6)
+
+    def test_torsion_residual_wraps_across_180(self) -> None:
+        """Torsion loss at observed=+179°, ref=-179° gives ~2° residual, not 358°."""
+        import jax.numpy as jnp
+
+        # Mimic the wrap logic used inside _loss_fn.
+        observed = jnp.array([179.0])
+        ref = jnp.array([-179.0])
+        weights = jnp.array([1.0])
+        diff = observed - ref
+        diff = (diff + 180.0) % 360.0 - 180.0
+        loss = float(jnp.sum(weights * diff * diff))
+        # Un-wrapped diff would be 358° → loss ≈ 128164.  Wrapped: −2° → 4.
+        assert loss < 10.0
+        np.testing.assert_allclose(loss, 4.0, atol=1e-6)


### PR DESCRIPTION
## Phase 4b — geometry refs via implicit diff in JaxLoss

Closes the last ❌ in the differentiability matrix. Bond-length, bond-angle, and torsion-angle references now flow through the JIT-compiled `JaxLoss` with end-to-end analytical gradients — no finite differences anywhere in the hot path.

### Approach

Locked in by the spike memo in #248 (`docs/how-it-works/geometry-refs-spike.md`):

- **Inner geometry minimization** via `jaxopt.LBFGS(..., tol=1e-8, maxiter=200, implicit_diff=True)`. The optimizer's KKT-based `custom_vjp` handles differentiation through the fixed point of `∇_x E(x*; p) = 0`.
- **Differentiable observables** on the relaxed coordinates: `jnp.linalg.norm` for bonds; NaN-safe clipped `arccos` for angles; `atan2`-based 4-atom dihedral with ±180° wrap for torsions (matches `GeometryEvaluator`).
- Loss contribution: `sum_i w_i · (obs_i − ref_i)²` summed with the existing energy / frequency / Hessian / eigenmatrix terms.

### Spec changes

- `MoleculeSpec` gains 9 geometry fields (`bond_atoms`, `bond_refs`, `bond_weights`, and analogous `angle_*` / `torsion_*`) plus 5 properties (`has_bond_length`, `has_bond_angle`, `has_torsion`, `has_geometry`, `needs_geometry_relaxation`).
- `ObjectiveSpec.has_geometry_refs()` returns `True` when any molecule carries a geometry reference.
- `_build_molecule_spec`: resolves atom indices from `ReferenceValue.atom_indices` first, falling back to topology (`DetectedBond`/`DetectedAngle`/`DetectedTorsion`).
- `ObjectiveFunction.to_jax_spec`: passes `topology=mol` and emits `"geometry"` in `supported_categories`.
- `GeometryEvaluator.supports_analytical_gradient(JaxEngine())` → `True`.

### Tests

New `test/test_jax_loss.py::TestJaxLossGeometryParity` (4 tests):

| Test | What it proves |
| --- | --- |
| `test_bond_length_relaxes_to_eq` | Relaxed H₂ bond length = eq `r0` → loss ≈ 0 |
| `test_bond_length_grad_matches_fd` | **∇_p loss matches central-difference FD** (atol=1e-5, rtol=1e-3) — validates implicit diff |
| `test_bond_angle_relaxes_to_eq` | Relaxed H₂O angle = eq → loss ≈ 0 |
| `test_geometry_grad_jit_callable` | Mixed bond+angle refs: loss & grad finite, jit-compilable |

Also converted the obsolete `test_geometry_excluded` → `test_geometry_included` and updated the bot docstring in `jaxopt_opt.py`.

### Results

- ruff check + format: clean
- `python -m pytest test/ -x -q -m "not (openmm or tinker or jax_md or psi4)"` → **685 passed, 320 skipped, 199 deselected** (CPU only)

### Deferred (tracked separately)

- Inner-solver non-convergence detection + penalty fallback
- Tikhonov regularization when `cond(H) > 1e4`
- Multi-molecule vmap (Phase 2 / #244)
- TS curvature inversion inside JIT (Phase 5 / #245)

Refs #152, #243
