### PR TITLE
ci: enforce env/extras parity between pyproject.toml and conda envs

### DIFF
--- a/.github/envs/full.yml
+++ b/.github/envs/full.yml
@@ -10,6 +10,8 @@ dependencies:
   - tinker
   - jax
   - jaxlib
+  - jaxopt
+  - optax
   - pytest
   - ruff
   - pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       - run: python -m pip install -e ".[dev]"
       - run: python -m ruff check q2mm/ test/ scripts/
       - run: python -m ruff format --check q2mm test scripts examples
+      - run: python scripts/check_env_dep_parity.py
 
   test-core:
     runs-on: ubuntu-latest

--- a/scripts/check_env_dep_parity.py
+++ b/scripts/check_env_dep_parity.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Assert backend extras in pyproject.toml are present in matching CI env files.
+
+Background
+----------
+Backend test jobs install q2mm with ``pip install -e . --no-deps`` and rely on
+the conda env baked into the CI container image to provide native deps. If a
+new dep is added to a ``[project.optional-dependencies]`` extra in
+``pyproject.toml`` but the matching ``.github/envs/<backend>.yml`` is not
+updated, the dep silently goes missing from CI — exactly the bug that bit
+PR #250 (jaxopt was in the ``[jax]`` extra but not in ``full.yml``).
+
+This script enforces the contract: every package declared in a backend extra
+must appear in both the backend-specific env file and ``full.yml``.
+
+Run manually:
+    python scripts/check_env_dep_parity.py
+
+Wired into CI lint job. Exit code 0 = parity OK, non-zero = drift detected.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+ENVS_DIR = REPO_ROOT / ".github" / "envs"
+
+# Map a pyproject extra name to the env files it must be a subset of.
+# Extras not listed here (e.g. ``amber``, ``qcel``, ``optimize``, ``dev``,
+# ``docs``) are not enforced because they have no corresponding CI env file.
+EXTRA_TO_ENV_FILES: dict[str, tuple[str, ...]] = {
+    "openmm": ("openmm.yml", "full.yml"),
+    "jax": ("jax.yml", "full.yml"),
+    "jax-md": ("jax-md.yml", "full.yml"),
+}
+
+# Packages that are always present in every env file as baseline (python,
+# numpy, scipy, pytest, ruff). Listing them in extras shouldn't trigger drift.
+BASELINE_PACKAGES: frozenset[str] = frozenset({"python", "numpy", "scipy", "pytest", "ruff", "pip"})
+
+
+def _normalize(name: str) -> str:
+    """Normalize a package name (lowercase, strip extras, replace _ with -)."""
+    name = name.split("[", 1)[0].strip().lower()
+    return name.replace("_", "-")
+
+
+def _strip_marker_and_specifier(spec: str) -> str:
+    """Extract the bare package name from a PEP 508 dep string."""
+    spec = spec.split(";", 1)[0].strip()
+    spec = re.split(r"[<>=!~ ]", spec, maxsplit=1)[0]
+    return _normalize(spec)
+
+
+def load_extras() -> dict[str, set[str]]:
+    """Return ``{extra_name: {normalized_pkg, ...}}``."""
+    with PYPROJECT.open("rb") as f:
+        data = tomllib.load(f)
+    extras = data.get("project", {}).get("optional-dependencies", {})
+    return {name: {_strip_marker_and_specifier(d) for d in deps} for name, deps in extras.items()}
+
+
+def load_env_packages(env_file: Path) -> set[str]:
+    """Return the set of normalized package names in a conda env file."""
+    with env_file.open() as f:
+        data = yaml.safe_load(f)
+    pkgs: set[str] = set()
+    for entry in data.get("dependencies", []):
+        if isinstance(entry, str):
+            # ``python=3.12`` → python
+            pkgs.add(_normalize(entry.split("=", 1)[0].split("<", 1)[0]))
+        elif isinstance(entry, dict) and "pip" in entry:
+            for pip_entry in entry["pip"]:
+                pkgs.add(_strip_marker_and_specifier(pip_entry))
+    return pkgs
+
+
+def check_parity() -> list[str]:
+    """Return a list of human-readable error messages (empty = OK)."""
+    extras = load_extras()
+    errors: list[str] = []
+
+    for extra_name, env_filenames in EXTRA_TO_ENV_FILES.items():
+        if extra_name not in extras:
+            errors.append(f"pyproject.toml extra [{extra_name}] is missing — expected by check_env_dep_parity.py")
+            continue
+
+        required = extras[extra_name] - BASELINE_PACKAGES
+        for env_filename in env_filenames:
+            env_path = ENVS_DIR / env_filename
+            if not env_path.exists():
+                errors.append(f"env file not found: {env_path}")
+                continue
+
+            present = load_env_packages(env_path)
+            missing = required - present - BASELINE_PACKAGES
+            if missing:
+                errors.append(
+                    f"{env_filename} is missing packages from "
+                    f"pyproject.toml [{extra_name}] extra: "
+                    f"{sorted(missing)}\n"
+                    f"  → add them to {env_path.relative_to(REPO_ROOT)} "
+                    "so the CI container image picks them up on next build."
+                )
+
+    return errors
+
+
+def main() -> int:
+    """Entry point: print parity status and return shell exit code."""
+    errors = check_parity()
+    if errors:
+        print("env-dep parity check FAILED:\n", file=sys.stderr)
+        for err in errors:
+            print(f"  ✗ {err}\n", file=sys.stderr)
+        print(
+            "Why this matters: backend CI jobs use `pip install -e . --no-deps` "
+            "and rely on the container image to provide deps. A package in a "
+            "pyproject.toml extra but not in the matching env file is silently "
+            "absent in CI. See scripts/check_env_dep_parity.py for details.",
+            file=sys.stderr,
+        )
+        return 1
+    print("env-dep parity OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/test_env_dep_parity.py
+++ b/test/test_env_dep_parity.py
@@ -1,0 +1,73 @@
+"""Unit tests for ``scripts/check_env_dep_parity``.
+
+Verifies the parity check correctly detects drift between pyproject.toml
+backend extras and the matching ``.github/envs/*.yml`` files. Uses the
+real repo state (no temp files) for the green-path test, and monkeypatches
+in-memory data structures for the red-path test.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "check_env_dep_parity.py"
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("check_env_dep_parity", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parity_holds_on_current_repo() -> None:
+    """The current repo state must satisfy the env/extras parity contract."""
+    mod = _load_module()
+    errors = mod.check_parity()
+    assert errors == [], "env-dep parity check failed:\n" + "\n".join(errors)
+
+
+def test_strip_marker_and_specifier_handles_pep508() -> None:
+    mod = _load_module()
+    cases = {
+        "jaxopt": "jaxopt",
+        "jaxopt; sys_platform != 'win32'": "jaxopt",
+        "jax[cuda12]; sys_platform != 'win32'": "jax",
+        "openmm>=8.0": "openmm",
+        "jax_md": "jax-md",
+        "PyYAML": "pyyaml",
+    }
+    for raw, expected in cases.items():
+        assert mod._strip_marker_and_specifier(raw) == expected, raw
+
+
+def test_load_extras_contains_known_extras() -> None:
+    mod = _load_module()
+    extras = mod.load_extras()
+    assert {"openmm", "jax", "jax-md"} <= extras.keys()
+    assert "jaxopt" in extras["jax"]
+    assert "openmm" in extras["openmm"]
+
+
+def test_drift_is_detected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If we strip jaxopt out of full.yml in-memory, the check must fail."""
+    mod = _load_module()
+    real_loader = mod.load_env_packages
+
+    def lying_loader(env_file: Path) -> set[str]:
+        pkgs = real_loader(env_file)
+        if env_file.name == "full.yml":
+            pkgs.discard("jaxopt")
+        return pkgs
+
+    monkeypatch.setattr(mod, "load_env_packages", lying_loader)
+    errors = mod.check_parity()
+    assert errors, "expected parity check to flag missing jaxopt in full.yml"
+    assert any("jaxopt" in e and "full.yml" in e for e in errors), errors


### PR DESCRIPTION
## Summary

The PR #250 mistake (jaxopt was in `[jax]` extra but not in `full.yml`) was a symptom of a broader drift hazard: every backend CI job uses `pip install -e . --no-deps` and relies on the conda env baked into the container image to provide native deps. There's no guardrail that catches a new dep added to `pyproject.toml` extras but missing from the matching `.github/envs/*.yml`.

This PR adds that guardrail.

## Changes

### `scripts/check_env_dep_parity.py`
Asserts every package in each backend extra (`jax`, `jax-md`, `openmm`) appears in both the backend-specific env file and `full.yml`. Uses stdlib `tomllib` + PyYAML (already a hard dep). Exit 0 = OK, non-zero = drift.

Run manually:
```bash
python scripts/check_env_dep_parity.py
```

### `.github/workflows/ci.yml`
Added one line to the `lint` job: `python scripts/check_env_dep_parity.py`. Drift is now caught before any test job runs.

### `.github/envs/full.yml`
Added the missing `jaxopt` and `optax` — the actual instance of drift the check detects on master. (PR #250 added these to the same file on its own branch; this PR makes the same fix on master since the PRs are independent.)

### `test/test_env_dep_parity.py`
Four tests:
- Green-path: parity holds on the real repo.
- PEP 508 marker/specifier stripping (e.g. `jaxopt; sys_platform != 'win32'` → `jaxopt`).
- Extras loader contains the expected backend extras.
- Red-path: monkeypatch `full.yml`'s loader to drop `jaxopt`, assert the check flags it.

## Verification

```
$ python scripts/check_env_dep_parity.py            # before full.yml fix
env-dep parity check FAILED:
  ✗ full.yml is missing packages from pyproject.toml [jax] extra: ['jaxopt', 'optax']

$ python scripts/check_env_dep_parity.py            # after full.yml fix
env-dep parity OK

$ pytest test/test_env_dep_parity.py -v
4 passed
```

Full core test suite (`pytest test/ -m "not (openmm or tinker or jax or jax_md or psi4)"`): 610 passed, 261 skipped.

## Context

First of 7 planned tech-debt PRs from the audit at `research/where-else-have-we-made-bad-choices-like-this.md`. PR-B (delete dead CI defenses) and PR-E (fixture skipif → assert) depend on this landing first.
