### PR TITLE
refactor: drop dead try/except around mandatory yaml import

### DIFF
--- a/q2mm/io/reference.py
+++ b/q2mm/io/reference.py
@@ -32,11 +32,7 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-
-try:
-    import yaml
-except ImportError:  # pragma: no cover
-    yaml = None  # type: ignore[assignment]
+import yaml
 
 from q2mm.constants import DEFAULT_BOND_TOLERANCE
 from q2mm.models.molecule import Q2MMMolecule


### PR DESCRIPTION
## Summary

`q2mm/io/reference.py:36-39` had a `try/except ImportError` around `import yaml` that fell back to `yaml = None`. That fallback was dead code:

- PyYAML is a **hard** runtime dep in `pyproject.toml:38`.
- The fallback would have caused `AttributeError: 'NoneType' object has no attribute 'safe_load'` several frames deeper at every call site (lines 500, 501, 648), not a clean `ImportError` at import time.

Just delete it.

## Audit of qcelemental (the other half of the original PR-D scope)

The audit report flagged `_HAS_QCEL` in `q2mm/models/molecule.py` as a candidate. After inspection:

- Only two call sites touch qcel: `from_qcel:489` and `to_qcel:510`.
- Both already guard with `_HAS_QCEL` and raise `ImportError("qcelemental required: pip install qcelemental")` — clean and actionable.

qcelemental is genuinely optional and the existing pattern is correct. **No change.**

## Verification

```
ruff check + format clean
606 core tests pass (no behavior change)
```

## Context

Part of the tech-debt PR series from `research/where-else-have-we-made-bad-choices-like-this.md`. Independent of #251 (PR-A).
