### PR TITLE
refactor: narrow bare-except in backend registry discovery

### DIFF
--- a/q2mm/backends/registry.py
+++ b/q2mm/backends/registry.py
@@ -105,7 +105,17 @@ def register_qm(name: str) -> Callable[[type[QMEngine]], type[QMEngine]]:
 
 
 def _discover() -> None:
-    """Import all known engine modules to trigger ``@register_*`` decorators."""
+    """Import all known engine modules to trigger ``@register_*`` decorators.
+
+    ``ImportError`` (and its subclasses) is the expected failure mode here:
+    optional backends raise it when their native deps are missing, and we
+    silently skip those — the engine simply won't be registered.
+
+    Any *other* exception during import indicates a real bug (syntax error,
+    misconfigured registration, JAX/OpenMM raising ``RuntimeError`` from
+    init code) that we should surface. Log it at WARNING so the user
+    sees why a backend they expect to be available isn't there.
+    """
     global _discovered
     if _discovered:
         return
@@ -113,8 +123,15 @@ def _discover() -> None:
     for module_path in _ENGINE_MODULES:
         try:
             importlib.import_module(module_path)
-        except Exception as exc:  # pragma: no cover
-            logger.debug("Could not import engine module %s: %s", module_path, exc)
+        except ImportError as exc:
+            logger.debug("Optional backend %s unavailable: %s", module_path, exc)
+        except Exception as exc:
+            logger.warning(
+                "Unexpected error importing engine module %s: %s",
+                module_path,
+                exc,
+                exc_info=True,
+            )
 
 
 def _check_available(cls: type) -> bool:


### PR DESCRIPTION
## Summary

Two findings from the bad-choice audit. One was real, one wasn't.

### 1. `q2mm/backends/registry.py:_discover` swallowed everything (FIXED)

```python
# Before
except Exception as exc:  # pragma: no cover
    logger.debug("Could not import engine module %s: %s", module_path, exc)
```

This means a syntax error in an engine module, a misconfigured `@register_*` decorator, or a `RuntimeError` from JAX/OpenMM init would silently make the backend unavailable with **no user-visible diagnostic** (debug log is invisible by default).

Fixed:

```python
except ImportError as exc:
    logger.debug("Optional backend %s unavailable: %s", module_path, exc)
except Exception as exc:
    logger.warning(
        "Unexpected error importing engine module %s: %s",
        module_path, exc, exc_info=True,
    )
```

`ImportError` is the *expected* failure (optional backend, missing native dep) — silence is correct. Anything else is a real bug — surface it.

### 2. OpenMM `'00'` wildcard handling (NO CHANGE)

The audit flagged commit `ecf6e74` as needing explanation. On inspection, it's already self-documenting:

- `q2mm/io/openmm.py:14-15` has an inline comment explaining MM3/Tinker use `'00'` as a wildcard with no OpenMM equivalent.
- Each skip site (lines 154, 189, 218) logs `WARNING` so users see when terms are dropped.

**No change.** The audit was wrong on this one.

## Verification

```
ruff clean
606 core tests pass
```

## Context

Part of the tech-debt PR series from `research/where-else-have-we-made-bad-choices-like-this.md`. Independent of #251 / #252.
