### PR TITLE
refactor: optimizer registry with descriptive missing-dep errors

### DIFF
--- a/q2mm/optimizers/__init__.py
+++ b/q2mm/optimizers/__init__.py
@@ -2,78 +2,170 @@
 
 Provides a clean, composable optimization framework built on
 :mod:`scipy.optimize`, :mod:`optax`, and the Q2MM clean model layer.
+
+Optional optimizers
+-------------------
+
+Several optimizers depend on optional packages declared via
+``[project.optional-dependencies]`` in ``pyproject.toml``:
+
+================================ ==============================
+Optimizer                        Install hint
+================================ ==============================
+``ScipyOptimizer``               ``pip install 'q2mm[optimize]'``
+``BasinHoppingOptimizer``        ``pip install 'q2mm[optimize]'``
+``MultiStartOptimizer``          ``pip install 'q2mm[optimize]'``
+``OptimizationLoop`` (cycling)   ``pip install 'q2mm[optimize]'``
+``OptaxOptimizer``               ``pip install 'q2mm[jax]'``
+``JaxOptOptimizer``              ``pip install 'q2mm[jax]'``
+``JaxMultiStartOptimizer``       ``pip install 'q2mm[jax]'``
+================================ ==============================
+
+If a missing-dep optimizer is requested, you get a descriptive
+``ImportError`` naming the original failure and the install hint —
+not a silent ``AttributeError`` deep inside a call stack.
+
+Use :func:`available_optimizers` to introspect what's installed and
+:func:`get_optimizer` to look one up by name with explicit error handling.
 """
 
+from __future__ import annotations
+
+import importlib
+import logging
+from typing import Any
+
 from q2mm.optimizers.objective import ObjectiveFunction, ReferenceData
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "ObjectiveFunction",
     "ReferenceData",
+    "available_optimizers",
+    "get_optimizer",
 ]
 
-# Lazy import: scipy is an optional dependency
-try:
-    from q2mm.optimizers.scipy_opt import ScipyOptimizer, OptimizationResult  # noqa: F401
+# (public attribute name, defining module, install hint).
+# Order is the order they are tried (and the order returned by
+# ``available_optimizers``); install hints match ``pyproject.toml`` extras.
+_OPTIONAL_OPTIMIZERS: tuple[tuple[str, str, str], ...] = (
+    ("ScipyOptimizer", "q2mm.optimizers.scipy_opt", "pip install 'q2mm[optimize]'"),
+    ("OptimizationResult", "q2mm.optimizers.scipy_opt", "pip install 'q2mm[optimize]'"),
+    ("OptimizationLoop", "q2mm.optimizers.cycling", "pip install 'q2mm[optimize]'"),
+    ("LoopResult", "q2mm.optimizers.cycling", "pip install 'q2mm[optimize]'"),
+    ("SubspaceObjective", "q2mm.optimizers.cycling", "pip install 'q2mm[optimize]'"),
+    ("SensitivityResult", "q2mm.optimizers.cycling", "pip install 'q2mm[optimize]'"),
+    ("compute_sensitivity", "q2mm.optimizers.cycling", "pip install 'q2mm[optimize]'"),
+    ("OptaxOptimizer", "q2mm.optimizers.optax", "pip install 'q2mm[jax]'"),
+    ("JaxOptOptimizer", "q2mm.optimizers.jaxopt_opt", "pip install 'q2mm[jax]'"),
+    (
+        "JaxMultiStartOptimizer",
+        "q2mm.optimizers.jax_multistart",
+        "pip install 'q2mm[jax]'",
+    ),
+    (
+        "BasinHoppingOptimizer",
+        "q2mm.optimizers.basinhopping",
+        "pip install 'q2mm[optimize]'",
+    ),
+    (
+        "MultiStartOptimizer",
+        "q2mm.optimizers.multistart",
+        "pip install 'q2mm[optimize]'",
+    ),
+)
 
-    __all__ += ["ScipyOptimizer", "OptimizationResult"]
-except ImportError:
-    pass
+# attribute → (install_hint, original ImportError) for every optimizer
+# whose backing module failed to import.  Populated by ``_discover``.
+_FAILED: dict[str, tuple[str, ImportError]] = {}
 
-try:
-    from q2mm.optimizers.cycling import (  # noqa: F401
-        OptimizationLoop,
-        LoopResult,
-        SubspaceObjective,
-        SensitivityResult,
-        compute_sensitivity,
-    )
 
-    __all__ += [
-        "OptimizationLoop",
-        "LoopResult",
-        "SubspaceObjective",
-        "SensitivityResult",
-        "compute_sensitivity",
-    ]
-except ImportError:
-    pass
+def _discover() -> None:
+    """Eagerly import each optional optimizer; record ImportError details.
 
-# Lazy import: optax + jax are optional dependencies
-try:
-    from q2mm.optimizers.optax import OptaxOptimizer  # noqa: F401
+    ``ImportError`` is the expected failure mode when an optional dep is
+    missing — silence is correct, but we record *why* so we can surface it
+    later when the user actually tries to use the optimizer.
 
-    __all__ += ["OptaxOptimizer"]
-except ImportError:
-    pass
+    Any *other* exception is logged at WARNING with traceback, since it
+    indicates a real bug rather than a missing dependency.
+    """
+    for attr, module_path, hint in _OPTIONAL_OPTIMIZERS:
+        try:
+            module = importlib.import_module(module_path)
+        except ImportError as exc:
+            _FAILED[attr] = (hint, exc)
+            logger.debug("Optimizer %s unavailable: %s (%s)", attr, exc, hint)
+            continue
+        except Exception as exc:
+            logger.warning(
+                "Unexpected error importing optimizer module %s: %s",
+                module_path,
+                exc,
+                exc_info=True,
+            )
+            _FAILED[attr] = (hint, ImportError(str(exc)))
+            continue
+        if hasattr(module, attr):
+            globals()[attr] = getattr(module, attr)
+            __all__.append(attr)
+        else:
+            logger.warning(
+                "Optimizer module %s loaded but exports no %s",
+                module_path,
+                attr,
+            )
 
-# Lazy import: jaxopt + jax are optional dependencies
-try:
-    from q2mm.optimizers.jaxopt_opt import JaxOptOptimizer  # noqa: F401
 
-    __all__ += ["JaxOptOptimizer"]
-except ImportError:
-    pass
+_discover()
 
-# Vmap-fused multi-start optimizer (requires jaxopt + jax)
-try:
-    from q2mm.optimizers.jax_multistart import JaxMultiStartOptimizer  # noqa: F401
 
-    __all__ += ["JaxMultiStartOptimizer"]
-except ImportError:
-    pass
+def available_optimizers() -> list[str]:
+    """Return names of optimizer attributes that imported successfully.
 
-# Basin-hopping wraps scipy.optimize.basinhopping (always available with scipy)
-try:
-    from q2mm.optimizers.basinhopping import BasinHoppingOptimizer  # noqa: F401
+    The returned names are guaranteed to be importable directly from
+    :mod:`q2mm.optimizers`.
+    """
+    return [attr for attr, *_ in _OPTIONAL_OPTIMIZERS if attr in globals()]
 
-    __all__ += ["BasinHoppingOptimizer"]
-except ImportError:
-    pass
 
-# Multi-start meta-optimizer (wraps any optimizer)
-try:
-    from q2mm.optimizers.multistart import MultiStartOptimizer  # noqa: F401
+def get_optimizer(name: str) -> Any:
+    """Look up an optimizer by name with descriptive error handling.
 
-    __all__ += ["MultiStartOptimizer"]
-except ImportError:
-    pass
+    Args:
+        name: The public attribute name (e.g. ``"JaxOptOptimizer"``).
+
+    Returns:
+        The class or function exported by the corresponding submodule.
+
+    Raises:
+        ImportError: The optimizer's optional dependency is not installed.
+            The message includes the original error and the install hint.
+        KeyError: ``name`` is not a known optimizer.
+
+    """
+    if name in globals():
+        return globals()[name]
+    if name in _FAILED:
+        hint, exc = _FAILED[name]
+        raise ImportError(
+            f"Optimizer {name!r} requires an optional dependency that is not installed: {exc}. Install with: {hint}"
+        ) from exc
+    known = ", ".join(sorted(attr for attr, *_ in _OPTIONAL_OPTIMIZERS))
+    raise KeyError(f"Unknown optimizer {name!r}. Known optimizers: {known}")
+
+
+def __getattr__(name: str) -> Any:
+    """Provide descriptive errors for ``from q2mm.optimizers import X``.
+
+    Without this fallback, importing an unavailable optimizer raises a
+    generic ``ImportError: cannot import name 'X'`` with no clue why.
+    Now the user gets the install hint at the import site.
+    """
+    if name in _FAILED:
+        hint, exc = _FAILED[name]
+        raise ImportError(
+            f"{name!r} requires an optional dependency that is not installed: {exc}. Install with: {hint}"
+        ) from exc
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/test/test_optimizer_registry.py
+++ b/test/test_optimizer_registry.py
@@ -1,0 +1,101 @@
+"""Tests for the q2mm.optimizers package-level registry.
+
+Covers ``available_optimizers``, ``get_optimizer``, and the module
+``__getattr__`` descriptive-error fallback.  These ensure that a
+missing optional dependency surfaces with an actionable install hint
+instead of being silently swallowed (as it was prior to PR-C).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from q2mm import optimizers
+
+
+def test_available_optimizers_returns_list() -> None:
+    """Available optimizers must be a list of strings."""
+    available = optimizers.available_optimizers()
+    assert isinstance(available, list)
+    assert all(isinstance(name, str) for name in available)
+
+
+def test_available_optimizers_contains_objective_independent_ones() -> None:
+    """Optimizers that need no optional deps should always register.
+
+    ``ObjectiveFunction`` is unconditionally re-exported (not part of the
+    optional registry) so it is not in ``available_optimizers()``.  We test
+    instead that the consumer-visible API is non-empty when scipy is
+    installed (which it is in any environment that runs the test suite).
+    """
+    pytest.importorskip("scipy")
+    available = optimizers.available_optimizers()
+    assert "ScipyOptimizer" in available
+    assert "BasinHoppingOptimizer" in available
+    assert "MultiStartOptimizer" in available
+
+
+def test_get_optimizer_returns_class_when_available() -> None:
+    """``get_optimizer`` must return the actual class for installed deps."""
+    pytest.importorskip("scipy")
+    cls = optimizers.get_optimizer("ScipyOptimizer")
+    assert cls.__name__ == "ScipyOptimizer"
+
+
+def test_get_optimizer_unknown_raises_keyerror() -> None:
+    """Unknown name → ``KeyError`` with the list of known names."""
+    with pytest.raises(KeyError, match="Unknown optimizer 'NotARealOptimizer'"):
+        optimizers.get_optimizer("NotARealOptimizer")
+
+
+def test_module_getattr_unknown_raises_attributeerror() -> None:
+    """Unknown attribute → standard ``AttributeError`` (Python convention)."""
+    with pytest.raises(AttributeError, match="has no attribute"):
+        _ = optimizers.NonexistentAttribute  # type: ignore[attr-defined]
+
+
+def test_get_optimizer_missing_dep_raises_descriptive_importerror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing-dep simulation: ``get_optimizer`` raises ``ImportError`` with hint.
+
+    Inject a fake failure record into ``_FAILED`` and verify the user-visible
+    error names the install command, the original exception, and chains it
+    via ``__cause__``.
+    """
+    fake_exc = ImportError("No module named 'fake_dep'")
+    monkeypatch.setitem(
+        optimizers._FAILED,
+        "FakeOptimizer",
+        ("pip install 'q2mm[fake]'", fake_exc),
+    )
+    with pytest.raises(ImportError) as excinfo:
+        optimizers.get_optimizer("FakeOptimizer")
+    msg = str(excinfo.value)
+    assert "FakeOptimizer" in msg
+    assert "pip install 'q2mm[fake]'" in msg
+    assert "fake_dep" in msg
+    assert excinfo.value.__cause__ is fake_exc
+
+
+def test_module_getattr_missing_dep_raises_descriptive_importerror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``from q2mm.optimizers import X`` → descriptive ``ImportError``.
+
+    This is the most common consumer pattern and the highest-leverage fix:
+    before PR-C this would be ``ImportError: cannot import name 'X'`` with
+    no install hint.
+    """
+    fake_exc = ImportError("No module named 'fake_dep'")
+    monkeypatch.setitem(
+        optimizers._FAILED,
+        "FakeOptimizer",
+        ("pip install 'q2mm[fake]'", fake_exc),
+    )
+    with pytest.raises(ImportError) as excinfo:
+        _ = optimizers.FakeOptimizer  # type: ignore[attr-defined]
+    msg = str(excinfo.value)
+    assert "FakeOptimizer" in msg
+    assert "pip install 'q2mm[fake]'" in msg
+    assert excinfo.value.__cause__ is fake_exc


### PR DESCRIPTION
## Summary

Replaces 7 silent `try/except ImportError: pass` blocks in `q2mm/optimizers/__init__.py` with a single registry that records *why* each optional optimizer failed. This is the same anti-pattern that caused PR #250's `jaxopt` regression — silence instead of signal — applied repo-wide.

## Before

```python
try:
    from q2mm.optimizers.jaxopt_opt import JaxOptOptimizer
    __all__ += ["JaxOptOptimizer"]
except ImportError:
    pass
```

When the user later did `from q2mm.optimizers import JaxOptOptimizer` with `jaxopt` missing, they got:

```
ImportError: cannot import name 'JaxOptOptimizer' from 'q2mm.optimizers'
```

No mention of `jaxopt`. No install hint. Just confusion.

## After

```python
_OPTIONAL_OPTIMIZERS = (
    ("ScipyOptimizer", "q2mm.optimizers.scipy_opt", "pip install 'q2mm[optimize]'"),
    ("OptaxOptimizer", "q2mm.optimizers.optax", "pip install 'q2mm[jax]'"),
    ("JaxOptOptimizer", "q2mm.optimizers.jaxopt_opt", "pip install 'q2mm[jax]'"),
    # ... 9 more
)

def _discover() -> None:
    for attr, module_path, hint in _OPTIONAL_OPTIMIZERS:
        try:
            module = importlib.import_module(module_path)
        except ImportError as exc:
            _FAILED[attr] = (hint, exc)          # remember why
        except Exception as exc:
            logger.warning(..., exc_info=True)   # real bug → surface it
        else:
            globals()[attr] = getattr(module, attr)
            __all__.append(attr)
```

Now the same import gives:

```
ImportError: 'JaxOptOptimizer' requires an optional dependency that is not installed:
No module named 'jaxopt'. Install with: pip install 'q2mm[jax]'
```

Proper exception chaining preserves `__cause__` for traceback inspection.

## New helpers

- `optimizers.available_optimizers()` — list of importable names.
- `optimizers.get_optimizer(name)` — explicit lookup, raises descriptive `ImportError` for missing-dep or `KeyError` for unknown.
- `__getattr__` fallback — same descriptive error for the common `from q2mm.optimizers import X` pattern.

## Tests

7 new tests in `test/test_optimizer_registry.py`:
- `available_optimizers()` shape + content.
- `get_optimizer` returns class for installed deps.
- `get_optimizer` raises `KeyError` for unknown.
- `__getattr__` raises `AttributeError` for unknown (Python convention).
- Monkeypatched missing-dep raises descriptive `ImportError` with hint, chained via `__cause__` (covers both `get_optimizer` and `__getattr__` paths).

```
test/test_optimizer_registry.py — 7 passed
test/ (core suite) — 613 passed, 261 skipped
```

## Backward compatibility

Every internal consumer imports directly from the submodule
(`from q2mm.optimizers.scipy_opt import ScipyOptimizer`, etc.) — verified
with grep. The single test using the package-level API
(`test/test_optax.py:381`) keeps working.

## Context

Part of the tech-debt PR series from `research/where-else-have-we-made-bad-choices-like-this.md`. Independent of #251, #252, #253.
