### PR TITLE
chore: link xfail markers to tracking issues (#255–#258)

### DIFF
--- a/test/integration/test_backend_optimizer_matrix.py
+++ b/test/integration/test_backend_optimizer_matrix.py
@@ -208,14 +208,15 @@ class TestBenchmarkPipeline:
     @pytest.mark.xfail(
         strict=False,
         reason=(
-            "L-BFGS-B frequently fails to converge within 200 iterations on "
-            "frequency-fitting problems. The objective landscape is noisy — "
-            "each evaluation requires a Hessian eigenvalue solve, creating "
-            "discontinuities that frustrate gradient-based convergence criteria "
-            "(gtol). Even with the grad-simp cycling optimizer available, "
-            "this single-shot L-BFGS-B test uses a fixed iteration budget "
-            "that may not suffice on all platforms. Non-convergence is "
-            "expected; the structural checks (test_optimizer_executed, "
+            "Tracked in #258. L-BFGS-B frequently fails to converge within "
+            "200 iterations on frequency-fitting problems. The objective "
+            "landscape is noisy — each evaluation requires a Hessian "
+            "eigenvalue solve, creating discontinuities that frustrate "
+            "gradient-based convergence criteria (gtol). Even with the "
+            "grad-simp cycling optimizer available, this single-shot "
+            "L-BFGS-B test uses a fixed iteration budget that may not "
+            "suffice on all platforms. Non-convergence is expected; the "
+            "structural checks (test_optimizer_executed, "
             "test_rmsd_values_finite) verify the pipeline ran correctly."
         ),
     )

--- a/test/integration/test_optimization_validation.py
+++ b/test/integration/test_optimization_validation.py
@@ -618,12 +618,13 @@ class TestGoldenFixtureRegression:
     @pytest.mark.xfail(
         strict=False,
         reason=(
-            "Final optimized parameters vary across OpenMM/scipy versions "
-            "because L-BFGS-B follows different trajectories through the loss "
-            "landscape depending on numerical precision of the Hessian "
-            "eigenvalue solver. The optimizer may land in different local "
-            "minima. test_optimizer_improves_score verifies meaningful "
-            "progress; exact reproducibility requires pinned environments."
+            "Tracked in #258. Final optimized parameters vary across "
+            "OpenMM/scipy versions because L-BFGS-B follows different "
+            "trajectories through the loss landscape depending on numerical "
+            "precision of the Hessian eigenvalue solver. The optimizer may "
+            "land in different local minima. test_optimizer_improves_score "
+            "verifies meaningful progress; exact reproducibility requires "
+            "pinned environments."
         ),
     )
     def test_matches_golden_fixture(self) -> None:

--- a/test/integration/test_published_ff_validation.py
+++ b/test/integration/test_published_ff_validation.py
@@ -336,8 +336,9 @@ class TestPublishedFFEvaluation:
 
     @pytest.mark.xfail(
         reason=(
-            "Known Check 1 gap: the published MacroModel/MM3* force field does not "
-            "yet reproduce a better OpenMM fit than the Seminario baseline."
+            "Known Check 1 gap (#255): the published MacroModel/MM3* force "
+            "field does not yet reproduce a better OpenMM fit than the "
+            "Seminario baseline."
         ),
         strict=True,
     )
@@ -362,8 +363,8 @@ class TestPublishedFFEvaluation:
 
     @pytest.mark.xfail(
         reason=(
-            "Known Check 1 gap: published MacroModel/MM3* parameters are not yet "
-            "correlated with the OpenMM frequency evaluation."
+            "Known Check 1 gap (#256): published MacroModel/MM3* parameters "
+            "are not yet correlated with the OpenMM frequency evaluation."
         ),
         strict=True,
     )
@@ -374,8 +375,8 @@ class TestPublishedFFEvaluation:
 
     @pytest.mark.xfail(
         reason=(
-            "Known Check 1 gap: average R² for the published MacroModel/MM3* force "
-            "field is not yet acceptable under OpenMM."
+            "Known Check 1 gap (#257): average R² for the published "
+            "MacroModel/MM3* force field is not yet acceptable under OpenMM."
         ),
         strict=True,
     )


### PR DESCRIPTION
## Summary

Five existing xfail markers documented real, persistent gaps but had no GitHub issue to track convergence to passing — so the gaps lived only in the test code itself, invisible to project planning. Filed 4 tracking issues and added the references to the xfail reasons.

## Tracking issues filed

| Issue | Test | Marker |
|---|---|---|
| #255 | `test_published_ff_beats_seminario` | Check 1 — published FF should beat Seminario baseline |
| #256 | `test_per_molecule_r_squared_positive` | Check 1 — per-molecule R² > 0 |
| #257 | `test_overall_r_squared_above_threshold` | Check 1 — average R² above threshold |
| #258 | `test_optimization_converged` AND `test_matches_golden_fixture` | L-BFGS-B `strict=False` convergence — proposes replacing with tolerance bands or moving to `benchmarks/` |

(The two L-BFGS-B xfails share one issue because they're the same root cause: noisy frequency-fitting landscape, non-deterministic across versions.)

## Changes

Each xfail decorator's `reason` now begins with the tracking issue reference (e.g., `"Tracked in #258. ..."` or `"Known Check 1 gap (#255): ..."`). No behaviour change.

## Verification

```
ruff check + format clean
```

Tests are still xfail and still skip the same way they did before — only the reason strings changed.

## Context

Part of the tech-debt PR series from `research/where-else-have-we-made-bad-choices-like-this.md`. Independent of #251, #252, #253, #254.
