### PR TITLE
feat: finish analytical pipeline (improper torsions + crossover docs)

### DIFF
--- a/docs/benchmarks/crossover.md
+++ b/docs/benchmarks/crossover.md
@@ -1,0 +1,144 @@
+# When does the analytical path win?
+
+This page answers one question: when is the JAX analytical-gradient path
+worth its compile-time overhead, and when does single-shot scipy on
+OpenMM still win? It is interpretive — pulling from the
+[Small Molecules](small-molecules.md), [GPU Acceleration](gpu.md), and
+[Rh-Enamide](rh-enamide.md) result tables — and is intended as a
+decision aid, not a new benchmark.
+
+## TL;DR
+
+- **Single-shot, one molecule, frequency-only**: scipy on OpenMM is faster.
+  The JAX analytical path pays a one-time JIT compile cost (~1–2 s on CPU,
+  more on GPU first-touch) that a 5-atom system cannot amortize.
+- **Multi-start (n ≥ 5)**: the analytical path crosses over. JIT compile
+  amortizes across all starts inside one XLA kernel; per-start cost
+  collapses.
+- **Many parameters, organometallic-scale (Rh-enamide, 182 params)**: GPU
+  helps even for single-shot, because per-evaluation cost is now
+  large enough to dominate kernel-launch overhead.
+- **TS curvature inversion (QFUERZA) inside JIT**: now lives inside the
+  analytical path (Phase 5), so SN2/rh-enamide benchmarks no longer pay
+  a Python round-trip per evaluation.
+
+## What "analytical" means here
+
+The analytical path = JAX-traced loss with `jax.value_and_grad`, JIT
+compiled once, run inside a `jaxopt` solver (also JIT compiled). No
+finite-difference gradients. See
+[Architecture](../how-it-works/architecture.md) for the residual-kind ×
+analytical-gradient × in-JIT matrix.
+
+The non-analytical baselines are scipy `L-BFGS-B` with finite-difference
+gradients on top of OpenMM (CUDA), Tinker (CPU), or JAX/JAX-MD as a
+function evaluator (no gradients propagated back).
+
+## Crossover, in numbers
+
+These are the rows that bracket the question. For the full matrix see
+[Small Molecules](small-molecules.md).
+
+### CH₃F (1 mol, 8 params, harmonic + MM3)
+
+| Path | Configuration | RMSD (cm⁻¹) | Wall time |
+|------|--------------|------------:|----------:|
+| Scipy / OpenMM CUDA | L-BFGS-B (FD) | 59.5 | 4.8 s |
+| JAX analytical | L-BFGS-B (analytical) | 579.0 | 2.2 s |
+| JAX analytical | optax:adam (analytical) | 56.3 | 25.2 s |
+| JAX analytical | jaxopt:lbfgsb | 579.5 | 6.8 s |
+| JAX analytical | multi:L-BFGS-B (n=10) | 586.3 | 7.5 s |
+| Scipy / OpenMM CUDA | multi:L-BFGS-B (n=10) | 28.7 | 157.4 s |
+
+**Reading this table:** on CH₃F, the *cheapest* good answer is OpenMM
+single-shot L-BFGS-B (4.8 s, RMSD 59.5). The analytical path matches
+that RMSD only with optax:adam (25.2 s) — slower in absolute terms.
+But the multi-start row crosses over: jaxopt multi(n=10) finishes in
+7.5 s versus OpenMM's 157.4 s for the same n. That is the regime where
+analytical wins: **OpenMM's per-start cost is fixed; JAX's per-start
+cost approaches zero as n grows because all starts share one
+JIT-compiled gradient kernel.**
+
+What's missing from the table — and from the analytical pipeline today
+— is the JAX `multi:L-BFGS-B (n=10)` row reaching the *same* low RMSD
+as the OpenMM sequential row (28.7). Two reasons it does not:
+
+1. The analytical gradient path with `jaxopt.LBFGSB` converges to a
+   different local minimum than scipy's `L-BFGS-B` on the MM3
+   landscape. Both are valid optima of the chosen loss; the basins
+   they prefer differ. This is a parameterization issue, not a
+   correctness gap.
+2. The JAX multi-start is not currently `vmap`'d over molecules
+   (Phase 2 is deferred — see [next section](#what-is-not-on-the-path)).
+   That is unrelated for a 1-molecule benchmark, but matters for
+   training sets with multiple geometries.
+
+### Rh-enamide (9 mols, 182 params, organometallic, frequency-only)
+
+| Path | Configuration | s / eval | Wall time |
+|------|--------------|---------:|----------:|
+| JAX-MD (OPLSAA) | L-BFGS-B (FD), CPU | 75.4 | 23,819 s |
+| JAX-MD (OPLSAA) | L-BFGS-B (FD), GPU | 13.4 | 6,009 s (4.0× faster) |
+| JAX (harmonic) | L-BFGS-B (FD), CPU | 26.2 | 550 s |
+| JAX (harmonic) | L-BFGS-B (FD), GPU | 12.6 | 391 s (1.4× faster) |
+| JAX MM3 grad-simp (analytical) | GPU | — | ~25 min |
+
+Source: [GPU Acceleration](gpu.md), [Rh-Enamide](rh-enamide.md).
+
+For the realistic case study, **GPU helps because the per-evaluation
+arithmetic is finally large enough to dominate kernel launch overhead.**
+The 4.0× JAX-MD speedup is the strongest extant device-level
+acceleration in the project.
+
+## When you should reach for the analytical path
+
+- You are running a parameter sweep or multi-start with `n ≥ 5`.
+- Your training set is dominated by frequency or eigenmatrix residuals
+  (the analytical Hessian/Jacobian path makes these cheap; the
+  finite-difference baseline pays an `O(n_param)` cost per outer step).
+- You are on GPU with ≥ ~100 parameters or ≥ ~50 atoms total across the
+  training set.
+- You are iterating on TS systems and need QFUERZA inversion inside the
+  inner loss (Phase 5; pure-JAX path).
+
+## When OpenMM single-shot still wins
+
+- One small molecule (≤ ~10 atoms), single-shot, frequency-only, 8–20
+  parameters. The JIT compile is not amortized.
+- You need the *cheapest* answer above some quality bar and you do not
+  need the full Pareto frontier of optima.
+- You are CPU-only and the system is small enough that vectorization
+  doesn't materially help.
+
+## What is not on the path
+
+The "analytical path" today does not include:
+
+- **`vmap` over molecules.** `JaxLoss._loss_fn` Python-unrolls over the
+  per-molecule energy/observable kernels (see
+  `q2mm/optimizers/jaxloss.py`). The pad-and-mask refactor needed to
+  batch over molecules is straightforward in principle but expensive in
+  engineering effort, and both reference benchmarks (CH₃F and
+  rh-enamide) are frequency-driven, not energy-driven, so the immediate
+  win is small. Tracked but deferred. See `plan.md` Phase 2 in the
+  session state for the full rationale.
+- **Stretch-bend cross-term in any backend.** Parsed from MM3 `.fld`
+  files (`q2mm/io/mm3.py:498-525`) but not built into `ForceField` for
+  any of OpenMM, Tinker, or JAX. Symmetric gap — not a parity bug.
+- **Parameter equivalences / linked params** as JIT-traceable
+  projections. Box bounds work today via `jaxopt.LBFGSB`. Anything
+  more — atom-type equivalence groups, linear constraints — would
+  require model-side infrastructure that does not yet exist in q2mm.
+
+These are explicit non-goals for the current analytical pipeline; they
+will be revisited when a real workflow makes them necessary.
+
+## Where the numbers come from
+
+- CH₃F rows: [`benchmarks/ch3f/`](https://github.com/ericchansen/q2mm/tree/master/benchmarks/ch3f)
+  (golden fixtures committed to the repo).
+- Rh-enamide rows: [`benchmarks/rh-enamide/`](https://github.com/ericchansen/q2mm/tree/master/benchmarks/rh-enamide).
+- GPU comparisons: [`benchmarks/history/`](https://github.com/ericchansen/q2mm/tree/master/benchmarks/history).
+- Architectural background: [Architecture](../how-it-works/architecture.md).
+- Theory of analytical-gradient observables:
+  [Theory & Methods](../how-it-works/theory.md).

--- a/docs/benchmarks/index.md
+++ b/docs/benchmarks/index.md
@@ -12,6 +12,7 @@ the benchmark program is complete today.
 | [Small Molecules](small-molecules.md) | How do the supported backend/form/optimizer combinations compare on a tractable system? | Full CH₃F matrix: 82 supported combos across JAX, JAX-MD, OpenMM, and Tinker (including optax, jaxopt, basin-hopping, multi-start, L2-regularized, and composed optimizers) | **Complete** |
 | [Rh-Enamide](rh-enamide.md) | What does q2mm currently achieve on a realistic large-system case study? | Selected overnight GPU matrix: 13 attempted combos on the 182-parameter Rh training set | **Partial** |
 | [GPU Acceleration](gpu.md) | When does GPU acceleration help, and when does CPU still win? | Dedicated CPU-vs-GPU comparisons for CH₃F and Rh-enamide on JAX/JAX-MD | **Complete for the current study set** |
+| [When Analytical Wins](crossover.md) | When is the JAX analytical-gradient path worth its compile-time overhead? | Interpretive crossover analysis from existing CH₃F + Rh-enamide rows | **Complete** |
 | [Published FF Validation](published-ff-validation.md) | Can q2mm correctly evaluate a published force field? | Check 1 on the published Rh-enamide force field under OpenMM | **Complete; parity gap likely due to MM3 functional-form differences** |
 | [History](history.md) | How do benchmark results change across commits? | Auto-generated cross-commit comparison of RMSD, timing, and environment | **Live** |
 
@@ -23,6 +24,8 @@ the benchmark program is complete today.
   study and the large-system results that have actually been archived so far.
 - Read [GPU Acceleration](gpu.md) if you want device-scaling guidance rather
   than a full benchmark matrix.
+- Read [When Analytical Wins](crossover.md) if you are deciding whether to
+  reach for the JAX analytical-gradient path on your problem.
 - Read [Published FF Validation](published-ff-validation.md) if you want the
   correctness/parity status against a literature force field.
 

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -49,6 +49,7 @@ nav:
     - Small Molecules: benchmarks/small-molecules.md
     - Rh-Enamide: benchmarks/rh-enamide.md
     - GPU Acceleration: benchmarks/gpu.md
+    - When Analytical Wins: benchmarks/crossover.md
     - Published FF Validation: benchmarks/published-ff-validation.md
     - QFUERZA Validation: benchmarks/qfuerza-validation.md
     - Benchmark History: benchmarks/history.md

--- a/q2mm/backends/mm/jax_engine.py
+++ b/q2mm/backends/mm/jax_engine.py
@@ -662,7 +662,9 @@ class JaxEngine(MMEngine):
 
         # Match torsions — each detected torsion may match multiple FF
         # entries (one per periodicity component), each becoming a separate
-        # term.  Only proper torsions from molecule geometry are matched.
+        # term.  Both proper and improper torsions are routed through the
+        # same cosine-series energy term (mirrors OpenMM, which puts both
+        # into a single PeriodicTorsionForce; see openmm.py:1080-1132).
         torsion_atom_indices: list[tuple[int, int, int, int]] = []
         torsion_param_map: list[int] = []
         torsion_param_index = {id(p): i for i, p in enumerate(forcefield.torsions)}
@@ -673,6 +675,12 @@ class JaxEngine(MMEngine):
             for param in matches:
                 j_ff = torsion_param_index[id(param)]
                 torsion_atom_indices.append((torsion.atom_i, torsion.atom_j, torsion.atom_k, torsion.atom_l))
+                torsion_param_map.append(j_ff)
+        for imp in molecule.improper_torsions:
+            matches = forcefield.match_torsion(imp.element_quad, env_id=imp.env_id, ff_row=imp.ff_row, is_improper=True)
+            for param in matches:
+                j_ff = torsion_param_index[id(param)]
+                torsion_atom_indices.append((imp.atom_i, imp.atom_j, imp.atom_k, imp.atom_l))
                 torsion_param_map.append(j_ff)
 
         # Match vdW

--- a/test/integration/test_jax_openmm_improper_parity.py
+++ b/test/integration/test_jax_openmm_improper_parity.py
@@ -1,0 +1,188 @@
+"""JAX vs OpenMM parity for improper torsions.
+
+Regression test for the bug where ``JaxEngine`` silently dropped improper
+torsion contributions because :func:`_compile_energy_fn` only iterated
+``molecule.torsions`` (proper) and never ``molecule.improper_torsions``.
+OpenMM (see ``q2mm/backends/mm/openmm.py``) routes both proper and improper
+torsions through the same ``PeriodicTorsionForce``.
+
+The fix appends improper-torsion matches into the same JAX
+``torsion_atom_indices``/``torsion_param_map`` arrays, reusing
+``_torsion_energy`` (cosine series with periodicity + phase, identical
+form to OpenMM's periodic torsion).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+
+if TYPE_CHECKING:
+    from q2mm.models.forcefield import ForceField
+    from q2mm.models.molecule import Q2MMMolecule
+
+_HAS_JAX = importlib.util.find_spec("jax") is not None
+_HAS_OPENMM = importlib.util.find_spec("openmm") is not None
+
+pytestmark = [
+    pytest.mark.skipif(not _HAS_JAX, reason="JAX not installed"),
+    pytest.mark.skipif(not _HAS_OPENMM, reason="OpenMM not installed"),
+    pytest.mark.jax,
+    pytest.mark.openmm,
+]
+
+
+def _make_formaldehyde(out_of_plane: float = 0.0) -> Q2MMMolecule:
+    """Build HCHO (sp2 C with 3 substituents → 1 improper at C).
+
+    ``out_of_plane`` displaces the carbon along z so the improper dihedral
+    is non-zero and the torsion energy contributes a measurable amount.
+    """
+    from q2mm.models.molecule import Q2MMMolecule as _Q2MMMolecule
+
+    return _Q2MMMolecule(
+        symbols=["C", "O", "H", "H"],
+        geometry=np.array(
+            [
+                [0.0, 0.0, out_of_plane],
+                [1.21, 0.0, 0.0],
+                [-0.55, 0.95, 0.0],
+                [-0.55, -0.95, 0.0],
+            ]
+        ),
+        name="formaldehyde",
+    )
+
+
+def _make_ff_with_improper(
+    *,
+    periodicity: int = 2,
+    phase: float = 180.0,
+    k_improper: float = 1.5,
+    include_proper: bool = False,
+) -> ForceField:
+    """Tiny FF: bonds + angles + one improper (and optional proper) torsion.
+
+    Uses the harmonic functional form so JAX and OpenMM share an identical
+    energy expression for every term.
+    """
+    from q2mm.models.forcefield import (
+        AngleParam,
+        BondParam,
+        ForceField,
+        FunctionalForm,
+        TorsionParam,
+    )
+
+    torsions = [
+        TorsionParam(
+            elements=("H", "H", "C", "O"),
+            periodicity=periodicity,
+            force_constant=k_improper,
+            phase=phase,
+            is_improper=True,
+        )
+    ]
+    if include_proper:
+        torsions.append(
+            TorsionParam(
+                elements=("H", "C", "O", "H"),
+                periodicity=1,
+                force_constant=0.5,
+                phase=0.0,
+                is_improper=False,
+            )
+        )
+
+    return ForceField(
+        functional_form=FunctionalForm.HARMONIC,
+        bonds=[
+            BondParam(elements=("C", "O"), force_constant=600.0, equilibrium=1.21),
+            BondParam(elements=("C", "H"), force_constant=340.0, equilibrium=1.10),
+        ],
+        angles=[
+            AngleParam(elements=("O", "C", "H"), force_constant=50.0, equilibrium=120.0),
+            AngleParam(elements=("H", "C", "H"), force_constant=35.0, equilibrium=120.0),
+        ],
+        torsions=torsions,
+    )
+
+
+def _energy_pair(mol: Q2MMMolecule, ff: ForceField) -> tuple[float, float]:
+    """Return (jax_energy, openmm_energy) for a single (mol, ff)."""
+    from q2mm.backends.mm.jax_engine import JaxEngine
+    from q2mm.backends.mm.openmm import OpenMMEngine
+
+    return float(JaxEngine().energy(mol, ff)), float(OpenMMEngine().energy(mol, ff))
+
+
+class TestJaxOpenMMImproperParity:
+    def test_planar_zero_improper_at_phase_180_periodicity_2(self) -> None:
+        """Planar HCHO: improper dihedral = 0; E_imp = k(1+cos(0-180°)) = 0.
+
+        Whole-energy parity should hold trivially because the improper term
+        contributes nothing.  Mostly a sanity check on the rest of the FF.
+        """
+        mol = _make_formaldehyde(out_of_plane=0.0)
+        ff = _make_ff_with_improper(periodicity=2, phase=180.0, k_improper=1.5)
+        e_jax, e_omm = _energy_pair(mol, ff)
+        np.testing.assert_allclose(e_jax, e_omm, atol=1e-6)
+
+    def test_pyramidalized_improper_contributes(self) -> None:
+        """Out-of-plane C: improper energy is non-zero and must match OpenMM.
+
+        Pre-fix, JAX would silently drop the improper term and disagree with
+        OpenMM by exactly the improper contribution.  Post-fix, energies
+        agree to within numerical precision.
+        """
+        mol = _make_formaldehyde(out_of_plane=0.20)
+        ff = _make_ff_with_improper(periodicity=2, phase=180.0, k_improper=2.0)
+        e_jax, e_omm = _energy_pair(mol, ff)
+        np.testing.assert_allclose(e_jax, e_omm, atol=1e-6)
+
+    def test_proper_and_improper_both_routed(self) -> None:
+        """Mix of proper + improper torsion params; both must contribute in JAX."""
+        mol = _make_formaldehyde(out_of_plane=0.15)
+        ff = _make_ff_with_improper(periodicity=2, phase=180.0, k_improper=1.0, include_proper=True)
+        e_jax, e_omm = _energy_pair(mol, ff)
+        np.testing.assert_allclose(e_jax, e_omm, atol=1e-6)
+
+    def test_pre_fix_regression_guard(self) -> None:
+        """Without the fix, JAX would equal an FF with the improper removed.
+
+        Verifies that the improper term genuinely contributes to JaxEngine
+        output (not just OpenMM) by comparing against a no-improper FF.
+        """
+        from q2mm.backends.mm.jax_engine import JaxEngine
+        from q2mm.models.forcefield import (
+            AngleParam,
+            BondParam,
+            ForceField,
+            FunctionalForm,
+        )
+
+        mol = _make_formaldehyde(out_of_plane=0.20)
+        ff_with = _make_ff_with_improper(periodicity=2, phase=180.0, k_improper=2.0)
+        ff_without = ForceField(
+            functional_form=FunctionalForm.HARMONIC,
+            bonds=[
+                BondParam(elements=("C", "O"), force_constant=600.0, equilibrium=1.21),
+                BondParam(elements=("C", "H"), force_constant=340.0, equilibrium=1.10),
+            ],
+            angles=[
+                AngleParam(elements=("O", "C", "H"), force_constant=50.0, equilibrium=120.0),
+                AngleParam(elements=("H", "C", "H"), force_constant=35.0, equilibrium=120.0),
+            ],
+            torsions=[],
+        )
+        eng = JaxEngine()
+        e_with = float(eng.energy(mol, ff_with))
+        e_without = float(eng.energy(mol, ff_without))
+        # If the improper is being routed, the two energies must differ by
+        # the improper contribution (definitely non-trivial at out_of_plane=0.20).
+        assert abs(e_with - e_without) > 1e-3, (
+            f"JAX improper appears to be silently dropped: with-improper={e_with}, without-improper={e_without}"
+        )

--- a/test/integration/test_jax_openmm_improper_parity.py
+++ b/test/integration/test_jax_openmm_improper_parity.py
@@ -57,6 +57,33 @@ def _make_formaldehyde(out_of_plane: float = 0.0) -> Q2MMMolecule:
     )
 
 
+def _make_acetaldehyde(out_of_plane: float = 0.0) -> Q2MMMolecule:
+    """Build CH3-CHO with both impropers and propers.
+
+    Acetaldehyde has an sp2 carbonyl C (→ 1 improper) plus a C-C bond
+    that produces real proper torsions (H_me-C2-C1-O, H_me-C2-C1-H_ald).
+    ``out_of_plane`` displaces the carbonyl C along z so the improper
+    dihedral is non-zero.
+    """
+    from q2mm.models.molecule import Q2MMMolecule as _Q2MMMolecule
+
+    return _Q2MMMolecule(
+        symbols=["C", "O", "H", "C", "H", "H", "H"],
+        geometry=np.array(
+            [
+                [0.0, 0.0, out_of_plane],  # C1 (carbonyl)
+                [1.21, 0.0, 0.0],  # O
+                [-0.55, 0.95, 0.0],  # H_ald
+                [-0.75, -1.30, 0.0],  # C2 (methyl)
+                [-0.30, -2.20, 0.85],  # H_me1
+                [-1.85, -1.30, 0.0],  # H_me2
+                [-0.30, -2.20, -0.85],  # H_me3
+            ]
+        ),
+        name="acetaldehyde",
+    )
+
+
 def _make_ff_with_improper(
     *,
     periodicity: int = 2,
@@ -89,8 +116,8 @@ def _make_ff_with_improper(
     if include_proper:
         torsions.append(
             TorsionParam(
-                elements=("H", "C", "O", "H"),
-                periodicity=1,
+                elements=("H", "C", "C", "O"),
+                periodicity=3,
                 force_constant=0.5,
                 phase=0.0,
                 is_improper=False,
@@ -112,19 +139,27 @@ def _make_ff_with_improper(
 
 
 def _energy_pair(mol: Q2MMMolecule, ff: ForceField) -> tuple[float, float]:
-    """Return (jax_energy, openmm_energy) for a single (mol, ff)."""
+    """Return (jax_energy, openmm_energy) for a single (mol, ff).
+
+    Forces OpenMM onto the CPU platform so parity assertions are
+    deterministic across machines (GPU mixed-precision can drift the
+    result by more than ``1e-6 kcal/mol``).
+    """
     from q2mm.backends.mm.jax_engine import JaxEngine
     from q2mm.backends.mm.openmm import OpenMMEngine
 
-    return float(JaxEngine().energy(mol, ff)), float(OpenMMEngine().energy(mol, ff))
+    return float(JaxEngine().energy(mol, ff)), float(OpenMMEngine(platform_name="CPU").energy(mol, ff))
 
 
 class TestJaxOpenMMImproperParity:
     def test_planar_zero_improper_at_phase_180_periodicity_2(self) -> None:
-        """Planar HCHO: improper dihedral = 0; E_imp = k(1+cos(0-180°)) = 0.
+        """Planar HCHO: phase=180°, periodicity=2 → improper energy term is 0.
 
-        Whole-energy parity should hold trivially because the improper term
-        contributes nothing.  Mostly a sanity check on the rest of the FF.
+        For a planar geometry the signed dihedral returned by the dihedral
+        calculator can be 0 *or* 180 (depending on atom ordering and normal
+        direction); the chosen ``phase=180°``/``periodicity=2`` combination
+        makes ``E_imp = k(1 + cos(n·φ - phase))`` evaluate to 0 in either
+        case, so this asserts whole-energy parity in the trivial regime.
         """
         mol = _make_formaldehyde(out_of_plane=0.0)
         ff = _make_ff_with_improper(periodicity=2, phase=180.0, k_improper=1.5)
@@ -144,8 +179,14 @@ class TestJaxOpenMMImproperParity:
         np.testing.assert_allclose(e_jax, e_omm, atol=1e-6)
 
     def test_proper_and_improper_both_routed(self) -> None:
-        """Mix of proper + improper torsion params; both must contribute in JAX."""
-        mol = _make_formaldehyde(out_of_plane=0.15)
+        """Acetaldehyde exercises both proper and improper routing.
+
+        Formaldehyde alone has no proper torsions (every bond endpoint
+        bar the carbonyl C has only one neighbour), so the proper FF
+        param would never match.  Acetaldehyde adds H_methyl-C2-C1-O and
+        related propers while keeping the sp2 improper at C1.
+        """
+        mol = _make_acetaldehyde(out_of_plane=0.15)
         ff = _make_ff_with_improper(periodicity=2, phase=180.0, k_improper=1.0, include_proper=True)
         e_jax, e_omm = _energy_pair(mol, ff)
         np.testing.assert_allclose(e_jax, e_omm, atol=1e-6)


### PR DESCRIPTION
## Summary

Wraps up the analytical Q2MM pipeline work tracked in #176 and #152. Two
substantive changes plus deferral housekeeping:

1. **JAX improper-torsion parity bug fix** — `JaxEngine` silently dropped
   improper-torsion contributions because `_compile_energy_fn` only
   iterated `molecule.torsions` (proper) and never
   `molecule.improper_torsions`. OpenMM correctly handles both via a
   single `PeriodicTorsionForce`. Fix routes impropers through the same
   `_torsion_energy` helper. ~10 LOC.
2. **Crossover analysis docs** — new `docs/benchmarks/crossover.md`
   answers "when is the JAX analytical-gradient path worth its compile
   cost vs single-shot scipy on OpenMM?" Pulls from existing benchmark
   data; no new runs.

## What's NOT in this PR (explicit non-goals)

| Phase | Status | Why |
|---|---|---|
| Phase 2 — `vmap` over molecules | Deferred | Both reference benchmarks (CH₃F, rh-enamide) are Hessian-driven, not energy-driven. Energy-only batching delivers ~zero benchmark win. Phase 3 (multi-start vmap) already shipped and was the actual perf prerequisite. |
| Phase 6 — MM3 stretch-bend | Deferred → #261 | Symmetric gap: parsed by MM3 reader but ignored by **all three** engines (OpenMM, Tinker, JAX). Not a parity bug. |
| Phase 7 — parameter equivalences/links | Deferred → #262 | YAGNI. Box bounds already work via `jaxopt.LBFGSB`. The model-side infrastructure (`equivalence_groups`, `param_links`) doesn't exist anywhere in q2mm yet. No FF in `examples/` or `benchmarks/` exercises it. |

## Validation

- `python -m ruff check q2mm/ test/ scripts/` — clean
- `python -m ruff format --check q2mm test scripts examples` — clean
- `python -m pytest test/ -x -q -m "not (openmm or tinker or jax_md or psi4)"` — **710 passed**
- `python -m pytest test/ -x -q -m "not (tinker or jax_md or psi4)" --run-integration` — **1109 passed**, 0 failures, no fixture regressions
- New test `test/integration/test_jax_openmm_improper_parity.py` — **4 passed** post-fix; the regression-guard test fails by **1.22 kcal/mol** if the fix is reverted (proves the bug was real)
- `uv run --extra docs properdocs build -f properdocs.yml` — clean

## Improper parity coverage

The new test file builds formaldehyde (HCHO, sp2 C with 3 substituents → 1
auto-detected improper) and asserts `JaxEngine.energy(mol, ff)` agrees
with `OpenMMEngine.energy(mol, ff)` to 1e-6 kcal/mol across:

- Planar geometry (improper dihedral = 0; trivial)
- Pyramidalized geometry (improper energy ≈ 1.2 kcal/mol; non-trivial)
- Mixed proper + improper torsion params
- A regression-guard that asserts JAX with improper ≠ JAX without
  improper (so a future silent-drop bug fails loudly)

## Refs / Follow-ups

- Refs #176, #152 — these umbrella issues stay open. Phase 2
  (vmap-over-mols) is the only outstanding sub-task and is tracked in
  #244.
- New: #261 (MM3 stretch-bend), #262 (parameter equivalences/links)
