### PR TITLE
fix: replace L-BFGS-B convergence xfails with tolerance bands (#258)

### DIFF
--- a/test/integration/test_backend_optimizer_matrix.py
+++ b/test/integration/test_backend_optimizer_matrix.py
@@ -205,24 +205,19 @@ class TestBenchmarkPipeline:
         assert result.seminario is not None
         assert result.optimized is not None
 
-    @pytest.mark.xfail(
-        strict=False,
-        reason=(
-            "Tracked in #258. L-BFGS-B frequently fails to converge within "
-            "200 iterations on frequency-fitting problems. The objective "
-            "landscape is noisy — each evaluation requires a Hessian "
-            "eigenvalue solve, creating discontinuities that frustrate "
-            "gradient-based convergence criteria (gtol). Even with the "
-            "grad-simp cycling optimizer available, this single-shot "
-            "L-BFGS-B test uses a fixed iteration budget that may not "
-            "suffice on all platforms. Non-convergence is expected; the "
-            "structural checks (test_optimizer_executed, "
-            "test_rmsd_values_finite) verify the pipeline ran correctly."
-        ),
-    )
-    def test_optimization_converged(self, result: BenchmarkResult) -> None:
-        """Strict convergence check — optimizer hit its gradient tolerance."""
-        assert result.optimized["converged"]
+    def test_optimization_made_progress(self, result: BenchmarkResult) -> None:
+        """Optimizer meaningfully improved the objective score.
+
+        L-BFGS-B on noisy Hessian landscapes may not hit strict ``gtol``
+        convergence within 200 iterations, but it should still make
+        substantial progress.  We require >50% score reduction from the
+        Seminario starting point.  Resolves #258.
+        """
+        initial = result.optimized["initial_score"]
+        final = result.optimized["final_score"]
+        assert final < initial * 0.5, (
+            f"Optimizer did not improve enough: initial={initial:.4f}, final={final:.4f} (expected >50% reduction)"
+        )
 
     def test_optimizer_executed(self, result: BenchmarkResult) -> None:
         """Verify the optimizer actually ran (structural, not outcome)."""

--- a/test/integration/test_optimization_validation.py
+++ b/test/integration/test_optimization_validation.py
@@ -615,20 +615,14 @@ class TestGoldenFixtureRegression:
         not (Path(__file__).resolve().parent.parent.parent / "test" / "fixtures" / "optimization_golden.json").exists(),
         reason="Golden fixture not yet generated (run scripts/generate_optimization_fixtures.py)",
     )
-    @pytest.mark.xfail(
-        strict=False,
-        reason=(
-            "Tracked in #258. Final optimized parameters vary across "
-            "OpenMM/scipy versions because L-BFGS-B follows different "
-            "trajectories through the loss landscape depending on numerical "
-            "precision of the Hessian eigenvalue solver. The optimizer may "
-            "land in different local minima. test_optimizer_improves_score "
-            "verifies meaningful progress; exact reproducibility requires "
-            "pinned environments."
-        ),
-    )
     def test_matches_golden_fixture(self) -> None:
-        """Exact match of final_score and final_params against golden fixture."""
+        """Final score and parameters fall within tolerance of golden fixture.
+
+        L-BFGS-B on noisy Hessian landscapes lands in different local
+        minima across scipy/OpenMM versions.  A 5% score tolerance and
+        10% parameter tolerance catch real regressions while allowing
+        legitimate platform variance.  Resolves #258.
+        """
         golden = json.loads(self.GOLDEN_PATH.read_text())
 
         true_ff, guess_ff, mols, ref, engine = _make_water_problem()
@@ -636,11 +630,14 @@ class TestGoldenFixtureRegression:
         opt = ScipyOptimizer(method="L-BFGS-B", maxiter=200, verbose=False)
         result = opt.optimize(obj)
 
-        assert result.final_score == pytest.approx(golden["final_score"], rel=1e-4), (
+        assert len(result.final_params) == len(golden["final_params"]), (
+            f"Param vector length changed: {len(result.final_params)} vs {len(golden['final_params'])}"
+        )
+        assert result.final_score == pytest.approx(golden["final_score"], rel=0.05), (
             f"Final score drift: {result.final_score} vs {golden['final_score']}"
         )
         for i, (got, want) in enumerate(zip(result.final_params, golden["final_params"])):
-            assert got == pytest.approx(want, rel=1e-3), f"Param {i} drift: {got} vs {want}"
+            assert got == pytest.approx(want, rel=0.10), f"Param {i} drift: {got} vs {want}"
 
     def test_optimizer_improves_score(self) -> None:
         """Verify optimizer substantially improves the score.


### PR DESCRIPTION
## Summary

Replace two `xfail(strict=False)` decorators with tolerance-band assertions that catch real regressions while accommodating legitimate L-BFGS-B platform variance.

Closes #258.

### Changes

**`test_optimization_converged` → `test_optimization_made_progress`**: Assert ≥50% score reduction from the Seminario starting point. L-BFGS-B on noisy Hessian landscapes may not hit strict `gtol` convergence, but it should always make substantial progress.

**`test_matches_golden_fixture`**: Widen tolerance from `rel=1e-4`/`rel=1e-3` to `rel=0.05`/`rel=0.10` (5% score, 10% params). Catches regressions while allowing L-BFGS-B to land in different local minima across scipy/OpenMM versions.

### Testing

- 604 core tests pass ✅
- Lint + format clean ✅
- No remaining `xfail(strict=False)` in the test suite
