### PR TITLE
chore: close #152 and #243 — convergence fallback + docs

### DIFF
--- a/docs/benchmarks/crossover.md
+++ b/docs/benchmarks/crossover.md
@@ -119,6 +119,13 @@ The "analytical path" today does not include:
   Hessian batching within each group. 25% loss-eval speedup on
   Rh-enamide (632 → 472 ms). Molecules with different topologies still
   use a small outer loop (no padding, no eigendecomposition corruption).
+- **Geometry references (bond_length, bond_angle, torsion_angle) via
+  implicit differentiation.** ~~Deferred~~ — **Done** (PR #249).
+  `jaxopt.LBFGS(implicit_diff=True)` relaxes coordinates at the current
+  parameters; the outer `jax.grad` gets exact `∂x*/∂p` via the implicit
+  function theorem.  Non-convergence fallback adds a penalty when the
+  inner solver fails to converge (PR #269).  Tested on CH₃F with mixed
+  frequency + geometry objectives.
 - **Stretch-bend cross-term in OpenMM/Tinker.** The JAX engine now
   computes stretch-bend energy; OpenMM and Tinker do not yet.
   `StretchBendParam` is in `ForceField`, and the MM3 `.fld` loader

--- a/q2mm/optimizers/jaxloss.py
+++ b/q2mm/optimizers/jaxloss.py
@@ -52,14 +52,22 @@ if TYPE_CHECKING:
 # implicit-function theorem applies.
 _GEOM_INNER_TOL = 1e-8
 _GEOM_INNER_MAXITER = 200
+# Penalty added per geometry reference when the inner solver does not
+# converge.  Large enough to dominate the loss and steer the outer
+# optimizer away from pathological parameter regions, but finite so
+# gradients remain usable.
+_GEOM_NONCONV_PENALTY = 1e4
 
 
 def _relax_coords(energy_fn, params, coords0):  # noqa: ANN001, ANN202
-    """Return the relaxed geometry ``x*(params)`` for a single molecule.
+    """Return the relaxed geometry and convergence flag for a molecule.
 
     Uses ``jaxopt.LBFGS(fun=energy_of_coords, implicit_diff=True)`` so the
     outer ``jax.grad`` sees the exact parameter-gradient of ``x*`` via the
     implicit function theorem, avoiding autodiff-through-iteration.
+
+    When the inner solver does not converge (gradient norm > tol after
+    maxiter), the caller should add a penalty to the loss.
 
     Args:
         energy_fn: ``(params, coords) -> scalar`` energy function
@@ -68,7 +76,8 @@ def _relax_coords(energy_fn, params, coords0):  # noqa: ANN001, ANN202
         coords0: Initial coordinates, shape ``(N, 3)``.
 
     Returns:
-        Relaxed coordinates, shape ``(N, 3)``.
+        tuple: ``(relaxed_coords, converged)`` where ``converged`` is a
+        scalar boolean (JAX array).
 
     """
     import jaxopt
@@ -83,7 +92,8 @@ def _relax_coords(energy_fn, params, coords0):  # noqa: ANN001, ANN202
         implicit_diff=True,
     )
     sol = solver.run(coords0, params)
-    return sol.params
+    converged = sol.state.error <= _GEOM_INNER_TOL
+    return sol.params, converged
 
 
 def _bond_lengths(coords, atoms):  # noqa: ANN001, ANN202
@@ -420,7 +430,19 @@ class JaxLoss:
                 # Geometry contributions — relax coords at current params,
                 # then compute bond/angle/torsion observables.
                 if mol_spec.has_geometry:
-                    relaxed = _relax_coords(energy_fn, params, coords)
+                    relaxed, geom_converged = _relax_coords(energy_fn, params, coords)
+                    # Penalty when inner solver fails to converge — the
+                    # implicit-diff gradient is unreliable in this case.
+                    n_geom_refs = (
+                        len(entry.get("bond_refs", []))
+                        + len(entry.get("angle_refs", []))
+                        + len(entry.get("torsion_refs", []))
+                    )
+                    total = total + jnp.where(
+                        geom_converged,
+                        0.0,
+                        _GEOM_NONCONV_PENALTY * n_geom_refs,
+                    )
 
                     if mol_spec.has_bond_length:
                         calc = _bond_lengths(relaxed, entry["bond_atoms"])

--- a/test/test_jax_loss.py
+++ b/test/test_jax_loss.py
@@ -695,6 +695,34 @@ class TestJaxLossGeometryParity:
         assert loss < 10.0
         np.testing.assert_allclose(loss, 4.0, atol=1e-6)
 
+    def test_nonconvergence_penalty_is_finite(self) -> None:
+        """When inner solver cannot converge, loss includes a finite penalty."""
+        import jax.numpy as jnp
+
+        from q2mm.optimizers.jaxloss import JaxLoss, _GEOM_NONCONV_PENALTY
+        from q2mm.optimizers.objective import ObjectiveFunction, ReferenceData
+
+        # Use a very stretched geometry far from equilibrium — the inner
+        # solver with limited iterations may not fully converge.
+        mol = make_diatomic(distance=3.0, bond_tolerance=5.0)
+        ff = _h2_ff(bond_k=359.7, bond_r0=0.74)
+        engine = JaxEngine()
+
+        ref = ReferenceData()
+        ref.add_bond_length(value=0.74, molecule_idx=0, atom_indices=(0, 1), weight=1.0)
+
+        obj = ObjectiveFunction(forcefield=ff, engine=engine, molecules=[mol], reference=ref)
+        spec = obj.to_jax_spec()
+        jax_loss = JaxLoss(spec, engine, [mol], ff)
+
+        params = jnp.array(ff.get_param_vector(), dtype=jnp.float64)
+        loss, _grad = jax_loss.loss_and_grad(params)
+        loss = float(loss)
+        # Loss must be finite regardless of convergence
+        assert np.isfinite(loss), f"Loss is not finite: {loss}"
+        # The _GEOM_NONCONV_PENALTY constant must be accessible and positive
+        assert _GEOM_NONCONV_PENALTY > 0
+
 
 class TestJaxLossTsCurvatureInversion:
     """TS-curvature inversion (QFUERZA) inside the JIT loss path."""


### PR DESCRIPTION
## Summary

Address the two remaining acceptance criteria gaps for #243 and document the completed state of #152.

Closes #243. Closes #152.

### Changes

1. **Non-convergence fallback** (`jaxloss.py`): `_relax_coords` now returns `(coords, converged)`. When `sol.state.error > tol` after maxiter, a JIT-traceable penalty of 1e4 per geometry reference is added to the loss. This satisfies #243 criterion 6.

2. **Geometry-refs documented** (`crossover.md`): Added geometry references (implicit diff via jaxopt.LBFGS) to the "What the analytical path includes" section. This satisfies #243 criterion 8 (benchmark documentation).

### Evidence for closing #243 (all 8 criteria)

| # | Criterion | Evidence |
|---|-----------|----------|
| 1 | Spike memo | Issue #243 comment (full spike report) |
| 2 | `_jax_relax_geometry` | `_relax_coords()` at `jaxloss.py:60` |
| 3 | MoleculeSpec geometry-ref tuples | `bond_refs`, `angle_refs`, `torsion_refs` at `spec.py:91-99` |
| 4 | JaxLoss geometry category | `jaxloss.py:432` (`has_geometry`) |
| 5 | `to_jax_spec` guard dropped | `has_geometry_refs` at `spec.py:204` |
| 6 | Non-convergence fallback | **This PR** — `sol.state.error` check + penalty |
| 7 | Integration test | `TestJaxLossGeometryParity` (6 tests) at `test_jax_loss.py:541` |
| 8 | Benchmark documentation | **This PR** — crossover.md updated |

### Evidence for closing #152 (all 4 phases)

| Phase | Delivered by |
|-------|-------------|
| 1: Energy-only | `energy_and_param_grad` in JaxEngine (pre-existing) |
| 2: Geometry refs | PR #249 (implicit diff via jaxopt.LBFGS) |
| 3: Frequency/eigenmatrix | PRs #242, #250 (Hessian eigendecomp + TS curvature) |
| 4: Unified pipeline | PR #263 (mixed ref types in one JaxLoss) |

### Testing

- 604 core tests pass ✅
- 6 geometry-parity tests pass ✅
