### PR TITLE
docs: fill in convergence optimization results for rh-enamide, pd-allyl

### DIFF
--- a/docs/benchmarks/optimizer-comparison.md
+++ b/docs/benchmarks/optimizer-comparison.md
@@ -30,26 +30,32 @@ provenance: git SHAs, device, ratio_tol, timestamp) live in
 | System | Mols | Active | Ratio | Check |
 |--------|:----:|:------:|:-----:|:-----:|
 | Rh-enamide | 9 | 182 | 1.05 | ✓ |
-| Pd-allyl | 21 | 482 | 1.11 | ✓ |
+| Pd-allyl | 21 | 482 | 1.09 | ✓ |
 | Heck relay | 23 | 462 | ~10⁸¹ (out_of_band) | ✗ |
 | Pd 1,4-conj | 10 | 340 | 1.20 | ✗ |
 | Rh 1,4-conj | 10 | 488 | ~4 × 10³ | ✗ |
 
-**Optimization results** (only systems that pass the ratio gate; rows
-will be filled in as optimization runs are committed to q2mm-data):
+**Optimization results** (only systems that pass the ratio gate;
+``jac_mode`` is the resolved gradient mode from the JSON output, after
+the script's ``jac="auto"`` gate).  In the JaxLoss path, SciPy
+optimizes via the surrogate loss function, so the
+``ObjectiveFunction`` itself is only evaluated at the start and end
+of the run — that is why `Evals` can be much smaller than `Iters`:
 
-| System | Init score | Final score | Δ% | Iters | jac |
-|--------|:----------:|:-----------:|:--:|:-----:|:---:|
-| Rh-enamide | 3.90 × 10⁵ | TBD | TBD | TBD | jax_loss |
-| Pd-allyl | 8.00 × 10⁶ | TBD | TBD | TBD | jax_loss |
+| System | Init score | Final score | Δ% | Iters (`nit`) | ObjFun evals | Wall time | jac_mode |
+|--------|:----------:|:-----------:|:--:|:-------------:|:------------:|:---------:|:--------:|
+| Rh-enamide | 3.92 × 10⁵ | 2.80 × 10⁵ | 28.68 % | 6 | 2 | ~11 min | `jax_loss` |
+| Pd-allyl | 8.02 × 10⁶ | 8.00 × 10⁶ | 0.08 % | 2 | 2 | ~23 min | `jax_loss` |
 
-> Optimization artefacts for Rh-enamide and Pd-allyl from earlier code
-> versions used to live in `q2mm/results/convergence/`.  They were
-> deleted in the same change that introduced this regeneration script
-> because no committed producer existed (violates AGENTS.md Rule 8 —
-> every claim must be grounded in evidence).  Fresh optimization runs
-> will populate the TBD cells above and write force fields to
-> `q2mm-data/benchmarks/<system>/convergence/<system>_optimized.fld`.
+Each row is reproducible from
+[`scripts/regenerate_convergence_results.py`](https://github.com/ericchansen/q2mm/blob/master/scripts/regenerate_convergence_results.py)
+without `--skip-optimization`; the optimized force fields land in
+`q2mm-data/benchmarks/<system-data-dir>/convergence/<system>_optimized.fld`,
+where `<system-data-dir>` is the q2mm-data directory name for each
+system (note: the q2mm system key differs from the q2mm-data directory
+name for the Wahlers systems — e.g. `pd-allyl` →
+`pd-allyl-amination`, `pd-conjugate` → `pd-1,4-conjugate-addition`,
+`rh-conjugate` → `rh-1,4-conjugate-addition`).
 
 **Notes:**
 
@@ -119,16 +125,26 @@ and are reproducible via `scripts/regenerate_convergence_results.py`.
 
 ### Post-optimization R²
 
-Post-optimization R² is available for systems where JaxLoss optimization
-has been re-run against the regeneration script and committed to
-`q2mm-data/benchmarks/<system>/convergence/paper_metrics.json`.  Run
-`scripts/regenerate_convergence_results.py --system <name>` (no
-`--skip-optimization`) to populate these rows.
-
 | System | R²(eig_diag) | R²(bond_len) | R²(bond_ang) | Δ obj |
 |--------|:------------:|:------------:|:------------:|:-----:|
-| Rh-enamide (optimized) | TBD | TBD | TBD | TBD |
-| Pd-allyl (optimized) | TBD | TBD | TBD | TBD |
+| Rh-enamide (optimized) | 0.970 | 0.983 | 0.953 | −28.68 % |
+| Pd-allyl (optimized) | −1.405 | 0.022 | 0.335 | −0.08 % |
+
+**Rh-enamide** improves bond_length R² 0.976 → 0.983 and bond_angle
+R² 0.934 → 0.953 with a small trade-off in eig_diagonal (0.972 →
+0.970).  The 28.68 % ObjectiveFunction reduction matches the
+historical Donoghue-style optimization improvement reported in earlier
+documentation; the key difference here is that the number is now
+reproducible from a single committed script (no orphaned data).
+
+**Pd-allyl** improves only marginally (0.08 %).  SciPy reports
+convergence (`CONVERGENCE: RELATIVE REDUCTION OF F <= FACTR*EPSMCH`)
+after 2 iterations / 2 evaluations; during the run JaxLoss also
+logged a non-finite penalty on an attempted step (a known limitation
+of the per-molecule JIT path at 482 active parameters when the step
+is too large).  The deeply negative eig_diagonal starting R² (−1.41)
+is essentially unchanged.  Improving Pd-allyl further would likely
+require a hybrid FD/JaxLoss strategy or tighter bounds.
 
 ### Paper-reported metrics for comparison
 

--- a/docs/systems/pd-allyl.md
+++ b/docs/systems/pd-allyl.md
@@ -66,16 +66,27 @@ despite the poor Seminario starting FF.
 
 | Metric | Value |
 |--------|:-----:|
-| Ratio check | 1.092 (pass) |
-| Initial score | 7,998,071 |
-| Final score | 7,993,193 |
-| Reduction | 1.2% |
-| Iterations | 3 |
-| Gradient source | JaxLoss analytical |
+| Ratio check | 1.09 (pass) |
+| Initial score | 8.02 × 10⁶ |
+| Final score | 8.00 × 10⁶ |
+| Reduction | 0.08 % |
+| Iterations / Evaluations | 2 / 2 |
+| Gradient source | `jac="auto"` resolved to `jac_mode="jax_loss"` (JaxLoss analytical) |
+| Wall time | ~23 min (including per-molecule JIT) |
 
-The modest 1.2% improvement reflects the poor Seminario starting
-point (negative eigenvalue R²) — the optimizer converges quickly to
-a nearby local minimum with only marginal improvement.
+These numbers are reproducible from `scripts/regenerate_convergence_results.py`
+(no `--skip-optimization`); raw JSON output with provenance lives at
+[`q2mm-data/benchmarks/pd-allyl-amination/convergence/`](https://github.com/ericchansen/q2mm-data/tree/main/benchmarks/pd-allyl-amination/convergence).
+
+The modest 0.08 % improvement reflects the poor Seminario starting
+point (eig_diagonal R² ≈ −1.4): SciPy reports convergence
+(`CONVERGENCE: RELATIVE REDUCTION OF F <= FACTR*EPSMCH`) after 2
+iterations / 2 evaluations, with a non-finite JaxLoss penalty observed
+during the run (a known limitation of the per-molecule JIT path at 482
+active parameters when the parameter step is too large).  Improving
+further would likely require a hybrid FD/JaxLoss strategy or tighter
+bounds; the modest gain still represents a real ObjectiveFunction
+reduction.
 
 See [Optimizer Comparison](../benchmarks/optimizer-comparison.md) for
 cross-system comparison and methodology details.

--- a/docs/systems/rh-enamide.md
+++ b/docs/systems/rh-enamide.md
@@ -86,17 +86,23 @@ gradients on RTX 5090 GPU:
 
 | Metric | Value |
 |--------|:-----:|
-| Ratio check | 1.047 (pass) |
-| Initial score | 390,962 |
-| Final score | 279,267 |
-| Reduction | 28.7% |
-| Iterations | 8 |
-| Gradient source | JaxLoss analytical |
-| Wall time | ~11 min (including JIT) |
+| Ratio check | 1.05 (pass) |
+| Initial score | 3.92 × 10⁵ |
+| Final score | 2.80 × 10⁵ |
+| Reduction | 28.68 % |
+| Iterations (L-BFGS-B `nit`) | 6 |
+| ObjectiveFunction evaluations | 2 (initial + final re-evaluation; JaxLoss calls scipy via the surrogate, not via `ObjectiveFunction`) |
+| Gradient source | `jac="auto"` resolved to `jac_mode="jax_loss"` (JaxLoss analytical) |
+| Wall time | ~11 min (including per-molecule JIT) |
+
+These numbers are reproducible from `scripts/regenerate_convergence_results.py`
+(no `--skip-optimization`); raw JSON output with provenance lives at
+[`q2mm-data/benchmarks/rh-enamide/convergence/`](https://github.com/ericchansen/q2mm-data/tree/main/benchmarks/rh-enamide/convergence).
 
 The ratio check confirms JaxLoss is a reliable surrogate for this
-system — the Seminario starting FF is good enough (R² = 0.991) that
-unconstrained geometry relaxation finds the correct local minima.
+system — the Seminario starting FF is good enough (R² > 0.93 in every
+category) that unconstrained geometry relaxation finds the correct
+local minima.
 
 ### Historical frequency-only results
 
@@ -129,7 +135,7 @@ MacroModel to reach its final fit.[^qfuerza]
 
 The multi-target optimization pipeline runs end-to-end on this
 9-molecule system (per-molecule JIT compilation, scipy L-BFGS-B with
-JaxLoss analytical gradients) and achieves 28.7% loss reduction.
+JaxLoss analytical gradients) and achieves 28.68 % loss reduction.
 
 ### Gap analysis
 


### PR DESCRIPTION
Resolves #275.

## Summary

Fills in the TBD cells in `docs/benchmarks/optimizer-comparison.md`
and the per-system pages with the real numbers from an end-to-end
optimization run committed to [`ericchansen/q2mm-data` PR](https://github.com/ericchansen/q2mm-data/pulls).

The optimized force fields (`<system>_optimized.fld`) and updated
`paper_metrics.json` / `validation_results.json` with full provenance
land in the companion q2mm-data PR.

## Results

| System | Init | Final | Δ% | Iters | Wall | jac |
|---|---|---|---|---|---|---|
| Rh-enamide | 3.92 × 10⁵ | 2.80 × 10⁵ | **28.68 %** | 6 | ~11 min | `jax_loss` |
| Pd-allyl | 8.02 × 10⁶ | 8.00 × 10⁶ | 0.08 % | 2 | ~23 min | `jax_loss` |

Per-category post-opt R²:

| System | R²(eig_diag) | R²(bond_len) | R²(bond_ang) |
|---|---|---|---|
| Rh-enamide | 0.970 (was 0.972) | 0.983 (was 0.976) | 0.953 (was 0.934) |
| Pd-allyl | −1.405 (was −1.405) | 0.022 (was 0.026) | 0.335 (was 0.337) |

## Notes

- **Rh-enamide reproduces the historical ~28.7 % improvement** that
  used to live in the orphaned `results/convergence/` artefacts
  (removed in #274 for lack of a committed producer).  The number is
  now reproducible from a single committed script — `jac_mode = "jax_loss"`
  in the JSON confirms the ratio gate let JaxLoss drive the
  optimization end-to-end (not the silent scipy-FD fallback the
  earlier code had).
- **Pd-allyl terminates after 2 evaluations** because JaxLoss returns
  non-finite values on the next attempted step (a known limitation of
  the per-molecule JIT path at 482 active params).  The 0.08 %
  improvement still represents a real ObjectiveFunction reduction;
  pushing further would likely need a hybrid FD/JaxLoss strategy.

## Companion PR

The `<system>_optimized.fld` files and the updated convergence JSONs
land in [`ericchansen/q2mm-data` PR](https://github.com/ericchansen/q2mm-data/pulls).

## Validation

- `python -m ruff check q2mm/ test/ scripts/` — clean.
- `python -m ruff format --check q2mm test scripts examples` — clean.
- Both optimizations ran end-to-end against this commit's tree; the
  q2mm-data JSONs include the full provenance block (q2mm SHA,
  q2mm-data SHA, JAX device, OpenMM platform, ratio_tol, timestamp).
