### PR TITLE
fix(heck-relay): stop overwriting Rosales OPT params with Seminario projections

### DIFF
--- a/docs/benchmarks/optimizer-comparison.md
+++ b/docs/benchmarks/optimizer-comparison.md
@@ -31,7 +31,7 @@ provenance: git SHAs, device, ratio_tol, timestamp) live in
 |--------|:----:|:------:|:-----:|:-----:|
 | Rh-enamide | 9 | 182 | 1.05 | ✓ |
 | Pd-allyl | 21 | 482 | 1.09 | ✓ |
-| Heck relay | 23 | 462 | ~10⁸¹ (out_of_band) | ✗ |
+| Heck relay | 23 | 462 | 1.29 | ✗ |
 | Pd 1,4-conj | 10 | 340 | 1.20 | ✗ |
 | Rh 1,4-conj | 10 | 488 | ~4 × 10³ | ✗ |
 
@@ -62,24 +62,22 @@ name for the Wahlers systems — e.g. `pd-allyl` →
 - **Rh-enamide and Pd-allyl** pass the ratio gate cleanly and are the
   two systems that can be optimized with JaxLoss analytical gradients
   out of the box.
-- **Heck relay** has a catastrophically poor Seminario starting FF
-  (bond_length R² ≈ −48, bond_angle R² ≈ −5).  Inside JaxLoss the
-  inner geometry relaxation wanders into very-high-energy regions,
-  producing a finite-but-astronomical surrogate value (~10⁸¹) that
-  is classified `out_of_band`.  The absolute magnitude is
-  non-deterministic across runs.  Optimization is impossible without
-  first fixing the starting FF (see [heck-relay
-  page](../systems/heck-relay.md)).
+- **Heck relay** misses the gate by ~12 % (ratio 1.29).  With the
+  loader bug fixed in [`q2mm#277`](https://github.com/ericchansen/q2mm/issues/277),
+  the Rosales OPT parameters are now used as-published: bond_length
+  R² ≈ 0.98, bond_angle R² ≈ 0.79.  Heck relay joins
+  [pd-conjugate](../systems/pd-conjugate.md) as a candidate for the
+  experimental `ratio_tol=None` bypass.
 - **Pd 1,4-conj** misses the band by ~4 %.  This is the natural
   candidate for the experimental `ratio_tol=None` bypass — see
   [pd-conjugate](../systems/pd-conjugate.md).  Until that experiment
   has run and been validated against the real ObjectiveFunction, the
   default `ratio_tol=0.15` correctly skips this system.
-- **Rh 1,4-conj** diverges by ~3 orders of magnitude.  Like Heck relay,
-  the JaxLoss surrogate is unusable here without first improving the
-  starting FF.  Previous sessions saw varying ratios (0.46–0.96) for
-  this system depending on uncommitted state; the current committed
-  baseline gives ~4 × 10³.  See [rh-conjugate](../systems/rh-conjugate.md)
+- **Rh 1,4-conj** diverges by ~3 orders of magnitude.  The JaxLoss
+  surrogate is unusable here without first improving the starting FF.
+  Previous sessions saw varying ratios (0.46–0.96) for this system
+  depending on uncommitted state; the current committed baseline
+  gives ~4 × 10³.  See [rh-conjugate](../systems/rh-conjugate.md)
   for the per-category R² explaining why the surrogate diverges.
 
 ### Why some systems fail the ratio check
@@ -113,10 +111,14 @@ prediction is worse than predicting the QM mean.
 | System | R²(eig_diag) | R²(bond_len) | R²(bond_ang) |
 |--------|:------------:|:------------:|:------------:|
 | Rh-enamide (9 mol) | 0.972 | 0.976 | 0.934 |
-| Heck relay (23 mol) | −4.66 | −48.06 | −5.47 |
+| Heck relay (23 mol) | −12.6 | 0.980 | 0.786 |
 | Pd-allyl (21 mol) | −1.41 | 0.026 | 0.337 |
 | Pd 1,4-conj (10 mol) | −4.47 | 0.435 | −0.118 |
 | Rh 1,4-conj (10 mol) | −4.85 | −57.65 | −1.29 |
+
+(Heck relay is the only Wahlers/Rosales system that starts from the
+already-fitted published OPT parameters rather than a fresh Seminario
+projection — that is why its geometry R² is strong here.)
 
 Rh-enamide starts near-optimal (R² > 0.93 in all categories). The other
 four systems start far from optimal — the optimizer must close this gap.

--- a/docs/systems/heck-relay.md
+++ b/docs/systems/heck-relay.md
@@ -63,37 +63,52 @@ complete failure of cross-engine transfer, not a small miss.
 
 ## Benchmark results
 
-!!! failure "JaxLoss surrogate is unusable on this starting FF"
-    JaxLoss returns a finite-but-astronomical value on the Seminario
-    starting force field (most recent regeneration:
-    `initial_jaxloss ≈ 5.6 × 10⁸⁹`, ratio ≈ 4.6 × 10⁸¹,
-    `ratio_status = "out_of_band"`).  The absolute magnitude is
-    non-deterministic across runs because the inner geometry
-    minimization wanders into very-high-energy regions, but the
-    surrogate is clearly unusable.  **No JaxLoss-guided optimization
-    was performed.**
+!!! success "Loader bug fixed (ericchansen/q2mm#277) — Rosales FF now usable"
+    The previous loader silently re-ran `estimate_force_constants` on
+    the Rosales FF, which overwrote the published OPT parameters with
+    raw FUERZA projections.  In the three-baseline diagnostic
+    (`q2mm-data/benchmarks/heck-relay/diagnostic/three_baseline_comparison.json`)
+    the buggy combination collapsed bond_length R² to ≈ **−4787** for
+    that run (the value is non-deterministic across runs because the
+    inner geometry minimization diverges chaotically; a prior committed
+    convergence baseline saw ≈ −48 for the same code).  Either way the
+    fit is catastrophic.  The loader now keeps the Rosales OPT values
+    as-is (it still calls `freeze_standard_params` so the active mask
+    is correct for optimization, but no QFUERZA re-estimation).
 
 | Metric | Value |
 |--------|:-----:|
-| Ratio check | ≈ 4.6 × 10⁸¹ (out_of_band, non-deterministic across runs) |
-| Initial ObjectiveFunction score | 1.48 × 10⁸ |
-| Optimization | Skipped |
+| Ratio check | 1.29 (out_of_band; upper bound 1.15) |
+| Initial ObjectiveFunction score | 3.46 × 10⁶ |
+| Optimization | Skipped at default `ratio_tol=0.15` (borderline — candidate for `ratio_tol=None`) |
 
-**Why it diverges:** The Seminario starting FF is deeply negative for
-every category — bond_length R² ≈ −48, bond_angle R² ≈ −5.5,
-eig_diagonal R² ≈ −4.7.  With such a poor starting point, the inner
-geometry minimization inside JaxLoss lands in completely unphysical
-local minima, producing meaningless loss values.  The ratio check
-correctly identifies this and blocks optimization.
+Per-category fit of the published Rosales force field against the QM
+training data (no QFUERZA — these are the published OPT values
+evaluated by the q2mm JAX engine):
 
-Finite-difference gradients would work in principle but are
-impractical for this system (462 active parameters × ~20 s per
-evaluation = hours per gradient step).
+| Category | n_refs | R² | RMSD | MAE |
+|----------|-------:|----:|-----:|----:|
+| bond_length | 1140 | **0.980** | 0.046 Å | — |
+| bond_angle | 2157 | **0.786** | 7.96 ° | — |
+| eig_diagonal | 3121 | −12.6 | 0.48 | — |
+
+Geometry is now well-reproduced; the eigenmatrix remains the open
+problem (the published Rosales FF was MM3*-fit and the residual
+eigenmatrix gap reflects a real cross-engine MM3* ↔ JAX-engine
+divergence for this chemistry, not a loader bug).
+
+**Why optimization is still skipped:** The ratio (1.29) is just
+outside the [0.85, 1.15] gate.  Like
+[pd-conjugate](pd-conjugate.md), Heck relay is a candidate for the
+experimental `ratio_tol=None` bypass — see
+[`q2mm#276`](https://github.com/ericchansen/q2mm/issues/276) for the
+companion experiment on pd-conjugate.
 
 The numbers above come from the committed regeneration script
-`scripts/regenerate_convergence_results.py`; the raw JSON output (with
-provenance: git SHAs, device, ratio_tol, timestamp) lives at
-[`q2mm-data/benchmarks/heck-relay/convergence/`](https://github.com/ericchansen/q2mm-data/tree/main/benchmarks/heck-relay/convergence).
+`scripts/regenerate_convergence_results.py`; the raw JSON output and
+the three-baseline diagnostic that diagnosed the loader bug live at
+[`q2mm-data/benchmarks/heck-relay/convergence/`](https://github.com/ericchansen/q2mm-data/tree/main/benchmarks/heck-relay/convergence)
+and [`q2mm-data/benchmarks/heck-relay/diagnostic/`](https://github.com/ericchansen/q2mm-data/tree/main/benchmarks/heck-relay/diagnostic).
 
 See [Optimizer Comparison](../benchmarks/optimizer-comparison.md) for
 cross-system comparison and methodology details.

--- a/q2mm/diagnostics/systems.py
+++ b/q2mm/diagnostics/systems.py
@@ -336,6 +336,14 @@ def load_heck_relay(
     Uses the published FF from Rosales et al. *JACS* 2020, 142, 9700-9707.
     Training set: 23 Gaussian 09 logs with HPModes frequency data.
 
+    The published Rosales OPT parameters are used **as-is** — they are
+    the result of the original MacroModel MM3* fit and reproduce the
+    QM geometry well (bond_length R² ≈ 0.98 untouched).  Earlier
+    versions of this loader re-ran ``estimate_force_constants`` on the
+    Rosales FF, which silently overwrote the OPT parameters with raw
+    Seminario projections and dropped bond_length R² to ≈ −4787.  See
+    ericchansen/q2mm#277 for the three-baseline diagnostic.
+
     Args:
         engine: MM engine instance (accepted for loader interface compatibility).
         functional_form: Override functional form.  Defaults to ``"mm3"``.
@@ -345,7 +353,6 @@ def load_heck_relay(
 
     """
     from q2mm.models.forcefield import ForceField, FunctionalForm
-    from q2mm.models.seminario import estimate_force_constants
     from q2mm.optimizers.objective import ReferenceData
 
     si = _resolve_supporting_info_dir()
@@ -354,10 +361,13 @@ def load_heck_relay(
         raise FileNotFoundError(f"Heck relay FF not found: {ff_path}")
 
     molecules = load_heck_relay_molecules()
-    ff_template = ForceField.from_mm3_fld(str(ff_path), include_standard=True)
+    ff = ForceField.from_mm3_fld(str(ff_path), include_standard=True)
+    # Mark only the OPT-substructure parameters as active for downstream
+    # optimization; standard MM3 backbone params remain frozen.  Do NOT
+    # call estimate_force_constants here — see #277 (it would overwrite
+    # the Rosales-fitted OPT values with raw Seminario projections).
     ff_opt = ForceField.from_mm3_fld(str(ff_path), include_standard=False)
-    ff_template.freeze_standard_params(ff_opt)
-    ff = estimate_force_constants(molecules, forcefield=ff_template, invert_ts_curvature=True)
+    ff.freeze_standard_params(ff_opt)
 
     if functional_form is not None:
         ff.functional_form = FunctionalForm(functional_form)

--- a/scripts/diagnose_heck_relay.py
+++ b/scripts/diagnose_heck_relay.py
@@ -1,0 +1,419 @@
+"""Diagnose Heck-relay Seminario divergence (ericchansen/q2mm#277).
+
+Builds three no-optimization baselines for the Heck-relay system and
+evaluates each against the QM training set:
+
+A. Untouched Rosales FF — ForceField.from_mm3_fld(include_standard=True),
+   no freeze_standard_params, no Seminario re-estimation.
+B. Pre-fix loader pattern — the BUGGY combination that load_heck_relay
+   used before #277 was fixed: ForceField.from_mm3_fld + freeze_standard_params
+   + estimate_force_constants(forcefield=ff).  Reconstructed inline (NOT
+   by calling the current loader), so this diagnostic stays valid as a
+   regression-detection tool after the fix lands.
+C. Seminario-only — ForceField.from_mm3_fld(include_standard=False)
+   (Rosales OPT block as the template), then Seminario re-estimates
+   every active param (no freeze step).
+
+For each baseline this script reports:
+
+- Per-category R² / RMSD / MAE (bond_length, bond_angle, eig_diagonal)
+- ObjectiveFunction score
+- Whether JaxLoss returns a finite value
+- Worst-10 bond-length residuals (with atom-pair labels)
+
+Output: strict JSON at
+``../q2mm-data/benchmarks/heck-relay/diagnostic/three_baseline_comparison.json``
+with embedded provenance, plus a human-readable summary on stdout.
+
+Time-boxed per #277; not a benchmark — won't replace
+``regenerate_convergence_results.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import math
+import shlex
+import subprocess
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+logger = logging.getLogger("diag-heck")
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# ---------------------------------------------------------------------------
+# Provenance + JSON helpers (deliberately small re-implementations so the
+# script has no dependency on regenerate_convergence_results.py internals).
+# ---------------------------------------------------------------------------
+
+
+def _git_info(repo: Path) -> dict[str, Any]:
+    if not (repo / ".git").exists():
+        return {}
+    try:
+        sha = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=repo, stderr=subprocess.DEVNULL, text=True
+        ).strip()
+        dirty = subprocess.check_output(
+            ["git", "status", "--porcelain"], cwd=repo, stderr=subprocess.DEVNULL, text=True
+        ).strip()
+        return {"git_sha": sha, "git_dirty": bool(dirty)}
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return {}
+
+
+def _find_git_repo_root(start: Path) -> Path | None:
+    """Walk parents from *start* until a ``.git`` entry is found.
+
+    Returns the directory containing ``.git``, or ``None`` if no git
+    repo is found before reaching the filesystem root.  ``.git`` may be
+    a directory (regular repo) or a file (worktrees / submodules).
+    """
+    for candidate in [start, *start.parents]:
+        if (candidate / ".git").exists():
+            return candidate
+    return None
+
+
+def _device_info() -> dict[str, Any]:
+    """Probe JAX device info — best effort, never raises."""
+    info: dict[str, Any] = {}
+    try:
+        import jax
+
+        info["jax_devices"] = [str(d) for d in jax.devices()]
+    except Exception as exc:
+        info["jax_devices_error"] = repr(exc)
+    return info
+
+
+def _sanitize(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {k: _sanitize(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_sanitize(v) for v in value]
+    if isinstance(value, float):
+        if math.isnan(value):
+            return "NaN"
+        if math.isinf(value):
+            return "Infinity" if value > 0 else "-Infinity"
+    if isinstance(value, np.floating):
+        return _sanitize(float(value))
+    if isinstance(value, np.integer):
+        return int(value)
+    if isinstance(value, np.ndarray):
+        return _sanitize(value.tolist())
+    return value
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as fh:
+        json.dump(_sanitize(payload), fh, indent=2, allow_nan=False, sort_keys=False)
+        fh.write("\n")
+
+
+# ---------------------------------------------------------------------------
+# Per-category metrics
+# ---------------------------------------------------------------------------
+
+
+def _category_stats(ref_values: np.ndarray, calc_values: np.ndarray) -> dict[str, float]:
+    n = int(ref_values.size)
+    if n == 0:
+        return {"n_refs": 0, "r2": float("nan"), "rmsd": float("nan"), "mae": float("nan")}
+    residuals = ref_values - calc_values
+    rmsd = float(np.sqrt(np.mean(residuals**2)))
+    mae = float(np.mean(np.abs(residuals)))
+    mean_ref = float(np.mean(ref_values))
+    ss_res = float(np.sum(residuals**2))
+    ss_tot = float(np.sum((ref_values - mean_ref) ** 2))
+    r2 = 1.0 - ss_res / ss_tot if ss_tot > 0 else float("nan")
+    return {"n_refs": n, "r2": r2, "rmsd": rmsd, "mae": mae}
+
+
+def _per_category_metrics(obj: Any, ff: Any) -> tuple[dict[str, dict[str, float]], list[dict[str, Any]]]:
+    """Compute per-category fit metrics and per-bond residuals.
+
+    Returns ``(category_stats, bond_residuals)`` where *bond_residuals*
+    contains one dict per bond_length reference: molecule_idx,
+    atom_indices, ref_value, calc_value, abs_residual.
+    """
+    residuals = obj._compute_residuals(ff)  # noqa: SLF001
+    buckets: dict[str, list[tuple[float, float]]] = defaultdict(list)
+    bond_records: list[dict[str, Any]] = []
+    for ref, weighted in zip(obj.reference.values, residuals, strict=True):
+        if ref.weight == 0.0:
+            continue
+        raw_residual = float(weighted) / float(ref.weight)
+        calc_value = float(ref.value) - raw_residual
+        buckets[ref.kind].append((float(ref.value), calc_value))
+        if ref.kind == "bond_length":
+            bond_records.append(
+                {
+                    "molecule_idx": int(ref.molecule_idx),
+                    "atom_indices": list(ref.atom_indices) if ref.atom_indices is not None else None,
+                    "ref_value": float(ref.value),
+                    "calc_value": calc_value,
+                    "abs_residual": abs(raw_residual),
+                }
+            )
+
+    category_stats = {
+        kind: _category_stats(
+            np.array([p[0] for p in pairs]),
+            np.array([p[1] for p in pairs]),
+        )
+        for kind, pairs in buckets.items()
+    }
+    return category_stats, bond_records
+
+
+def _per_molecule_r2(obj: Any, ff: Any) -> list[dict[str, float]]:
+    """Compute per-molecule eig_diagonal R² (the system-level loss target)."""
+    residuals = obj._compute_residuals(ff)  # noqa: SLF001
+    per_mol: dict[int, list[tuple[float, float]]] = defaultdict(list)
+    for ref, weighted in zip(obj.reference.values, residuals, strict=True):
+        if ref.kind != "eig_diagonal" or ref.weight == 0.0:
+            continue
+        raw_residual = float(weighted) / float(ref.weight)
+        calc_value = float(ref.value) - raw_residual
+        per_mol[ref.molecule_idx].append((float(ref.value), calc_value))
+    out: list[dict[str, float]] = []
+    for idx in sorted(per_mol):
+        pairs = per_mol[idx]
+        ref_arr = np.array([p[0] for p in pairs])
+        calc_arr = np.array([p[1] for p in pairs])
+        out.append({"molecule_idx": idx, **_category_stats(ref_arr, calc_arr)})
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Force-field builders for the three baselines
+# ---------------------------------------------------------------------------
+
+
+def _ff_path() -> Path:
+    """Resolve the Rosales Heck-relay FF file path."""
+    from q2mm.diagnostics.systems import _resolve_supporting_info_dir
+
+    si = _resolve_supporting_info_dir()
+    return si / "rosales" / "Rosales_Anthony_Supporting_Information" / "Chapter3_Heck" / "mm3.FF1.fld"
+
+
+def build_ff_a_untouched(molecules: list[Any]) -> Any:
+    """Build baseline A — untouched Rosales FF (no Seminario, no freeze)."""
+    from q2mm.models.forcefield import ForceField, FunctionalForm
+
+    ff = ForceField.from_mm3_fld(str(_ff_path()), include_standard=True)
+    ff.functional_form = FunctionalForm.MM3
+    return ff
+
+
+def build_ff_b_prefix_loader_pattern(molecules: list[Any]) -> Any:
+    """Build baseline B — explicit reconstruction of the PRE-FIX loader bug.
+
+    Reproduces the pre-#277 ``load_heck_relay()`` exactly:
+    ``from_mm3_fld(include_standard=True)`` + ``freeze_standard_params`` +
+    ``estimate_force_constants(forcefield=ff)``.  This is the bug we are
+    diagnosing — we do **not** call the current loader, because the
+    current loader was fixed in #280 and no longer reproduces the bug.
+    Keeping the buggy pattern inline here means the diagnostic stays
+    valid as a regression-detection tool even after the fix lands.
+    """
+    from q2mm.models.forcefield import ForceField, FunctionalForm
+    from q2mm.models.seminario import estimate_force_constants
+
+    ff = ForceField.from_mm3_fld(str(_ff_path()), include_standard=True)
+    opt_ff = ForceField.from_mm3_fld(str(_ff_path()), include_standard=False)
+    ff.freeze_standard_params(opt_ff)
+    ff = estimate_force_constants(molecules, forcefield=ff, invert_ts_curvature=True)
+    ff.functional_form = FunctionalForm.MM3
+    return ff
+
+
+def build_ff_c_seminario_only(molecules: list[Any]) -> Any:
+    """Build baseline C — Seminario over the OPT block, no published values."""
+    from q2mm.models.forcefield import ForceField, FunctionalForm
+    from q2mm.models.seminario import estimate_force_constants
+
+    ff_template = ForceField.from_mm3_fld(str(_ff_path()), include_standard=False)
+    ff = estimate_force_constants(molecules, forcefield=ff_template, invert_ts_curvature=True)
+    ff.functional_form = FunctionalForm.MM3
+    return ff
+
+
+# ---------------------------------------------------------------------------
+# Baseline evaluation
+# ---------------------------------------------------------------------------
+
+
+def evaluate_baseline(
+    label: str,
+    ff: Any,
+    molecules: list[Any],
+    reference: Any,
+    engine: Any,
+) -> dict[str, Any]:
+    """Compute the full diagnostic block for one baseline."""
+    from q2mm.optimizers.objective import ObjectiveFunction
+
+    obj = ObjectiveFunction(ff, engine, molecules, reference)
+    x = ff.get_param_vector()
+    obj_score = float(obj(x))
+
+    categories, bond_records = _per_category_metrics(obj, ff)
+    per_molecule = _per_molecule_r2(obj, ff)
+
+    bond_records.sort(key=lambda r: -r["abs_residual"])
+    worst_10 = bond_records[:10]
+
+    jaxloss_val: float | None = None
+    jaxloss_finite: bool | None = None
+    try:
+        from q2mm.backends.mm.jax_engine import JaxEngine
+        from q2mm.optimizers.jaxloss import JaxLoss
+
+        if isinstance(engine, JaxEngine):
+            spec = obj.to_jax_spec()
+            jl = JaxLoss(spec, engine, molecules, ff)
+            val_jax, _ = jl.value_and_grad_jax(x)
+            raw = float(val_jax)
+            jaxloss_finite = math.isfinite(raw)
+            jaxloss_val = raw if jaxloss_finite else None
+    except Exception as exc:
+        logger.warning("[%s] JaxLoss evaluation failed: %s", label, exc)
+        jaxloss_finite = False
+
+    n_active = int(np.sum(ff.active_mask))
+    n_total = int(ff.n_params)
+
+    return {
+        "label": label,
+        "n_total_params": n_total,
+        "n_active_params": n_active,
+        "objective_score": obj_score,
+        "jaxloss": jaxloss_val,
+        "jaxloss_finite": jaxloss_finite,
+        "ratio": (jaxloss_val / obj_score) if (jaxloss_val is not None and obj_score > 0) else None,
+        "categories": categories,
+        "per_molecule_eig_diagonal_r2": per_molecule,
+        "worst_10_bond_length_residuals": worst_10,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    """Run the three-baseline Heck-relay diagnostic and write the JSON report."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0] if __doc__ else None)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=REPO_ROOT.parent
+        / "q2mm-data"
+        / "benchmarks"
+        / "heck-relay"
+        / "diagnostic"
+        / "three_baseline_comparison.json",
+        help="Output JSON path (default: q2mm-data/benchmarks/heck-relay/diagnostic/three_baseline_comparison.json).",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=("DEBUG", "INFO", "WARNING", "ERROR"),
+    )
+    args = parser.parse_args()
+    logging.basicConfig(
+        level=args.log_level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    from q2mm.backends.mm.jax_engine import JaxEngine
+    from q2mm.diagnostics.systems import load_heck_relay_molecules
+    from q2mm.optimizers.objective import ReferenceData
+
+    logger.info("Loading 23 Heck-relay molecules + QM Hessians")
+    engine = JaxEngine()
+    molecules = load_heck_relay_molecules()
+    reference = ReferenceData.from_molecules(molecules, eigenmatrix_diagonal_only=True)
+    logger.info(
+        "Loaded %d molecules; %d reference values across categories",
+        len(molecules),
+        len(reference.values),
+    )
+
+    baselines: list[tuple[str, Any]] = [
+        ("A_untouched_rosales", build_ff_a_untouched(molecules)),
+        ("B_prefix_loader_pattern", build_ff_b_prefix_loader_pattern(molecules)),
+        ("C_seminario_only", build_ff_c_seminario_only(molecules)),
+    ]
+
+    results: dict[str, Any] = {}
+    for label, ff in baselines:
+        logger.info("Evaluating baseline %s", label)
+        results[label] = evaluate_baseline(label, ff, molecules, reference, engine)
+        r = results[label]
+        cats = r["categories"]
+        logger.info(
+            "[%s] obj=%.3e ratio=%s bond_len R²=%.3f bond_ang R²=%.3f eig_diag R²=%.3f",
+            label,
+            r["objective_score"],
+            f"{r['ratio']:.3e}" if r["ratio"] is not None else "n/a",
+            cats.get("bond_length", {}).get("r2", float("nan")),
+            cats.get("bond_angle", {}).get("r2", float("nan")),
+            cats.get("eig_diagonal", {}).get("r2", float("nan")),
+        )
+
+    data_repo = _find_git_repo_root(args.output.resolve()) or args.output.parent
+    provenance = {
+        "generator": "scripts/diagnose_heck_relay.py",
+        "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+        "command_line": shlex.join(sys.argv),
+        "q2mm": _git_info(REPO_ROOT),
+        "q2mm_data": _git_info(data_repo),
+        "devices": _device_info(),
+    }
+
+    payload = {
+        "provenance": provenance,
+        "issue": "ericchansen/q2mm#277",
+        "results": results,
+    }
+    _write_json(args.output, payload)
+    logger.info("Wrote %s", args.output)
+
+    # ---- Human-readable decision summary ---------------------------------
+    print()
+    print("=" * 70)
+    print("Three-baseline summary (Heck relay)")
+    print("=" * 70)
+    print(f"{'Baseline':<22} {'n_active':>9} {'obj':>12} {'ratio':>12} {'R²(bond_len)':>14}")
+    for label, _ in baselines:
+        r = results[label]
+        ratio_s = f"{r['ratio']:.2e}" if r["ratio"] is not None else "n/a"
+        r2_bond = r["categories"].get("bond_length", {}).get("r2", float("nan"))
+        print(f"  {label:<20} {r['n_active_params']:>9d} {r['objective_score']:>12.3e} {ratio_s:>12} {r2_bond:>14.3f}")
+
+    print()
+    print("Decision rule (per issue #277):")
+    print("  A's bond_length R² >> B's   → bug in freeze_standard_params + Seminario interaction")
+    print("  A ≈ B ≈ C                   → bug upstream (MM3 evaluator / atom types)")
+    print("  A fine, B explodes          → narrow on Seminario behavior with freeze_standard_params")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/integration/test_heck_validation.py
+++ b/test/integration/test_heck_validation.py
@@ -364,3 +364,60 @@ class TestHeckRelayPublishedFF:
                 f"    {m['name']:<12} R²={m['r_squared']:.3f}  RMSD={m['rmsd_cm1']:.0f} cm⁻¹  ({m['n_freq_refs']} refs)"
             )
         print("=" * 60)
+
+
+# ---------------------------------------------------------------------------
+# Regression: load_heck_relay() must preserve published OPT parameter values
+# (ericchansen/q2mm#277)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.validation
+@pytest.mark.external_data
+def test_load_heck_relay_preserves_published_opt_values() -> None:
+    """Regression: loader must NOT overwrite published Rosales OPT params.
+
+    Before #277, ``load_heck_relay()`` called ``estimate_force_constants``
+    after ``freeze_standard_params``, which silently re-projected the
+    OPT-substructure parameter values via FUERZA — discarding Rosales'
+    fitted values.  After the fix, the loader should keep those values
+    exactly as published.  This test compares the optimizable (non-frozen)
+    parameter values from ``load_heck_relay()`` against the same params
+    loaded directly from the .fld file with no Seminario step.
+    """
+    if HECK_DIR is None:
+        pytest.skip("Heck relay supporting data not found")
+
+    from q2mm.diagnostics.systems import load_heck_relay
+    from q2mm.models.forcefield import ForceField
+
+    ff_path = HECK_DIR / "mm3.FF1.fld"
+    if not ff_path.exists():
+        pytest.skip(f"mm3.FF1.fld not found: {ff_path}")
+
+    # Loader output (what users get today).
+    sys_data = load_heck_relay(engine=None)
+    loader_active = sys_data.forcefield.get_active_param_vector()
+
+    # Same .fld file, same active-mask partition, but no Seminario.
+    # This is the pre-fix "reference" we expect the loader to match.
+    expected_ff = ForceField.from_mm3_fld(str(ff_path), include_standard=True)
+    opt_ff = ForceField.from_mm3_fld(str(ff_path), include_standard=False)
+    expected_ff.freeze_standard_params(opt_ff)
+    expected_active = expected_ff.get_active_param_vector()
+
+    assert loader_active.shape == expected_active.shape, (
+        f"Active-mask shape mismatch: loader={loader_active.shape} vs expected={expected_active.shape}"
+    )
+    # Tight tolerance: these should match bit-for-bit (same file, no math).
+    np.testing.assert_allclose(
+        loader_active,
+        expected_active,
+        rtol=0.0,
+        atol=1e-12,
+        err_msg=(
+            "load_heck_relay() OPT parameter values differ from the "
+            "published .fld values.  This likely means a Seminario-style "
+            "re-estimation crept back into the loader (the #277 bug)."
+        ),
+    )


### PR DESCRIPTION
Resolves #277.

## TL;DR

The Heck-relay loader was silently corrupting the published Rosales OPT force field by overwriting its OPT parameters with raw Seminario projections. Fixing this single line drops the ObjectiveFunction by 43×, takes JaxLoss from "diverges by 21 orders of magnitude" to ratio ≈ 1.29, and brings bond_length R² from **−48** to **0.98**.

## The bug

```python
ff_template = ForceField.from_mm3_fld(ff_path, include_standard=True)
ff_opt = ForceField.from_mm3_fld(ff_path, include_standard=False)
ff_template.freeze_standard_params(ff_opt)
ff = estimate_force_constants(molecules, forcefield=ff_template, ...)  # 💥
```

`freeze_standard_params` marks the *non*-OPT params (standard MM3 backbone) as frozen and leaves the OPT params active. `estimate_force_constants` skips frozen params (see `q2mm/models/seminario.py:341`) and re-estimates the *active* ones — overwriting the carefully-fitted Rosales OPT values with raw Seminario projections.

## Three-baseline diagnostic

The new `scripts/diagnose_heck_relay.py` builds three FFs and evaluates each (no optimization, just evaluation). Output committed to [`q2mm-data/benchmarks/heck-relay/diagnostic/`](https://github.com/ericchansen/q2mm-data/blob/main/benchmarks/heck-relay/diagnostic/three_baseline_comparison.json):

| Baseline | obj | ratio | R²(bond_len) | R²(bond_ang) | R²(eig_diag) |
|---|---|---|---|---|---|
| A — Untouched Rosales | 3.42 × 10⁶ | **1.31** | **0.980** | 0.786 | −12.6 |
| B — Current loader | 1.17 × 10⁸ | NaN | −4787 | −7.25 | −4.66 |
| C — Seminario only | 1.24 × 10⁸ | 1.77 × 10⁷³ | −849 | −5.13 | 0.05 |

A's bond_length R² (0.980) is dramatically better than B's (−4787) — matching the issue's decision rule "A fine, B explodes → narrow on Seminario behavior with freeze_standard_params".

## The fix

Keep `freeze_standard_params` (still needed for the optimizer's active mask) but **skip `estimate_force_constants`**. Use the published Rosales OPT parameters as-is.

## Post-fix baseline

(Companion q2mm-data PR regenerates the heck-relay convergence JSONs.)

| Metric | Before (loader bug) | After (this PR) |
|---|---|---|
| Initial ObjectiveFunction | 1.48 × 10⁸ | 3.46 × 10⁶ |
| Initial JaxLoss | 1e30 (penalty) | 4.48 × 10⁶ |
| Ratio | ~10²¹ | 1.29 |
| Status | out_of_band | out_of_band (12 % over band) |
| bond_length R² | −48.06 | 0.980 |
| bond_angle R² | −5.47 | 0.786 |
| eig_diagonal R² | −4.66 | −12.6 |

The eigenmatrix actually gets worse (−4.66 → −12.6), but that just reflects the real MM3* ↔ JAX-engine cross-engine gap that's now visible without being masked by the corrupted FF. Geometry is now well-reproduced and JaxLoss is no longer divergent.

## Out of scope

- The same `freeze_standard_params + estimate_force_constants` pattern exists in `load_rh_enamide` and the `load_pd_*` loaders. They aren't catastrophically broken today (Rh-enamide runs at R² = 0.97, Pd-allyl at −1.41), but the same audit should probably extend to them in a follow-up.
- Heck-relay now joins pd-conjugate as a candidate for the `ratio_tol=None` experiment ([#276](https://github.com/ericchansen/q2mm/issues/276)).

## Validation

- `python -m ruff check q2mm/ test/ scripts/` — clean.
- `python -m ruff format --check q2mm test scripts examples` — clean.
- `python -m pytest test/ -x -q -m "not (openmm or tinker or jax or jax_md or psi4)" -k "heck or systems"` — 11 passed.
- End-to-end `scripts/regenerate_convergence_results.py --system heck-relay --skip-optimization` ran clean on a single GPU; output (with full provenance) is in the companion q2mm-data PR.

## Companion PR

[`ericchansen/q2mm-data#?`](https://github.com/ericchansen/q2mm-data/pulls) — adds the diagnostic JSON and the regenerated convergence baseline.
