### PR TITLE
refactor: loader API + frozen-as-invariant + QFUERZA split

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,30 @@ functions, and evaluation tools for force field development.
 
 > ⚠️ **This project is in alpha.** The rules below are non-negotiable.
 
+### Key Papers — Read Before Touching Methodology
+
+Q2MM has a specific scientific lineage.  Before changing anything in
+`q2mm/models/seminario.py`, `q2mm/models/forcefield.py`, the
+parametrization loaders in `q2mm/diagnostics/systems.py`, or the
+optimizers in `q2mm/optimizers/`, look at the right paper.  Agents have
+repeatedly cited the wrong reference here.
+
+| Paper | DOI | What it governs |
+|-------|-----|-----------------|
+| **Farrugia, Helquist, Norrby & Wiest 2025** — "Rapid FF Generation via Hessian-Informed Initial Parameters and Automated Refinement", *J. Chem. Theory Comput.* **22**, 469. | [10.1021/acs.jctc.5c01751](https://doi.org/10.1021/acs.jctc.5c01751) | **QFUERZA** — the methodology of record for `q2mm/models/seminario.py`. Defines the FUERZA + H-angle-substitution variant we ship; documents that torsions are intentionally zeroed at initial-parameter time; explains the "mixing literature + custom params" workflow our loaders implement. |
+| Seminario 1996 — "Calculation of intramolecular force fields from second-derivative tensors", *Int. J. Quantum Chem.* **60**, 1271. | [10.1002/(SICI)1097-461X(1996)60:7%3C1271::AID-QUA8%3E3.0.CO;2-W](https://doi.org/10.1002/(SICI)1097-461X(1996)60:7%3C1271::AID-QUA8%3E3.0.CO;2-W) | Original **FUERZA** projection.  Background only; QFUERZA above supersedes it for us. |
+| Limé & Norrby 2015 — *J. Chem. Theory Comput.* **11**, 3696. | [10.1021/acs.jctc.5b00461](https://doi.org/10.1021/acs.jctc.5b00461) | TS Hessian inversion (`invert_ts_curvature=True`).  See the "TS Hessian Inversion" warning below. |
+| Donoghue, Helquist, Norrby & Wiest 2008 — *J. Chem. Theory Comput.* **4**, 1313. | [10.1021/ct800132a](https://doi.org/10.1021/ct800132a) | Rh-enamide TSFF reference paper.  Governs `examples/rh-enamide/`, `load_rh_enamide`, and the 9-molecule benchmark system. |
+| Rosales, Helquist, Norrby & Wiest 2020 — *J. Am. Chem. Soc.* **142**, 9700. | [10.1021/jacs.0c01979](https://doi.org/10.1021/jacs.0c01979) | Heck-relay TSFF reference paper.  Governs `load_heck_relay` and the 23-molecule benchmark system. |
+| Wahlers, *Ph.D. Dissertation*, University of Notre Dame, 2022. | (dissertation, no DOI) | pd-allyl, pd 1,4-conjugate-addition, rh 1,4-conjugate-addition TSFFs.  Governs `load_pd_allyl`, `load_pd_conjugate`, `load_rh_conjugate`. |
+
+**If you propose changes to the parametrization or loader code without
+having consulted Farrugia 2025, stop and read it first.** Many of the
+loader-API decisions (frozen params, OPT-only re-estimation, the
+distinction between literature and custom parameter values) are
+deliberate implementations of the QFUERZA workflow and will not make
+sense otherwise.
+
 ### TS Hessian Inversion — DO NOT GET THIS WRONG
 
 Q2MM handles **transition state (TS) systems** by inverting the QM Hessian's

--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ pip install -e ".[dev]"
 ```python
 from q2mm.optimizers.objective import ReferenceData, ObjectiveFunction
 from q2mm.optimizers.scipy_opt import ScipyOptimizer
-from q2mm.models.seminario import estimate_force_constants
+from q2mm.models.seminario import qfuerza_fresh
 from q2mm.backends.mm import OpenMMEngine
 
 # 1. Load QM reference data and molecule from a Gaussian checkpoint
 ref, mol = ReferenceData.from_fchk("ts-optimized.fchk", bond_tolerance=1.4)
 
-# 2. Estimate initial force field from the QM Hessian
-ff = estimate_force_constants(mol, au_hessian=True)
+# 2. Build the initial force field from the QM Hessian (QFUERZA)
+ff = qfuerza_fresh(mol, au_hessian=True)
 
 # 3. Set up the objective function and optimize
 engine = OpenMMEngine()

--- a/docs/benchmarks/optimizer-comparison.md
+++ b/docs/benchmarks/optimizer-comparison.md
@@ -29,11 +29,25 @@ provenance: git SHAs, device, ratio_tol, timestamp) live in
 
 | System | Mols | Active | Ratio | Check |
 |--------|:----:|:------:|:-----:|:-----:|
-| Rh-enamide | 9 | 182 | 1.05 | ✓ |
-| Pd-allyl | 21 | 482 | 1.09 | ✓ |
-| Heck relay | 23 | 462 | 1.29 | ✗ |
-| Pd 1,4-conj | 10 | 340 | 1.20 | ✗ |
-| Rh 1,4-conj | 10 | 488 | ~4 × 10³ | ✗ |
+| Rh-enamide | 9 | 182 | 1.07 | ✓ |
+| Pd-allyl | 21 | 482 | 1.10 | ✓ |
+| Heck relay | 23 | 462 | 1.30 | ✗ |
+| Pd 1,4-conj | 10 | 340 | 0.96 | ✓ |
+| Rh 1,4-conj | 10 | 488 | 1.04 | ✓ |
+
+**Note on the gate behaviour after the loader API refactor.**  The
+loader API refactor (the same commit that introduces this update)
+stopped overwriting published OPT parameter values with raw QFUERZA
+projections — see :func:`q2mm.models.loaders.load_published_opt` and
+:func:`q2mm.models.loaders.load_published_opt_composed` and AGENTS.md
+"Key Papers" for the QFUERZA / Farrugia 2025 background.  Four of
+the five published-FF systems (rh-enamide, pd-allyl, pd-conjugate,
+rh-conjugate) now use the literature OPT values as-published and the
+ratio gate passes for four of them (heck-relay remains marginally
+out of band at 1.30).  Pre-refactor ratios for the two "Wahlers
+composed" systems were 1.20 (pd-conjugate) and ~4 × 10³
+(rh-conjugate); the dramatic change for rh-conjugate is the loss of
+the silent QFUERZA overwrite, not anything about JaxLoss itself.
 
 **Optimization results** (only systems that pass the ratio gate;
 ``jac_mode`` is the resolved gradient mode from the JSON output, after
@@ -44,8 +58,19 @@ of the run — that is why `Evals` can be much smaller than `Iters`:
 
 | System | Init score | Final score | Δ% | Iters (`nit`) | ObjFun evals | Wall time | jac_mode |
 |--------|:----------:|:-----------:|:--:|:-------------:|:------------:|:---------:|:--------:|
-| Rh-enamide | 3.92 × 10⁵ | 2.80 × 10⁵ | 28.68 % | 6 | 2 | ~11 min | `jax_loss` |
-| Pd-allyl | 8.02 × 10⁶ | 8.00 × 10⁶ | 0.08 % | 2 | 2 | ~23 min | `jax_loss` |
+| Rh-enamide | 4.87 × 10⁵ | TBD | TBD | TBD | TBD | TBD | `jax_loss` |
+| Pd-allyl | 7.99 × 10⁶ | TBD | TBD | TBD | TBD | TBD | `jax_loss` |
+| Pd 1,4-conj | 8.79 × 10⁶ | TBD | TBD | TBD | TBD | TBD | `jax_loss` |
+| Rh 1,4-conj | 6.42 × 10⁶ | TBD | TBD | TBD | TBD | TBD | `jax_loss` |
+
+The post-optimization rows are TBD pending end-to-end optimization
+runs against the refactored loaders (tracked in
+[q2mm#275](https://github.com/ericchansen/q2mm/issues/275) and its
+follow-ups).  The earlier published 28.68 % rh-enamide improvement
+came from an FF whose OPT values were overwritten by QFUERZA — that
+result is no longer reproducible because the new loader preserves
+the Donoghue OPT values, which start closer to optimum so the
+absolute headroom is smaller.
 
 Each row is reproducible from
 [`scripts/regenerate_convergence_results.py`](https://github.com/ericchansen/q2mm/blob/master/scripts/regenerate_convergence_results.py)
@@ -59,26 +84,24 @@ name for the Wahlers systems — e.g. `pd-allyl` →
 
 **Notes:**
 
-- **Rh-enamide and Pd-allyl** pass the ratio gate cleanly and are the
-  two systems that can be optimized with JaxLoss analytical gradients
-  out of the box.
-- **Heck relay** misses the gate by ~12 % (ratio 1.29).  With the
-  loader bug fixed in [`q2mm#277`](https://github.com/ericchansen/q2mm/issues/277),
-  the Rosales OPT parameters are now used as-published: bond_length
-  R² ≈ 0.98, bond_angle R² ≈ 0.79.  Heck relay joins
-  [pd-conjugate](../systems/pd-conjugate.md) as a candidate for the
-  experimental `ratio_tol=None` bypass.
-- **Pd 1,4-conj** misses the band by ~4 %.  This is the natural
-  candidate for the experimental `ratio_tol=None` bypass — see
-  [pd-conjugate](../systems/pd-conjugate.md).  Until that experiment
-  has run and been validated against the real ObjectiveFunction, the
-  default `ratio_tol=0.15` correctly skips this system.
-- **Rh 1,4-conj** diverges by ~3 orders of magnitude.  The JaxLoss
-  surrogate is unusable here without first improving the starting FF.
-  Previous sessions saw varying ratios (0.46–0.96) for this system
-  depending on uncommitted state; the current committed baseline
-  gives ~4 × 10³.  See [rh-conjugate](../systems/rh-conjugate.md)
-  for the per-category R² explaining why the surrogate diverges.
+- **Rh-enamide, Pd-allyl, Pd 1,4-conj, and Rh 1,4-conj** pass the
+  ratio gate cleanly after the loader API refactor — the literature
+  OPT values reproduce QM geometry well and JaxLoss's inner
+  geometry minimization stays in a sensible basin.
+- **Heck relay** misses the gate by ~12 % (ratio 1.30).  The Rosales
+  OPT parameters are used as-published; bond_length R² ≈ 0.98 and
+  bond_angle R² ≈ 0.79 are healthy, but eig_diagonal R² ≈ −12.6
+  reflects a real MM3* ↔ JAX-engine cross-engine gap.  Heck relay
+  remains a candidate for the experimental `ratio_tol=None` bypass
+  ([q2mm#276](https://github.com/ericchansen/q2mm/issues/276)).
+- **Pd 1,4-conj** is now within the gate (0.96) — the pre-refactor
+  ratio of 1.20 came from QFUERZA overwriting the Wahlers OPT
+  values.  See [pd-conjugate](../systems/pd-conjugate.md).
+- **Rh 1,4-conj** is now within the gate (1.04) — the pre-refactor
+  ratio of ~4 × 10³ came from QFUERZA overwriting the Wahlers OPT
+  values, sending JaxLoss's inner geometry minimization into
+  pathological regions.  See [rh-conjugate](../systems/rh-conjugate.md)
+  for the per-category R² that explains the recovery.
 
 ### Why some systems fail the ratio check
 
@@ -102,26 +125,26 @@ Our eigenmatrix-diagonal R² is analogous to paper R²(hessian), though we
 use diagonal elements only while papers use the full lower-triangular
 eigenmatrix.
 
-### Seminario starting-point R² (pre-optimization)
+### Pre-optimization R² (published OPT values as-published)
 
-These R² values show how well the Seminario-estimated force constants
-reproduce QM data *before* any optimization. Negative R² means the MM
-prediction is worse than predicting the QM mean.
+These R² values show how well the published OPT values, evaluated by
+the q2mm JAX engine, reproduce QM data *before* any q2mm-side
+optimization.  All five systems use the literature OPT block as-is
+(no QFUERZA overwrite) after the loader API refactor.
 
 | System | R²(eig_diag) | R²(bond_len) | R²(bond_ang) |
 |--------|:------------:|:------------:|:------------:|
-| Rh-enamide (9 mol) | 0.972 | 0.976 | 0.934 |
-| Heck relay (23 mol) | −12.6 | 0.980 | 0.786 |
-| Pd-allyl (21 mol) | −1.41 | 0.026 | 0.337 |
-| Pd 1,4-conj (10 mol) | −4.47 | 0.435 | −0.118 |
-| Rh 1,4-conj (10 mol) | −4.85 | −57.65 | −1.29 |
+| Rh-enamide (9 mol) | 0.963 | 0.987 | 0.918 |
+| Heck relay (23 mol) | −12.6 | 0.980 | 0.781 |
+| Pd-allyl (21 mol) | −2.82 | 0.042 | 0.330 |
+| Pd 1,4-conj (10 mol) | −10.06 | 0.939 | −0.177 |
+| Rh 1,4-conj (10 mol) | −7.86 | 0.891 | 0.454 |
 
-(Heck relay is the only Wahlers/Rosales system that starts from the
-already-fitted published OPT parameters rather than a fresh Seminario
-projection — that is why its geometry R² is strong here.)
-
-Rh-enamide starts near-optimal (R² > 0.93 in all categories). The other
-four systems start far from optimal — the optimizer must close this gap.
+Geometry reproduction is healthy across all five systems
+(bond_length R² ≥ 0.89 for the published OPT systems; pd-allyl is
+weaker at 0.04 but not catastrophic).  The eigenmatrix R² is
+consistently negative — that is the real cross-engine gap (MM3*
+versus q2mm's JAX engine), not a loader artifact.
 These numbers come from `q2mm-data/benchmarks/<system>/convergence/paper_metrics.json`
 and are reproducible via `scripts/regenerate_convergence_results.py`.
 

--- a/docs/benchmarks/qfuerza-validation.md
+++ b/docs/benchmarks/qfuerza-validation.md
@@ -95,8 +95,8 @@ def _is_hydrogen_angle(elements):
     return elements[0] == "H" or elements[2] == "H"
 ```
 
-In `estimate_force_constants()`, after computing the Seminario-projected
-value for each angle:
+In `qfuerza_into()` (and indirectly `qfuerza_fresh()`), after computing
+the Seminario-projected value for each angle:
 
 ```python
 if strategy == "qfuerza" and _is_hydrogen_angle(angle_param.elements):

--- a/docs/how-it-works/optimization-guide.md
+++ b/docs/how-it-works/optimization-guide.md
@@ -24,7 +24,8 @@ then links to source code for API details.
 | JAX engine, multi-molecule TS systems | [Workflow D](#workflow-d-end-to-end-differentiable-jax) | Per-molecule JaxLoss analytical gradients via scipy L-BFGS-B |
 
 Every workflow assumes **QFUERZA initialization** — run
-`estimate_force_constants()` before optimization. QFUERZA puts you in the
+`qfuerza_fresh()` (single molecule) or `qfuerza_into()` (template-based,
+multi-molecule averaging) before optimization. QFUERZA puts you in the
 right neighbourhood; the optimizer refines from there.
 
 ---
@@ -372,8 +373,8 @@ top harmonic results on CH₃F all use analytical or auto mode.
 
 !!! tip "QFUERZA initialization matters"
     Starting from QFUERZA-estimated parameters puts you close to the
-    optimum. Always run `estimate_force_constants()` before optimization
-    when QM data is available.
+    optimum. Run `qfuerza_fresh()` or `qfuerza_into()` before
+    optimization when QM data is available.
 
 !!! tip "Monitor convergence"
     Plot `result.history` (single-shot) or `result.cycle_scores` (cycling)

--- a/docs/how-it-works/theory.md
+++ b/docs/how-it-works/theory.md
@@ -90,13 +90,13 @@ plain Seminario give identical results.
 QFUERZA is the default. To use plain Seminario projection instead:
 
 ```python
-from q2mm.models.seminario import estimate_force_constants
+from q2mm.models.seminario import qfuerza_fresh
 
 # Default — QFUERZA (recommended)
-ff = estimate_force_constants(molecule)
+ff = qfuerza_fresh(molecule)
 
 # Plain Seminario projection (no H-angle substitution)
-ff = estimate_force_constants(molecule, strategy="fuerza")
+ff = qfuerza_fresh(molecule, strategy="fuerza")
 ```
 
 The implementation lives in
@@ -165,8 +165,9 @@ eigenvalue replacement approach (J. Comput. Chem. 2015, 36, 244–250).
 | `invert_ts_curvature()` | `q2mm.models.hessian` | Decompose → replace negative eigenvalue → reconstruct |
 | `replace_neg_eigenvalue()` | `q2mm.models.hessian` | Low-level eigenvalue replacement |
 
-The `invert_ts_curvature` parameter in `estimate_force_constants()` controls
-whether curvature inversion is applied (default: `False`).
+The `invert_ts_curvature` parameter on both `qfuerza_fresh()` and
+`qfuerza_into()` controls whether curvature inversion is applied
+(default: `False`; published-FF system loaders pass `True` for TS systems).
 
 ---
 

--- a/docs/references.md
+++ b/docs/references.md
@@ -44,7 +44,7 @@ If you use Q2MM in your research, please cite the relevant publications below. C
 
 8. **Farrugia, M.; Helquist, P.; Norrby, P.-O.; Wiest, O.** Rapid FF Generation via Hessian-Informed Initial Parameters and Automated Refinement. *J. Chem. Theory Comput.* **2025**, *22*, 469–476. [DOI: 10.1021/acs.jctc.5c01751](https://doi.org/10.1021/acs.jctc.5c01751)
 
-    Builds on the Seminario/FUERZA projection method by substituting known-problematic force constants — particularly hydrogen angle bends, which Seminario overestimates by ~2× — with empirical defaults (0.5 mdyn·Å/rad²). QFUERZA is the default strategy for `estimate_force_constants()`. Starting from QFUERZA parameters leads to faster optimizer convergence and fewer local-minimum traps. Tested on cis-platinum (ground state) and Rh-enamide (transition state). See [theory](how-it-works/theory.md#stage-1-qfuerza-estimation).
+    Builds on the Seminario/FUERZA projection method by substituting known-problematic force constants — particularly hydrogen angle bends, which Seminario overestimates by ~2× — with empirical defaults (0.5 mdyn·Å/rad²). QFUERZA is the default strategy for `qfuerza_fresh()` and `qfuerza_into()`. Starting from QFUERZA parameters leads to faster optimizer convergence and fewer local-minimum traps. Tested on cis-platinum (ground state) and Rh-enamide (transition state). See [theory](how-it-works/theory.md#stage-1-qfuerza-estimation).
 
 ---
 

--- a/docs/systems/heck-relay.md
+++ b/docs/systems/heck-relay.md
@@ -64,9 +64,12 @@ complete failure of cross-engine transfer, not a small miss.
 ## Benchmark results
 
 !!! success "Loader bug fixed (ericchansen/q2mm#277) — Rosales FF now usable"
-    The previous loader silently re-ran `estimate_force_constants` on
-    the Rosales FF, which overwrote the published OPT parameters with
-    raw FUERZA projections.  In the three-baseline diagnostic
+    The previous loader silently re-ran QFUERZA (the old
+    ``estimate_force_constants(forcefield=ff)`` overload — since
+    deleted in favour of separate ``qfuerza_fresh`` / ``qfuerza_into``
+    APIs) on the Rosales FF, which overwrote the published OPT
+    parameters with raw FUERZA projections.  In the three-baseline
+    diagnostic
     (`q2mm-data/benchmarks/heck-relay/diagnostic/three_baseline_comparison.json`)
     the buggy combination collapsed bond_length R² to ≈ **−4787** for
     that run (the value is non-deterministic across runs because the
@@ -78,7 +81,7 @@ complete failure of cross-engine transfer, not a small miss.
 
 | Metric | Value |
 |--------|:-----:|
-| Ratio check | 1.29 (out_of_band; upper bound 1.15) |
+| Ratio check | 1.30 (out_of_band; upper bound 1.15) |
 | Initial ObjectiveFunction score | 3.46 × 10⁶ |
 | Optimization | Skipped at default `ratio_tol=0.15` (borderline — candidate for `ratio_tol=None`) |
 

--- a/docs/systems/pd-allyl.md
+++ b/docs/systems/pd-allyl.md
@@ -60,33 +60,29 @@ worse than simply predicting the average.
 
 ## Benchmark results
 
-SciPy L-BFGS-B with JaxLoss analytical gradients on RTX 5090 GPU.
-The ratio check passed, confirming JaxLoss as a reliable surrogate
-despite the poor Seminario starting FF.
+SciPy L-BFGS-B with JaxLoss analytical gradients.  After the loader
+API refactor that preserves the published Wahlers OPT values
+as-published (no QFUERZA overwrite), the ratio gate passes for
+pd-allyl.
 
 | Metric | Value |
 |--------|:-----:|
-| Ratio check | 1.09 (pass) |
-| Initial score | 8.02 × 10⁶ |
-| Final score | 8.00 × 10⁶ |
-| Reduction | 0.08 % |
-| Iterations / Evaluations | 2 / 2 |
+| Ratio check | 1.10 (pass) |
+| Initial score | 7.99 × 10⁶ |
+| Final score | TBD |
+| Reduction | TBD |
+| Iterations / Evaluations | TBD |
 | Gradient source | `jac="auto"` resolved to `jac_mode="jax_loss"` (JaxLoss analytical) |
-| Wall time | ~23 min (including per-molecule JIT) |
+| Wall time | TBD |
 
 These numbers are reproducible from `scripts/regenerate_convergence_results.py`
 (no `--skip-optimization`); raw JSON output with provenance lives at
 [`q2mm-data/benchmarks/pd-allyl-amination/convergence/`](https://github.com/ericchansen/q2mm-data/tree/main/benchmarks/pd-allyl-amination/convergence).
 
-The modest 0.08 % improvement reflects the poor Seminario starting
-point (eig_diagonal R² ≈ −1.4): SciPy reports convergence
-(`CONVERGENCE: RELATIVE REDUCTION OF F <= FACTR*EPSMCH`) after 2
-iterations / 2 evaluations, with a non-finite JaxLoss penalty observed
-during the run (a known limitation of the per-molecule JIT path at 482
-active parameters when the parameter step is too large).  Improving
-further would likely require a hybrid FD/JaxLoss strategy or tighter
-bounds; the modest gain still represents a real ObjectiveFunction
-reduction.
+The post-optimization rows are TBD pending an end-to-end run against
+the refactored loader.  A prior baseline reported a 0.08 % reduction
+on an FF whose OPT values had been QFUERZA-overwritten; that result
+is not reproducible against the current loader.
 
 See [Optimizer Comparison](../benchmarks/optimizer-comparison.md) for
 cross-system comparison and methodology details.

--- a/docs/systems/pd-conjugate.md
+++ b/docs/systems/pd-conjugate.md
@@ -58,25 +58,32 @@ complete failure of cross-engine transfer, not a small miss.
 
 ## Benchmark results
 
-!!! warning "Ratio check failed — optimization skipped"
-    The JaxLoss/ObjectiveFunction ratio (most recent regeneration: 1.20)
-    is just outside the [0.85, 1.15] tolerance.  JaxLoss is not yet a
-    reliable surrogate for this system at the Seminario starting point.
+!!! success "Ratio gate now passes — loader API refactor"
+    After the loader API refactor that stopped overwriting Wahlers OPT
+    values with raw QFUERZA projections, the JaxLoss/ObjectiveFunction
+    ratio for pd-conjugate is 0.96 — comfortably inside the
+    [0.85, 1.15] band.  JaxLoss-guided optimization is now possible.
 
 | Metric | Value |
 |--------|:-----:|
-| Ratio check | 1.20 (out_of_band; upper bound is 1.15) |
-| Initial ObjectiveFunction score | 8.26 × 10⁶ |
-| Optimization | Skipped at default `ratio_tol=0.15` |
+| Ratio check | 0.96 (in_band) |
+| Initial ObjectiveFunction score | 8.79 × 10⁶ |
+| Optimization | TBD pending end-to-end run against the refactored loader |
 
-**Why it fails:** The Seminario starting FF has negative eigenvalue R²
-for all 10 molecules (eig_diagonal R² ≈ −4.5).  Unconstrained geometry
-relaxation finds different local minima in JaxLoss vs ObjectiveFunction,
-producing divergent loss values.  Because the ratio (1.20) is only
-just outside the upper bound (1.15) — vs orders of magnitude for
-[Rh 1,4-conjugate](rh-conjugate.md) and [Heck relay](heck-relay.md) —
-this system is a candidate for the `ratio_tol=None` bypass (see
-Optimizer Comparison for the experimental status).
+Per-category fit of the published Wahlers force field against the QM
+training data (no QFUERZA — these are the published OPT values
+evaluated by the q2mm JAX engine):
+
+| Category | n_refs | R² | RMSD |
+|----------|-------:|----:|-----:|
+| bond_length | 473 | 0.939 | — |
+| bond_angle | 892 | −0.177 | — |
+| eig_diagonal | 1296 | −10.06 | — |
+
+Geometry reproduction is now strong (bond_length R² ≈ 0.94); the
+eigenmatrix R² is still negative, reflecting the same MM3* ↔ JAX-engine
+cross-engine gap that affects all Wahlers / Rosales systems but not
+rh-enamide.
 
 See [Optimizer Comparison](../benchmarks/optimizer-comparison.md) for
 cross-system comparison and methodology details.  Raw numbers are in the

--- a/docs/systems/rh-conjugate.md
+++ b/docs/systems/rh-conjugate.md
@@ -57,31 +57,37 @@ complete failure of cross-engine transfer, not a small miss.
 
 ## Benchmark results
 
-!!! warning "Ratio check failed — optimization skipped"
-    The JaxLoss/ObjectiveFunction ratio is out of the [0.85, 1.15]
-    tolerance (most recent regeneration: ratio ≈ 4.6 × 10³,
-    `ratio_status = "out_of_band"`).  JaxLoss is not a reliable
-    surrogate for this system at the Seminario starting point.
+!!! success "Ratio gate now passes — loader API refactor"
+    The pre-refactor loader silently overwrote the Wahlers OPT
+    parameters with raw QFUERZA projections, sending JaxLoss's inner
+    geometry minimization into pathological regions and producing
+    ratios that varied wildly across runs (0.46 / 0.96 / ~4 × 10³ in
+    successive sessions).  After the loader API refactor that
+    preserves the published OPT values as-is, the ratio is 1.04 —
+    comfortably inside the [0.85, 1.15] band.  JaxLoss-guided
+    optimization is now possible.
 
 | Metric | Value |
 |--------|:-----:|
-| Ratio check | ≈ 4.6 × 10³ (out_of_band) |
-| Initial ObjectiveFunction score | 2.21 × 10⁷ |
-| Optimization | Skipped |
+| Ratio check | 1.04 (in_band) |
+| Initial ObjectiveFunction score | 6.42 × 10⁶ |
+| Optimization | TBD pending end-to-end run against the refactored loader |
 
-**Why it fails:** The Seminario starting FF has deeply negative R² for
-all 10 molecules (bond_length R² ≈ −58, bond_angle R² ≈ −1.3,
-eig_diagonal R² ≈ −4.8).  The MM PES that comes out of the
-inverted-Hessian Seminario projection is so far from the QM
-geometries that the inner geometry minimization inside JaxLoss lands
-in unphysical local minima — the resulting JaxLoss value is many
-orders of magnitude larger than the ObjectiveFunction.
+Per-category fit of the published Wahlers force field against the QM
+training data (no QFUERZA — these are the published OPT values
+evaluated by the q2mm JAX engine):
 
-This is **not** a JaxLoss bug; the ratio gate is correctly identifying
-that the surrogate is unreliable for this parameter regime.  The root
-cause is the poor starting FF — the published Wahlers force field
-relies on a base MM3 layer that does not transfer cleanly under
-JaxEngine, and Seminario alone cannot recover from that.
+| Category | n_refs | R² |
+|----------|-------:|----:|
+| bond_length | 457 | 0.891 |
+| bond_angle | 926 | 0.454 |
+| eig_diagonal | 1254 | −7.86 |
+
+The dramatic improvement vs the pre-refactor numbers (where
+bond_length R² was −58) is the loss of the QFUERZA overwrite that
+was destroying the published Wahlers fit.  The eigenmatrix R² is
+still negative, reflecting the same MM3* ↔ JAX-engine cross-engine
+gap that affects all Wahlers systems.
 
 See [Optimizer Comparison](../benchmarks/optimizer-comparison.md) for
 the cross-system comparison.  Raw numbers are in the

--- a/docs/systems/rh-enamide.md
+++ b/docs/systems/rh-enamide.md
@@ -86,23 +86,31 @@ gradients on RTX 5090 GPU:
 
 | Metric | Value |
 |--------|:-----:|
-| Ratio check | 1.05 (pass) |
-| Initial score | 3.92 × 10⁵ |
-| Final score | 2.80 × 10⁵ |
-| Reduction | 28.68 % |
-| Iterations (L-BFGS-B `nit`) | 6 |
-| ObjectiveFunction evaluations | 2 (initial + final re-evaluation; JaxLoss calls scipy via the surrogate, not via `ObjectiveFunction`) |
+| Ratio check | 1.07 (pass) |
+| Initial score | 4.87 × 10⁵ |
+| Final score | TBD |
+| Reduction | TBD |
+| Iterations (L-BFGS-B `nit`) | TBD |
+| ObjectiveFunction evaluations | TBD |
 | Gradient source | `jac="auto"` resolved to `jac_mode="jax_loss"` (JaxLoss analytical) |
-| Wall time | ~11 min (including per-molecule JIT) |
+| Wall time | TBD |
+
+The post-optimization rows are pending a fresh end-to-end run
+against the refactored loader.  The earlier "28.68 % reduction"
+number that appeared here came from a force field whose Donoghue
+OPT values had been overwritten by QFUERZA — the loader API
+refactor preserves those values as-published, so the absolute
+optimization headroom is smaller (the starting point is closer to
+the optimum).
 
 These numbers are reproducible from `scripts/regenerate_convergence_results.py`
 (no `--skip-optimization`); raw JSON output with provenance lives at
 [`q2mm-data/benchmarks/rh-enamide/convergence/`](https://github.com/ericchansen/q2mm-data/tree/main/benchmarks/rh-enamide/convergence).
 
 The ratio check confirms JaxLoss is a reliable surrogate for this
-system — the Seminario starting FF is good enough (R² > 0.93 in every
-category) that unconstrained geometry relaxation finds the correct
-local minima.
+system — the published Donoghue OPT values reproduce QM geometry well
+(R² > 0.96 across categories) so unconstrained geometry relaxation
+finds the correct local minima.
 
 ### Historical frequency-only results
 
@@ -135,7 +143,12 @@ MacroModel to reach its final fit.[^qfuerza]
 
 The multi-target optimization pipeline runs end-to-end on this
 9-molecule system (per-molecule JIT compilation, scipy L-BFGS-B with
-JaxLoss analytical gradients) and achieves 28.68 % loss reduction.
+JaxLoss analytical gradients).  An earlier baseline reported a
+28.68 % loss reduction; that result depended on an FF whose Donoghue
+OPT values had been overwritten by QFUERZA.  The current loader API
+preserves the published OPT values, so optimization headroom is
+smaller and the post-optimization Δ% will be lower (TBD pending the
+next end-to-end run).
 
 ### Gap analysis
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -350,10 +350,12 @@ without running a single MM calculation.
 ???+ example "Quick start — auto-create and estimate"
 
     ```python
-    from q2mm.models.seminario import estimate_force_constants
+    from q2mm.models.seminario import qfuerza_fresh
 
-    # estimate_force_constants accepts a single molecule or a list
-    ff = estimate_force_constants(
+    # qfuerza_fresh accepts a single molecule and builds a fresh FF from
+    # its QM Hessian.  For multi-molecule averaging (with a template FF
+    # whose frozen partition is preserved), use qfuerza_into instead.
+    ff = qfuerza_fresh(
         mol,
         zero_torsions=True,    # set torsion barriers to zero (common for TS)
         au_hessian=True,       # Hessian is in Hartree/Bohr²
@@ -375,20 +377,25 @@ without running a single MM calculation.
 ???+ example "With an existing force field template"
 
     If you already have an MM3 `.fld` file with initial guesses (or placeholder
-    values), pass it so QFUERZA updates the force constants in place while
-    preserving atom types and row numbers:
+    values), use ``qfuerza_into`` to update the unfrozen parameters in place
+    while preserving atom types and row numbers.  Any parameters that the
+    caller has frozen (e.g. via ``ForceField.freeze_standard_params``) are
+    left untouched — see Farrugia 2025 for the "mixing literature + custom
+    params" workflow this enables.
 
     ```python
     from q2mm.models.forcefield import ForceField
-    from q2mm.models.seminario import estimate_force_constants
+    from q2mm.models.seminario import qfuerza_into
 
     # Load template with initial guesses (replace with your .fld path)
     initial_ff = ForceField.from_mm3_fld("my-system.fld")
 
-    # QFUERZA updates force constants, keeps equilibrium values and metadata
-    estimated_ff = estimate_force_constants(
+    # Make a working copy so the template isn't mutated, then overwrite
+    # every unfrozen parameter's value with the QFUERZA projection.
+    estimated_ff = initial_ff.copy()
+    qfuerza_into(
+        estimated_ff,
         mol,
-        forcefield=initial_ff,
         zero_torsions=True,
         au_hessian=True,
         invalid_policy="skip",
@@ -944,7 +951,7 @@ from pathlib import Path
 
 from q2mm.models.molecule import Q2MMMolecule
 from q2mm.models.forcefield import ForceField
-from q2mm.models.seminario import estimate_force_constants
+from q2mm.models.seminario import qfuerza_fresh
 from q2mm.optimizers.objective import ObjectiveFunction, ReferenceData
 from q2mm.optimizers.scipy_opt import ScipyOptimizer
 
@@ -964,7 +971,7 @@ print(f"Loaded: {mol.n_atoms} atoms, {len(mol.bonds)} bonds, "
       f"{len(mol.angles)} angles")
 
 # ── Step 2: QFUERZA estimation ──────────────────────────────────
-ff = estimate_force_constants(
+ff = qfuerza_fresh(
     mol,
     zero_torsions=True,
     au_hessian=True,

--- a/examples/rh-enamide/README.md
+++ b/examples/rh-enamide/README.md
@@ -40,7 +40,7 @@ Master files: `rh_enamide_training_set.mae`, `.mol2`, `.mmo`
 ```python
 from q2mm.models.molecule import Q2MMMolecule
 from q2mm.models.forcefield import ForceField
-from q2mm.models.seminario import estimate_force_constants
+from q2mm.models.seminario import qfuerza_into
 
 # Load a structure with its QM Hessian
 mol = Q2MMMolecule.from_xyz("rh_enamide_training_set/raw_xyz/1_zdmp.xyz")
@@ -48,8 +48,10 @@ mol = Q2MMMolecule.from_xyz("rh_enamide_training_set/raw_xyz/1_zdmp.xyz")
 # Load the starting force field
 ff = ForceField.from_mm3_fld("mm3.fld")
 
-# Estimate force constants from the QM Hessian
-estimated_ff = estimate_force_constants(mol, forcefield=ff, au_hessian=True)
+# Overwrite all unfrozen params with QFUERZA-projected values.
+# Frozen params (the standard MM3 backbone if you call
+# ff.freeze_standard_params first) are preserved as-is.
+qfuerza_into(ff, mol, au_hessian=True)
 ```
 
 ## See also

--- a/examples/sn2-test/demo_pipeline.py
+++ b/examples/sn2-test/demo_pipeline.py
@@ -10,7 +10,7 @@ logging.basicConfig(level=logging.INFO, format="%(message)s")
 
 from q2mm.models.molecule import Q2MMMolecule
 from q2mm.models.forcefield import ForceField
-from q2mm.models.seminario import estimate_force_constants
+from q2mm.models.seminario import qfuerza_fresh
 
 QM_REF = Path(__file__).parent / "qm-reference"
 
@@ -37,7 +37,7 @@ for a in ff.angles:
 print("\n" + "=" * 60)
 print("Running QFUERZA estimation...")
 print("=" * 60)
-estimated_ff = estimate_force_constants(mol)
+estimated_ff = qfuerza_fresh(mol)
 
 print(f"\n{'=' * 60}")
 print("RESULTS: Estimated Force Constants from QM Hessian")

--- a/examples/sn2-test/run_tsff_pipeline.py
+++ b/examples/sn2-test/run_tsff_pipeline.py
@@ -14,7 +14,7 @@ sys.path.insert(0, str(REPO_ROOT))
 from q2mm.models.hessian import decompose, reform_hessian
 from q2mm.models.forcefield import ForceField
 from q2mm.models.molecule import Q2MMMolecule
-from q2mm.models.seminario import estimate_force_constants
+from q2mm.models.seminario import qfuerza_into
 
 QM_REF = Path(__file__).parent / "qm-reference"
 
@@ -132,13 +132,8 @@ def main() -> None:
     # ------------------------------------------------------------------
     print("\n[4/5] Running QFUERZA estimation...")
 
-    estimated_ff = estimate_force_constants(
-        molecule,
-        forcefield=initial_ff,
-        zero_torsions=True,
-        au_hessian=True,
-        invalid_policy="skip",
-    )
+    estimated_ff = initial_ff.copy()
+    qfuerza_into(estimated_ff, molecule, zero_torsions=True, au_hessian=True, invalid_policy="skip")
 
     print("  QFUERZA estimation completed successfully.")
     print("  Negative or complex TS estimates are skipped to preserve legacy semantics.")

--- a/q2mm/__init__.py
+++ b/q2mm/__init__.py
@@ -17,7 +17,7 @@ except Exception:
 # Public API — the most commonly used classes at the top level
 from q2mm.models.molecule import Q2MMMolecule  # noqa: E402
 from q2mm.models.forcefield import ForceField, BondParam, AngleParam  # noqa: E402
-from q2mm.models.seminario import estimate_force_constants  # noqa: E402
+from q2mm.models.seminario import qfuerza_fresh, qfuerza_into  # noqa: E402
 from q2mm.optimizers.objective import ReferenceData, ObjectiveFunction  # noqa: E402
 
 __all__ = [
@@ -25,7 +25,8 @@ __all__ = [
     "ForceField",
     "BondParam",
     "AngleParam",
-    "estimate_force_constants",
+    "qfuerza_fresh",
+    "qfuerza_into",
     "ReferenceData",
     "ObjectiveFunction",
     "__version__",

--- a/q2mm/diagnostics/__init__.py
+++ b/q2mm/diagnostics/__init__.py
@@ -13,14 +13,14 @@ from q2mm.diagnostics.benchmark import (
 )
 from q2mm.diagnostics.pes_distortion import compute_distortions, load_normal_modes
 from q2mm.diagnostics.report import detailed_report, full_report
-from q2mm.diagnostics.systems import SYSTEMS, BenchmarkSystem, SystemData
+from q2mm.diagnostics.systems import SYSTEMS, SystemData, SystemSpec, load_system
 from q2mm.diagnostics.tables import TablePrinter
 
 __all__ = [
     "BenchmarkResult",
-    "BenchmarkSystem",
     "SYSTEMS",
     "SystemData",
+    "SystemSpec",
     "TablePrinter",
     "compute_distortions",
     "detailed_report",
@@ -28,6 +28,7 @@ __all__ = [
     "frequency_rmsd",
     "full_report",
     "load_normal_modes",
+    "load_system",
     "real_frequencies",
     "run_combo",
 ]

--- a/q2mm/diagnostics/cli.py
+++ b/q2mm/diagnostics/cli.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from q2mm.diagnostics.benchmark import BenchmarkResult
-    from q2mm.diagnostics.systems import BenchmarkSystem
+    from q2mm.diagnostics.systems import SystemSpec
 
 
 def _discover_backends() -> list[tuple[str, type, str]]:
@@ -117,14 +117,14 @@ def _functional_form_configs() -> list[tuple[str, str]]:
     ]
 
 
-def _resolve_system(system_key: str) -> BenchmarkSystem:
+def _resolve_system(system_key: str) -> SystemSpec:
     """Look up a benchmark system by key.
 
     Args:
         system_key: System name (e.g. ``"ch3f"``, ``"rh-enamide"``).
 
     Returns:
-        BenchmarkSystem: The system configuration.
+        SystemSpec: The system configuration.
 
     Raises:
         SystemExit: If the system is not registered.
@@ -225,13 +225,17 @@ def _run_matrix(
 
             # Reload system data per-form (reference data depends on form)
             try:
-                loader_kwargs: dict[str, Any] = {"functional_form": form_value}
-                if system_key == "ch3f" and data_dir is not None:
-                    from q2mm.diagnostics.systems import load_ch3f
+                from q2mm.diagnostics.systems import load_system
 
-                    sys_data = load_ch3f(engine, data_dir=data_dir, **loader_kwargs)
-                else:
-                    sys_data = system_cfg.loader(engine, **loader_kwargs)
+                molecule_loader_kwargs: dict[str, Any] | None = None
+                if system_key == "ch3f" and data_dir is not None:
+                    molecule_loader_kwargs = {"data_dir": data_dir}
+                sys_data = load_system(
+                    system_key,
+                    engine=engine,
+                    functional_form=form_value,
+                    molecule_loader_kwargs=molecule_loader_kwargs,
+                )
             except Exception as e:
                 print(
                     f"  Skipping {backend_name}/{form_label}: cannot load {system_key} data: {e}",

--- a/q2mm/diagnostics/systems.py
+++ b/q2mm/diagnostics/systems.py
@@ -145,7 +145,7 @@ def load_ch3f(
 
     """
     from q2mm.models.molecule import Q2MMMolecule
-    from q2mm.models.seminario import estimate_force_constants
+    from q2mm.models.seminario import qfuerza_fresh
 
     qm_dir = data_dir or _find_ch3f_data_dir()
     xyz = qm_dir / "ch3f-optimized.xyz"
@@ -158,7 +158,7 @@ def load_ch3f(
     qm_hessian = np.load(hess_path)
 
     mol_h = molecule.with_hessian(qm_hessian)
-    ff = estimate_force_constants(mol_h, invert_ts_curvature=True)
+    ff = qfuerza_fresh(mol_h, invert_ts_curvature=True)
 
     if functional_form is not None:
         from q2mm.models.forcefield import FunctionalForm
@@ -264,7 +264,7 @@ def load_rh_enamide(
 
     """
     from q2mm.models.forcefield import ForceField, FunctionalForm
-    from q2mm.models.seminario import estimate_force_constants
+    from q2mm.models.seminario import qfuerza_into
     from q2mm.optimizers.objective import ReferenceData
 
     mm3_path = _RH_DIR / "mm3.fld"
@@ -275,7 +275,8 @@ def load_rh_enamide(
     ff_template = ForceField.from_mm3_fld(str(mm3_path), include_standard=True)
     ff_opt = ForceField.from_mm3_fld(str(mm3_path), include_standard=False)
     ff_template.freeze_standard_params(ff_opt)
-    ff = estimate_force_constants(molecules, forcefield=ff_template, invert_ts_curvature=True)
+    ff = ff_template.copy()
+    qfuerza_into(ff, molecules, invert_ts_curvature=True)
 
     # Set functional form: explicit override > default (mm3)
     if functional_form is not None:
@@ -339,7 +340,7 @@ def load_heck_relay(
     The published Rosales OPT parameters are used **as-is** — they are
     the result of the original MacroModel MM3* fit and reproduce the
     QM geometry well (bond_length R² ≈ 0.98 untouched).  Earlier
-    versions of this loader re-ran ``estimate_force_constants`` on the
+    versions of this loader re-ran `qfuerza_fresh` / `qfuerza_into` on the
     Rosales FF, which silently overwrote the OPT parameters with raw
     Seminario projections and dropped bond_length R² to ≈ −4787.  See
     ericchansen/q2mm#277 for the three-baseline diagnostic.
@@ -364,7 +365,7 @@ def load_heck_relay(
     ff = ForceField.from_mm3_fld(str(ff_path), include_standard=True)
     # Mark only the OPT-substructure parameters as active for downstream
     # optimization; standard MM3 backbone params remain frozen.  Do NOT
-    # call estimate_force_constants here — see #277 (it would overwrite
+    # call qfuerza_into here — see #277 (it would overwrite
     # the Rosales-fitted OPT values with raw Seminario projections).
     ff_opt = ForceField.from_mm3_fld(str(ff_path), include_standard=False)
     ff.freeze_standard_params(ff_opt)
@@ -559,7 +560,7 @@ def _load_wahlers_system(
     composes them with the standard MM3 base to produce a complete FF.
     """
     from q2mm.models.forcefield import ForceField, FunctionalForm
-    from q2mm.models.seminario import estimate_force_constants
+    from q2mm.models.seminario import qfuerza_into
     from q2mm.optimizers.objective import ReferenceData
 
     si = _resolve_supporting_info_dir()
@@ -615,7 +616,8 @@ def _load_wahlers_system(
                 )
 
     composed.freeze_standard_params(opt_ff)
-    ff = estimate_force_constants(molecules, forcefield=composed, invert_ts_curvature=True)
+    ff = composed.copy()
+    qfuerza_into(ff, molecules, invert_ts_curvature=True)
 
     if functional_form is not None:
         ff.functional_form = FunctionalForm(functional_form)

--- a/q2mm/diagnostics/systems.py
+++ b/q2mm/diagnostics/systems.py
@@ -1,15 +1,23 @@
 """Benchmark system configurations.
 
-Each :class:`BenchmarkSystem` describes a molecular system with its reference
-data, force field template, and metadata.  The :data:`SYSTEMS` registry maps
-system names to their configs, making it easy to add new benchmark targets.
+Each :class:`SystemSpec` declaratively describes one benchmark system —
+its molecule source, FF-assembly strategy, and metadata — and the
+:data:`SYSTEMS` registry maps a CLI key to that spec.  The single
+public entry point is :func:`load_system`, which dispatches to the
+right molecule loader and the right FF strategy based on the spec.
+
+Adding a new system = appending a :class:`SystemSpec` entry to
+:data:`SYSTEMS`; no new module-level function is required.
 
 Usage::
 
-    from q2mm.diagnostics.systems import SYSTEMS, BenchmarkSystem
+    from q2mm.diagnostics.systems import load_system, SYSTEMS
 
-    system = SYSTEMS["rh-enamide"]
-    sys_data = system.loader(engine)
+    sys_data = load_system("rh-enamide", engine=engine)
+
+The FF-assembly strategies live in :mod:`q2mm.models.loaders` and
+correspond to the published-FF workflows in Farrugia, Helquist, Norrby
+& Wiest 2025 (the QFUERZA paper — see AGENTS.md "Key Papers").
 """
 
 from __future__ import annotations
@@ -17,8 +25,8 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
-from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Literal
+from collections.abc import Callable, Mapping
 
 import numpy as np
 
@@ -100,17 +108,6 @@ def _build_frequency_reference(
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 
-# Published metal vdW parameters for systems where the base FF lacks them.
-# Source: Rosales Heck FF (mm3.FF1.fld:1063) for PD.
-def _metal_vdw_registry() -> dict[str, Any]:
-    """Lazy-import VdwParam to avoid circular imports at module level."""
-    from q2mm.models.forcefield import VdwParam
-
-    return {
-        "PD": VdwParam(atom_type="PD", radius=1.70, epsilon=0.414, element="Pd"),
-    }
-
-
 def _find_ch3f_data_dir() -> Path:
     """Locate CH3F reference data directory."""
     candidates = [
@@ -122,76 +119,6 @@ def _find_ch3f_data_dir() -> Path:
             return d
     raise FileNotFoundError(
         "Cannot find CH3F reference data (ch3f-optimized.xyz). Run from the repo root or use --data-dir."
-    )
-
-
-def load_ch3f(
-    engine: Any,
-    *,
-    data_dir: Path | None = None,
-    functional_form: str | None = None,
-) -> SystemData:
-    """Load the CH3F benchmark system.
-
-    Args:
-        engine: MM engine instance (used for frequency computation).
-        data_dir: Override for the QM reference data directory.
-        functional_form: Override functional form (e.g. ``"harmonic"``,
-            ``"mm3"``).  When ``None``, the form is left unset and the
-            engine uses its native default.
-
-    Returns:
-        SystemData with a single CH3F molecule.
-
-    """
-    from q2mm.models.molecule import Q2MMMolecule
-    from q2mm.models.seminario import qfuerza_fresh
-
-    qm_dir = data_dir or _find_ch3f_data_dir()
-    xyz = qm_dir / "ch3f-optimized.xyz"
-    hess_path = qm_dir / "ch3f-hessian.npy"
-    freqs_path = qm_dir / "ch3f-frequencies.txt"
-    modes_path = qm_dir / "ch3f-normal-modes.npz"
-
-    molecule = Q2MMMolecule.from_xyz(xyz, bond_tolerance=1.5)
-    qm_freqs_all = np.loadtxt(freqs_path)
-    qm_hessian = np.load(hess_path)
-
-    mol_h = molecule.with_hessian(qm_hessian)
-    ff = qfuerza_fresh(mol_h, invert_ts_curvature=True)
-
-    if functional_form is not None:
-        from q2mm.models.forcefield import FunctionalForm
-
-        ff.functional_form = FunctionalForm(functional_form)
-
-    mm_all = engine.frequencies(molecule, ff)
-    freq_ref, qm_real = _build_frequency_reference(qm_freqs_all, mm_all)
-
-    # Load normal modes for PES distortion analysis (optional)
-    normal_modes = None
-    if modes_path.exists():
-        from q2mm.diagnostics.pes_distortion import load_normal_modes
-
-        normal_modes = load_normal_modes(modes_path)
-
-    # Resolve functional form for metadata: explicit override > ff value
-    resolved_form = functional_form
-    if resolved_form is None and ff.functional_form is not None:
-        resolved_form = ff.functional_form.value
-
-    return SystemData(
-        molecules=[molecule],
-        forcefield=ff,
-        reference=freq_ref,
-        qm_freqs_per_mol=[qm_real],
-        metadata={
-            "molecule_name": "CH3F",
-            "level_of_theory": "B3LYP/6-31+G(d)",
-            "n_atoms": len(molecule.symbols),
-            **({"functional_form": resolved_form} if resolved_form else {}),
-        },
-        normal_modes=normal_modes,
     )
 
 
@@ -247,66 +174,6 @@ def load_rh_enamide_molecules() -> list[Q2MMMolecule]:
     return molecules
 
 
-def load_rh_enamide(
-    engine: Any,
-    *,
-    functional_form: str | None = None,
-) -> SystemData:
-    """Load the Rh-enamide benchmark system (9 molecules).
-
-    Args:
-        engine: MM engine instance (accepted for loader interface compatibility).
-        functional_form: Override functional form (e.g. ``"harmonic"``,
-            ``"mm3"``).  Defaults to ``"mm3"`` since the template is MM3.
-
-    Returns:
-        SystemData with 9 Rh-enamide molecules and multi-target references.
-
-    """
-    from q2mm.models.forcefield import ForceField, FunctionalForm
-    from q2mm.models.seminario import qfuerza_into
-    from q2mm.optimizers.objective import ReferenceData
-
-    mm3_path = _RH_DIR / "mm3.fld"
-    if not mm3_path.exists():
-        raise FileNotFoundError(f"Rh-enamide force field not found: {mm3_path}")
-
-    molecules = load_rh_enamide_molecules()
-    ff_template = ForceField.from_mm3_fld(str(mm3_path), include_standard=True)
-    ff_opt = ForceField.from_mm3_fld(str(mm3_path), include_standard=False)
-    ff_template.freeze_standard_params(ff_opt)
-    ff = ff_template.copy()
-    qfuerza_into(ff, molecules, invert_ts_curvature=True)
-
-    # Set functional form: explicit override > default (mm3)
-    if functional_form is not None:
-        ff.functional_form = FunctionalForm(functional_form)
-    else:
-        ff.functional_form = FunctionalForm.MM3
-
-    qm_freqs_per_mol = []
-    for mol in molecules:
-        qm_freqs = _qm_frequencies_from_hessian(mol.hessian, mol.symbols)
-        qm_real = np.array(sorted(f for f in qm_freqs if f > 50.0))
-        qm_freqs_per_mol.append(qm_real)
-
-    reference = ReferenceData.from_molecules(molecules, eigenmatrix_diagonal_only=True)
-
-    return SystemData(
-        molecules=molecules,
-        forcefield=ff,
-        reference=reference,
-        qm_freqs_per_mol=qm_freqs_per_mol,
-        metadata={
-            "molecule_name": "Rh-enamide",
-            "level_of_theory": "B3LYP/LACVP**",
-            "n_molecules": len(molecules),
-            "n_atoms_per_mol": [len(m.symbols) for m in molecules],
-            "functional_form": functional_form or "mm3",
-        },
-    )
-
-
 # ---------------------------------------------------------------------------
 # Heck relay (Rosales 2020, JACS 142, 9700)
 # ---------------------------------------------------------------------------
@@ -325,79 +192,6 @@ def load_heck_relay_molecules() -> list[Q2MMMolecule]:
     si = _resolve_supporting_info_dir()
     ts_dir = si / "rosales" / "Rosales_Anthony_Supporting_Information" / "Chapter3_Heck" / "TrainingSet"
     return _load_gaussian_molecules(ts_dir)
-
-
-def load_heck_relay(
-    engine: Any,
-    *,
-    functional_form: str | None = None,
-) -> SystemData:
-    """Load the Heck relay benchmark system (23 TS molecules).
-
-    Uses the published FF from Rosales et al. *JACS* 2020, 142, 9700-9707.
-    Training set: 23 Gaussian 09 logs with HPModes frequency data.
-
-    The published Rosales OPT parameters are used **as-is** — they are
-    the result of the original MacroModel MM3* fit and reproduce the
-    QM geometry well (bond_length R² ≈ 0.98 untouched).  Earlier
-    versions of this loader re-ran `qfuerza_fresh` / `qfuerza_into` on the
-    Rosales FF, which silently overwrote the OPT parameters with raw
-    Seminario projections and dropped bond_length R² to ≈ −4787.  See
-    ericchansen/q2mm#277 for the three-baseline diagnostic.
-
-    Args:
-        engine: MM engine instance (accepted for loader interface compatibility).
-        functional_form: Override functional form.  Defaults to ``"mm3"``.
-
-    Returns:
-        SystemData with 23 Heck TS molecules and multi-target references.
-
-    """
-    from q2mm.models.forcefield import ForceField, FunctionalForm
-    from q2mm.optimizers.objective import ReferenceData
-
-    si = _resolve_supporting_info_dir()
-    ff_path = si / "rosales" / "Rosales_Anthony_Supporting_Information" / "Chapter3_Heck" / "mm3.FF1.fld"
-    if not ff_path.exists():
-        raise FileNotFoundError(f"Heck relay FF not found: {ff_path}")
-
-    molecules = load_heck_relay_molecules()
-    ff = ForceField.from_mm3_fld(str(ff_path), include_standard=True)
-    # Mark only the OPT-substructure parameters as active for downstream
-    # optimization; standard MM3 backbone params remain frozen.  Do NOT
-    # call qfuerza_into here — see #277 (it would overwrite
-    # the Rosales-fitted OPT values with raw Seminario projections).
-    ff_opt = ForceField.from_mm3_fld(str(ff_path), include_standard=False)
-    ff.freeze_standard_params(ff_opt)
-
-    if functional_form is not None:
-        ff.functional_form = FunctionalForm(functional_form)
-    else:
-        ff.functional_form = FunctionalForm.MM3
-
-    qm_freqs_per_mol = []
-    for mol in molecules:
-        qm_freqs = _qm_frequencies_from_hessian(mol.hessian, mol.symbols)
-        qm_real = np.array(sorted(f for f in qm_freqs if f > 50.0))
-        qm_freqs_per_mol.append(qm_real)
-
-    reference = ReferenceData.from_molecules(molecules, eigenmatrix_diagonal_only=True)
-
-    return SystemData(
-        molecules=molecules,
-        forcefield=ff,
-        reference=reference,
-        qm_freqs_per_mol=qm_freqs_per_mol,
-        metadata={
-            "molecule_name": "Heck relay",
-            "level_of_theory": "M06/gen+pseudo (GD3)",
-            "n_molecules": len(molecules),
-            "n_atoms_per_mol": [len(m.symbols) for m in molecules],
-            "functional_form": functional_form or "mm3",
-            "publication": "Rosales et al. JACS 2020, 142, 9700",
-            "doi": "10.1021/jacs.0c01979",
-        },
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -542,153 +336,271 @@ def _assign_mm3_atom_types(mol: Any) -> None:
         mol.atom_types[i] = mm3_type
 
 
-def _load_wahlers_system(
-    chapter_dir: str,
-    ff_filename: str,
-    engine: Any,
-    *,
-    system_name: str,
-    level_of_theory: str = "M06/gen+pseudo (GD3)",
-    publication: str = "",
-    doi: str = "",
-    functional_form: str | None = None,
-    metal: str | None = None,
-) -> SystemData:
-    """Load a Wahlers dissertation system with FF composition.
+# ---------------------------------------------------------------------------
+# Wahlers-system molecule loaders
+# ---------------------------------------------------------------------------
 
-    Wahlers FFs are standalone OPT-substructure-only files.  This loader
-    composes them with the standard MM3 base to produce a complete FF.
-    """
-    from q2mm.models.forcefield import ForceField, FunctionalForm
-    from q2mm.models.seminario import qfuerza_into
-    from q2mm.optimizers.objective import ReferenceData
 
+def _load_wahlers_molecules(chapter_subdir: str) -> list[Q2MMMolecule]:
+    """Load Wahlers-dissertation Gaussian molecules from a chapter subdirectory."""
     si = _resolve_supporting_info_dir()
-    wahlers_base = si / "wahlers" / "Wahlers_Jessica_Supporting_information"
-    chapter = wahlers_base / chapter_dir
-
-    # Load training set
+    chapter = si / "wahlers" / "Wahlers_Jessica_Supporting_information" / chapter_subdir
     ts_dir = chapter / "Training Set Structures"
     if not ts_dir.exists():
         ts_dir = chapter / "DFT-optmized training set structures"
-    molecules = _load_gaussian_molecules(ts_dir)
+    return _load_gaussian_molecules(ts_dir)
 
-    # Compose FF: standard base + Wahlers OPT overlay.
-    # The base file (mm3_base.fld) is not committed due to copyright.
-    # Fall back to the rh-enamide mm3.fld which includes the same base section.
-    mm3_base_path = _REPO_ROOT / "validation" / "published_ffs" / "mm3_base.fld"
-    if not mm3_base_path.exists():
-        mm3_base_path = _REPO_ROOT / "examples" / "rh-enamide" / "mm3.fld"
-    if not mm3_base_path.exists():
-        raise FileNotFoundError(
-            "MM3 base force field not found. Place mm3_base.fld in "
-            "validation/published_ffs/ (download from atlas-nano/ATLAS_toolkit) "
-            "or ensure examples/rh-enamide/mm3.fld exists."
-        )
-    base_ff = ForceField.from_mm3_fld(str(mm3_base_path))
-    opt_ff = ForceField.from_mm3_fld(str(chapter / ff_filename), include_standard=False)
 
-    composed = ForceField(
-        bonds=list(opt_ff.bonds) + list(base_ff.bonds),
-        angles=list(opt_ff.angles) + list(base_ff.angles),
-        torsions=list(opt_ff.torsions) + list(base_ff.torsions),
-        vdws=list(opt_ff.vdws) + list(base_ff.vdws),
-        stretch_bends=list(opt_ff.stretch_bends) + list(base_ff.stretch_bends),
-        functional_form=FunctionalForm.MM3,
+def load_pd_allyl_molecules() -> list[Q2MMMolecule]:
+    """Load the 21 Pd-allyl amination TS molecules (Wahlers Ch 3)."""
+    return _load_wahlers_molecules("Chapter 3")
+
+
+def load_pd_conjugate_molecules() -> list[Q2MMMolecule]:
+    """Load the 10 Pd 1,4-conjugate addition TS molecules (Wahlers Ch 5)."""
+    return _load_wahlers_molecules("Chapter 5")
+
+
+def load_rh_conjugate_molecules() -> list[Q2MMMolecule]:
+    """Load the 10 Rh 1,4-conjugate addition TS molecules (Wahlers Ch 6)."""
+    return _load_wahlers_molecules("Chapter 6")
+
+
+def _load_ch3f_molecules(*, data_dir: Path | None = None) -> list[Q2MMMolecule]:
+    """Load the single CH3F molecule + its QM Hessian (B3LYP/6-31+G(d))."""
+    from q2mm.models.molecule import Q2MMMolecule
+
+    qm_dir = data_dir or _find_ch3f_data_dir()
+    xyz = qm_dir / "ch3f-optimized.xyz"
+    hess_path = qm_dir / "ch3f-hessian.npy"
+    molecule = Q2MMMolecule.from_xyz(xyz, bond_tolerance=1.5)
+    return [molecule.with_hessian(np.load(hess_path))]
+
+
+# ---------------------------------------------------------------------------
+# Wahlers-system FF paths
+# ---------------------------------------------------------------------------
+
+
+def _wahlers_opt_path(chapter_subdir: str, ff_filename: str) -> Path:
+    """Resolve the path to a Wahlers chapter's standalone OPT .fld file."""
+    si = _resolve_supporting_info_dir()
+    return si / "wahlers" / "Wahlers_Jessica_Supporting_information" / chapter_subdir / ff_filename
+
+
+def _mm3_base_path() -> Path:
+    """Resolve the standard MM3 base .fld file.
+
+    The base file (mm3_base.fld) is not committed due to copyright;
+    fall back to examples/rh-enamide/mm3.fld which includes the same
+    base section.
+    """
+    p = _REPO_ROOT / "validation" / "published_ffs" / "mm3_base.fld"
+    if p.exists():
+        return p
+    p = _REPO_ROOT / "examples" / "rh-enamide" / "mm3.fld"
+    if p.exists():
+        return p
+    raise FileNotFoundError(
+        "MM3 base force field not found. Place mm3_base.fld in "
+        "validation/published_ffs/ (download from atlas-nano/ATLAS_toolkit) "
+        "or ensure examples/rh-enamide/mm3.fld exists."
     )
 
-    # Inject metal-specific vdW if missing from the base FF
-    if metal:
-        registry = _metal_vdw_registry()
-        metal_key = metal.upper()
-        if metal_key in registry:
-            has_metal_vdw = any(
-                v.atom_type == metal_key or (v.element or "").capitalize() == metal.capitalize() for v in composed.vdws
+
+# ---------------------------------------------------------------------------
+# SystemSpec and load_system dispatch
+# ---------------------------------------------------------------------------
+
+
+FFStrategy = Literal[
+    "qfuerza_fresh",
+    "published_opt",
+    "published_opt_composed",
+]
+"""Names of the FF-assembly strategies in :mod:`q2mm.models.loaders`."""
+
+
+@dataclass(frozen=True)
+class SystemSpec:
+    """Declarative spec for one benchmark system.
+
+    The :func:`load_system` dispatcher reads this spec to build a
+    :class:`SystemData` for the system.  Add new systems by appending
+    to :data:`SYSTEMS`; do not write per-system loader functions.
+
+    Attributes:
+        key: CLI key (e.g. ``"ch3f"``, ``"rh-enamide"``).
+        name: Human-readable system name.
+        molecule_loader: Zero-argument callable returning the training-
+            set molecules (with QM Hessians for the published-FF
+            systems).
+        ff_strategy: Name of the FF-assembly strategy in
+            :mod:`q2mm.models.loaders`.  One of
+            ``"qfuerza_fresh"``, ``"published_opt"``,
+            ``"published_opt_composed"``.
+        ff_paths: Mapping of strategy-specific path keys to zero-arg
+            callables returning a :class:`Path`.  Required keys per
+            strategy:
+
+            - ``qfuerza_fresh``: no keys.
+            - ``published_opt``: ``"ff_path"`` → published .fld.
+            - ``published_opt_composed``: ``"opt_path"`` → standalone
+              Wahlers OPT-only .fld; ``"base_path"`` → MM3 base .fld.
+        normal_modes_path: Optional callable returning a path to a
+            ``.npz`` file with pre-computed normal-mode eigendecomposition
+            (used by PES distortion analysis).  Accepts the same
+            ``data_dir`` override the CLI may pass via
+            :func:`load_system`'s ``molecule_loader_kwargs`` so molecule,
+            Hessian, and normal modes stay co-located.  Return ``None``
+            (or a non-existent path) to signal "no modes available".
+        metadata: Static metadata merged into the returned
+            :class:`SystemData.metadata` (level of theory, publication,
+            etc.).
+        metal: Optional element symbol for vdW injection during
+            ``published_opt_composed`` (e.g. ``"PD"``).
+        description: One-line CLI description.
+        default_forms: Functional forms to benchmark by default.
+
+    """
+
+    key: str
+    name: str
+    molecule_loader: Callable[..., list[Q2MMMolecule]]
+    ff_strategy: FFStrategy
+    ff_paths: Mapping[str, Callable[[], Path]] = field(default_factory=dict)
+    normal_modes_path: Callable[[Path | None], Path | None] | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    metal: str | None = None
+    description: str = ""
+    default_forms: tuple[str, ...] = ("mm3",)
+
+
+def load_system(
+    key: str,
+    *,
+    engine: Any | None = None,
+    functional_form: str | None = None,
+    molecule_loader_kwargs: dict[str, Any] | None = None,
+) -> SystemData:
+    """Build a :class:`SystemData` for one benchmark system.
+
+    The single loader entry point.  Dispatches on the system's
+    :class:`SystemSpec` to build the molecule list and the force
+    field, then constructs the reference data and metadata.
+
+    Reference construction depends on the FF strategy:
+
+    - ``qfuerza_fresh`` (single-molecule, e.g. CH3F): a frequency-only
+      reference is built from ``engine.frequencies(molecule, ff)``
+      compared against the QM frequencies derived from the Hessian.
+      The *engine* must be provided in this case.
+    - ``published_opt`` / ``published_opt_composed`` (multi-molecule
+      published-FF systems): an eigenmatrix-diagonal reference is built
+      via :meth:`ReferenceData.from_molecules`.  The engine is unused.
+
+    Args:
+        key: System key from :data:`SYSTEMS`.
+        engine: MM engine instance; required for ``qfuerza_fresh``
+            systems (CH3F-style).  Unused for other strategies.
+        functional_form: Override the FF's functional form
+            (``"harmonic"`` or ``"mm3"``).
+        molecule_loader_kwargs: Optional kwargs forwarded to the
+            system's molecule loader (e.g. ``data_dir`` for CH3F).
+
+    Returns:
+        A fully-populated :class:`SystemData`.
+
+    Raises:
+        KeyError: If *key* is not in :data:`SYSTEMS`.
+        TypeError: If *engine* is required but not provided.
+
+    """
+    from q2mm.models import loaders
+    from q2mm.models.forcefield import FunctionalForm
+    from q2mm.optimizers.objective import ReferenceData
+
+    if key not in SYSTEMS:
+        raise KeyError(f"Unknown system {key!r}; available: {sorted(SYSTEMS)}")
+    spec = SYSTEMS[key]
+
+    # 1. Molecules ---------------------------------------------------------
+    molecules = spec.molecule_loader(**(molecule_loader_kwargs or {}))
+
+    # 2. Force field via the named strategy --------------------------------
+    if spec.ff_strategy == "qfuerza_fresh":
+        if len(molecules) != 1:
+            raise ValueError(
+                f"qfuerza_fresh strategy requires exactly 1 molecule, got {len(molecules)} for system {key!r}"
             )
-            if not has_metal_vdw:
-                composed = ForceField(
-                    bonds=composed.bonds,
-                    angles=composed.angles,
-                    torsions=composed.torsions,
-                    vdws=list(composed.vdws) + [registry[metal_key]],
-                    stretch_bends=composed.stretch_bends,
-                    functional_form=composed.functional_form,
-                )
+        ff = loaders.load_qfuerza_fresh(molecules[0])
+    elif spec.ff_strategy == "published_opt":
+        ff = loaders.load_published_opt(spec.ff_paths["ff_path"]())
+    elif spec.ff_strategy == "published_opt_composed":
+        ff = loaders.load_published_opt_composed(
+            spec.ff_paths["opt_path"](),
+            spec.ff_paths["base_path"](),
+            metal=spec.metal,
+        )
+    else:  # pragma: no cover — unreachable per FFStrategy literal
+        raise ValueError(f"Unknown ff_strategy {spec.ff_strategy!r} for system {key!r}")
 
-    composed.freeze_standard_params(opt_ff)
-    ff = composed.copy()
-    qfuerza_into(ff, molecules, invert_ts_curvature=True)
-
+    # Functional form: explicit override > strategy default (MM3)
     if functional_form is not None:
         ff.functional_form = FunctionalForm(functional_form)
 
-    qm_freqs_per_mol = []
-    for mol in molecules:
-        qm_freqs = _qm_frequencies_from_hessian(mol.hessian, mol.symbols)
-        qm_real = np.array(sorted(f for f in qm_freqs if f > 50.0))
-        qm_freqs_per_mol.append(qm_real)
+    # 3. Reference data ----------------------------------------------------
+    if spec.ff_strategy == "qfuerza_fresh":
+        # Frequency-only reference: requires the engine to compute MM
+        # frequencies against the QM ones derived from the Hessian.
+        if engine is None:
+            raise TypeError(
+                f"System {key!r} uses ff_strategy='qfuerza_fresh' which requires "
+                "engine= to build the frequency-only reference."
+            )
+        molecule = molecules[0]
+        qm_freqs_all = _qm_frequencies_from_hessian(molecule.hessian, molecule.symbols)
+        mm_all = engine.frequencies(molecule, ff)
+        reference, qm_real = _build_frequency_reference(qm_freqs_all, mm_all)
+        qm_freqs_per_mol = [qm_real]
+    else:
+        reference = ReferenceData.from_molecules(molecules, eigenmatrix_diagonal_only=True)
+        qm_freqs_per_mol = []
+        for mol in molecules:
+            qm_freqs = _qm_frequencies_from_hessian(mol.hessian, mol.symbols)
+            qm_real = np.array(sorted(f for f in qm_freqs if f > 50.0))
+            qm_freqs_per_mol.append(qm_real)
 
-    reference = ReferenceData.from_molecules(molecules, eigenmatrix_diagonal_only=True)
+    # 4. Optional normal-modes side-load (declared per-spec).  Pass the
+    #    CLI's data_dir override (if any) through so molecule, Hessian,
+    #    and normal modes stay co-located.
+    normal_modes: dict[str, np.ndarray] | None = None
+    if spec.normal_modes_path is not None:
+        data_dir_override = (molecule_loader_kwargs or {}).get("data_dir")
+        modes_path = spec.normal_modes_path(data_dir_override)
+        if modes_path is not None and modes_path.exists():
+            from q2mm.diagnostics.pes_distortion import load_normal_modes
 
+            normal_modes = load_normal_modes(modes_path)
+
+    # 5. Wrap in SystemData ------------------------------------------------
+    resolved_form = functional_form
+    if resolved_form is None and ff.functional_form is not None:
+        resolved_form = ff.functional_form.value
+    metadata = {
+        "molecule_name": spec.name,
+        "n_molecules": len(molecules),
+        "n_atoms_per_mol": [len(m.symbols) for m in molecules],
+        **dict(spec.metadata),
+        **({"functional_form": resolved_form} if resolved_form else {}),
+    }
     return SystemData(
         molecules=molecules,
         forcefield=ff,
         reference=reference,
         qm_freqs_per_mol=qm_freqs_per_mol,
-        metadata={
-            "molecule_name": system_name,
-            "level_of_theory": level_of_theory,
-            "n_molecules": len(molecules),
-            "n_atoms_per_mol": [len(m.symbols) for m in molecules],
-            "functional_form": functional_form or "mm3",
-            "publication": publication,
-            "doi": doi,
-        },
-    )
-
-
-# ---------------------------------------------------------------------------
-# Wahlers systems
-# ---------------------------------------------------------------------------
-
-
-def load_pd_allyl(engine: Any, *, functional_form: str | None = None) -> SystemData:
-    """Load the Pd-allyl amination system (Wahlers Ch 3, 21 TS structures)."""
-    return _load_wahlers_system(
-        "Chapter 3",
-        "mm3.Pd-allyl.fld",
-        engine,
-        system_name="Pd-allyl amination",
-        publication="Wahlers et al. Nat. Commun. 2021, 12, 6508",
-        doi="10.1038/s41467-021-27065-2",
-        functional_form=functional_form,
-        metal="PD",
-    )
-
-
-def load_pd_conjugate(engine: Any, *, functional_form: str | None = None) -> SystemData:
-    """Load the Pd 1,4-conjugate addition system (Wahlers Ch 5, 10 TS structures)."""
-    return _load_wahlers_system(
-        "Chapter 5",
-        "mm3.Pd-1,4.fld",
-        engine,
-        system_name="Pd 1,4-conjugate addition",
-        publication="Wahlers et al. J. Org. Chem. 2021, 86, 5660",
-        doi="10.1021/acs.joc.1c00136",
-        functional_form=functional_form,
-        metal="PD",
-    )
-
-
-def load_rh_conjugate(engine: Any, *, functional_form: str | None = None) -> SystemData:
-    """Load the Rh 1,4-conjugate addition system (Wahlers Ch 6, 10 TS structures)."""
-    return _load_wahlers_system(
-        "Chapter 6",
-        "mm3.Rh-1,4.fld",
-        engine,
-        system_name="Rh 1,4-conjugate addition",
-        functional_form=functional_form,
-        metal="RH",
+        metadata=metadata,
+        normal_modes=normal_modes,
     )
 
 
@@ -697,67 +609,103 @@ def load_rh_conjugate(engine: Any, *, functional_form: str | None = None) -> Sys
 # ---------------------------------------------------------------------------
 
 
-@dataclass(frozen=True)
-class BenchmarkSystem:
-    """Configuration for a benchmark molecular system.
-
-    Attributes:
-        name: Human-readable system name.
-        key: CLI key (e.g. ``"ch3f"``, ``"rh-enamide"``).
-        loader: Callable that takes an engine and returns :class:`SystemData`.
-        description: One-line description for ``--list`` output.
-        default_forms: Functional forms to benchmark by default.
-
-    """
-
-    name: str
-    key: str
-    loader: Callable
-    description: str = ""
-    default_forms: tuple[str, ...] = ("harmonic", "mm3")
+def _heck_relay_ff_path() -> Path:
+    """Resolve the Heck-relay Rosales FF file path lazily."""
+    si = _resolve_supporting_info_dir()
+    return si / "rosales" / "Rosales_Anthony_Supporting_Information" / "Chapter3_Heck" / "mm3.FF1.fld"
 
 
-SYSTEMS: dict[str, BenchmarkSystem] = {
-    "ch3f": BenchmarkSystem(
-        name="CH3F",
+def _ch3f_normal_modes_path(data_dir_override: Path | None) -> Path:
+    """Resolve the CH3F normal-modes ``.npz`` path, honouring a CLI override."""
+    base = data_dir_override or _find_ch3f_data_dir()
+    return base / "ch3f-normal-modes.npz"
+
+
+SYSTEMS: dict[str, SystemSpec] = {
+    "ch3f": SystemSpec(
         key="ch3f",
-        loader=load_ch3f,
+        name="CH3F",
+        molecule_loader=_load_ch3f_molecules,
+        ff_strategy="qfuerza_fresh",
+        normal_modes_path=_ch3f_normal_modes_path,
+        metadata={"level_of_theory": "B3LYP/6-31+G(d)"},
         description="Single CH3F molecule (SN2 test, B3LYP/6-31+G(d))",
         default_forms=("harmonic", "mm3"),
     ),
-    "rh-enamide": BenchmarkSystem(
-        name="Rh-enamide",
+    "rh-enamide": SystemSpec(
         key="rh-enamide",
-        loader=load_rh_enamide,
+        name="Rh-enamide",
+        molecule_loader=load_rh_enamide_molecules,
+        ff_strategy="published_opt",
+        ff_paths={"ff_path": lambda: _RH_DIR / "mm3.fld"},
+        metadata={
+            "level_of_theory": "B3LYP/LACVP**",
+            "publication": "Donoghue et al. JCTC 2008, 4, 1313",
+            "doi": "10.1021/ct800132a",
+        },
         description="9 Rh-diphosphine structures (Jaguar B3LYP/LACVP**)",
-        default_forms=("mm3",),
     ),
-    "heck-relay": BenchmarkSystem(
-        name="Heck relay",
+    "heck-relay": SystemSpec(
         key="heck-relay",
-        loader=load_heck_relay,
+        name="Heck relay",
+        molecule_loader=load_heck_relay_molecules,
+        ff_strategy="published_opt",
+        ff_paths={"ff_path": _heck_relay_ff_path},
+        metadata={
+            "level_of_theory": "M06/gen+pseudo (GD3)",
+            "publication": "Rosales et al. JACS 2020, 142, 9700",
+            "doi": "10.1021/jacs.0c01979",
+        },
         description="23 Pd-catalyzed redox-relay Heck TS structures (Gaussian M06/HPModes)",
-        default_forms=("mm3",),
     ),
-    "pd-allyl": BenchmarkSystem(
-        name="Pd-allyl amination",
+    "pd-allyl": SystemSpec(
         key="pd-allyl",
-        loader=load_pd_allyl,
+        name="Pd-allyl amination",
+        molecule_loader=load_pd_allyl_molecules,
+        ff_strategy="published_opt_composed",
+        ff_paths={
+            "opt_path": lambda: _wahlers_opt_path("Chapter 3", "mm3.Pd-allyl.fld"),
+            "base_path": _mm3_base_path,
+        },
+        metadata={
+            "level_of_theory": "M06/gen+pseudo (GD3)",
+            "publication": "Wahlers et al. Nat. Commun. 2021, 12, 6508",
+            "doi": "10.1038/s41467-021-27065-2",
+        },
+        metal="PD",
         description="21 Pd-allyl TS structures (Wahlers, Nat. Commun. 2021)",
-        default_forms=("mm3",),
     ),
-    "pd-conjugate": BenchmarkSystem(
-        name="Pd 1,4-conjugate addition",
+    "pd-conjugate": SystemSpec(
         key="pd-conjugate",
-        loader=load_pd_conjugate,
+        name="Pd 1,4-conjugate addition",
+        molecule_loader=load_pd_conjugate_molecules,
+        ff_strategy="published_opt_composed",
+        ff_paths={
+            "opt_path": lambda: _wahlers_opt_path("Chapter 5", "mm3.Pd-1,4.fld"),
+            "base_path": _mm3_base_path,
+        },
+        metadata={
+            "level_of_theory": "M06/gen+pseudo (GD3)",
+            "publication": "Wahlers et al. J. Org. Chem. 2021, 86, 5660",
+            "doi": "10.1021/acs.joc.1c00136",
+        },
+        metal="PD",
         description="10 Pd 1,4-conjugate TS structures (Wahlers, J. Org. Chem. 2021)",
-        default_forms=("mm3",),
     ),
-    "rh-conjugate": BenchmarkSystem(
-        name="Rh 1,4-conjugate addition",
+    "rh-conjugate": SystemSpec(
         key="rh-conjugate",
-        loader=load_rh_conjugate,
+        name="Rh 1,4-conjugate addition",
+        molecule_loader=load_rh_conjugate_molecules,
+        ff_strategy="published_opt_composed",
+        ff_paths={
+            "opt_path": lambda: _wahlers_opt_path("Chapter 6", "mm3.Rh-1,4.fld"),
+            "base_path": _mm3_base_path,
+        },
+        metadata={
+            "level_of_theory": "M06/gen+pseudo (GD3)",
+            "publication": "Wahlers, J. Ph.D. Dissertation, U. Notre Dame, 2022, Ch. 6",
+        },
+        metal="RH",
         description="10 Rh 1,4-conjugate TS structures (Wahlers thesis)",
-        default_forms=("mm3",),
     ),
 }

--- a/q2mm/models/forcefield.py
+++ b/q2mm/models/forcefield.py
@@ -26,6 +26,67 @@ if TYPE_CHECKING:
     from q2mm.models.molecule import Q2MMMolecule
 
 
+class FrozenParamError(ValueError):
+    """Raised when code attempts to mutate a value field of a frozen parameter.
+
+    A parameter is "frozen" when its ``frozen`` attribute is ``True``;
+    optimizers respect this by holding the parameter fixed, and so does
+    every method that writes to physical value fields (force constants,
+    equilibria, vdW radii, etc.).  Construction is unaffected — you may
+    instantiate a new dataclass with ``frozen=True`` directly, and the
+    initial values are stored without triggering the guard.
+
+    To intentionally overwrite a frozen parameter's value (e.g. when
+    rebuilding a force field from optimized parameters), call
+    :meth:`_FrozenAwareParam.unfreeze` first.
+    """
+
+
+class _FrozenAwareParam:
+    """Mixin enforcing the ``frozen`` invariant on value-field writes.
+
+    Subclasses declare which dataclass fields are *physical values*
+    (force constants, equilibria, etc.) via the ``_VALUE_FIELDS`` class
+    attribute.  ``__setattr__`` raises :class:`FrozenParamError` when
+    code tries to assign to one of those fields while ``self.frozen``
+    is ``True``.
+
+    Construction via ``__init__`` is exempt because the dataclass
+    generates an ``__init__`` that runs *before* ``self.frozen`` is
+    True (Python sets attributes in declaration order; ``frozen``
+    appears last in every Param dataclass).  Even when ``frozen=True``
+    is passed at construction time, the value fields are assigned
+    first, so the guard never trips.  Direct post-construction writes
+    via :meth:`set_value` or attribute assignment are guarded.
+
+    Use :meth:`freeze` / :meth:`unfreeze` for the explicit, named
+    state transitions rather than ``param.frozen = True/False``;
+    direct writes to ``frozen`` itself are allowed (the mixin only
+    guards value fields).
+    """
+
+    _VALUE_FIELDS: ClassVar[frozenset[str]] = frozenset()
+
+    # mypy: the dataclass decorator adds these; declared here for type
+    frozen: bool
+
+    def __setattr__(self, name: str, value: object) -> None:
+        if name in self._VALUE_FIELDS and getattr(self, "frozen", False):
+            raise FrozenParamError(
+                f"Cannot set {type(self).__name__}.{name} on a frozen parameter. "
+                "Call .unfreeze() first, or construct a fresh parameter."
+            )
+        object.__setattr__(self, name, value)
+
+    def freeze(self) -> None:
+        """Mark this parameter as frozen (forbids future value writes)."""
+        object.__setattr__(self, "frozen", True)
+
+    def unfreeze(self) -> None:
+        """Mark this parameter as unfrozen (allows value writes again)."""
+        object.__setattr__(self, "frozen", False)
+
+
 class FunctionalForm(str, Enum):
     """Physical functional form used by a force field.
 
@@ -47,7 +108,7 @@ class FunctionalForm(str, Enum):
 
 
 @dataclass
-class BondParam:
+class BondParam(_FrozenAwareParam):
     """A bond force field parameter.
 
     Units (canonical): ``force_constant`` in kcal/(mol·Å²),
@@ -68,6 +129,8 @@ class BondParam:
     dipole_moment: float = 0.0  # Bond dipole in Debye (MM3 .fld P3 column)
     frozen: bool = False
 
+    _VALUE_FIELDS: ClassVar[frozenset[str]] = frozenset({"equilibrium", "force_constant", "dipole_moment"})
+
     @property
     def key(self) -> tuple[str, str]:
         """Sorted element pair for canonical matching (e.g., ``('C', 'F')``)."""
@@ -75,7 +138,7 @@ class BondParam:
 
 
 @dataclass
-class AngleParam:
+class AngleParam(_FrozenAwareParam):
     """An angle force field parameter.
 
     Units (canonical): ``force_constant`` in kcal/(mol·rad²),
@@ -96,6 +159,10 @@ class AngleParam:
     ub_equilibrium: float | None = None  # Å, None = no UB term
     frozen: bool = False
 
+    _VALUE_FIELDS: ClassVar[frozenset[str]] = frozenset(
+        {"equilibrium", "force_constant", "ub_force_constant", "ub_equilibrium"}
+    )
+
     @property
     def key(self) -> tuple[str, str, str]:
         """Canonical key: center fixed, outers sorted."""
@@ -104,7 +171,7 @@ class AngleParam:
 
 
 @dataclass
-class StretchBendParam:
+class StretchBendParam(_FrozenAwareParam):
     """A stretch-bend cross-term parameter (MM3).
 
     Couples bond stretching with angle bending:
@@ -122,6 +189,8 @@ class StretchBendParam:
     ff_row: int | None = None
     frozen: bool = False
 
+    _VALUE_FIELDS: ClassVar[frozenset[str]] = frozenset({"force_constant"})
+
     @property
     def key(self) -> tuple[str, str, str]:
         """Canonical key: center fixed, outers sorted."""
@@ -130,7 +199,7 @@ class StretchBendParam:
 
 
 @dataclass
-class TorsionParam:
+class TorsionParam(_FrozenAwareParam):
     """A torsion/dihedral force field parameter.
 
     Each object represents a single Fourier component (V_n).  An MM3
@@ -153,9 +222,11 @@ class TorsionParam:
     is_improper: bool = False
     frozen: bool = False
 
+    _VALUE_FIELDS: ClassVar[frozenset[str]] = frozenset({"force_constant", "phase"})
+
 
 @dataclass
-class VdwParam:
+class VdwParam(_FrozenAwareParam):
     """An atom-type van der Waals parameter."""
 
     atom_type: str
@@ -167,11 +238,16 @@ class VdwParam:
     ff_row: int | None = None
     frozen: bool = False
 
+    _VALUE_FIELDS: ClassVar[frozenset[str]] = frozenset({"radius", "epsilon", "reduction"})
+
     def __post_init__(self) -> None:
         """Normalize atom_type and auto-extract element if not provided."""
-        self.atom_type = str(self.atom_type).strip()
+        # Bypass the frozen guard here — atom_type and element are
+        # identity fields, not value fields, but assigning to them
+        # after construction is fine even on frozen params.
+        object.__setattr__(self, "atom_type", str(self.atom_type).strip())
         if not self.element:
-            self.element = _extract_element(self.atom_type)
+            object.__setattr__(self, "element", _extract_element(self.atom_type))
 
 
 @dataclass
@@ -287,11 +363,9 @@ class ForceField:
         mask: list[bool] = []
         for attr, slots in self._PARAM_SLOTS:
             for param in getattr(self, attr):
-                frozen = getattr(param, "frozen", False)
-                mask.extend([not frozen] * len(slots))
+                mask.extend([not param.frozen] * len(slots))
         for angle in self._ub_angles:
-            frozen = getattr(angle, "frozen", False)
-            mask.extend([not frozen, not frozen])
+            mask.extend([not angle.frozen, not angle.frozen])
         return np.array(mask, dtype=bool)
 
     @property
@@ -645,18 +719,26 @@ class ForceField:
         return self.get_vdw(atom_type=atom_type, element=element)
 
     def set_param_vector(self, vec: np.ndarray) -> None:
-        """Set parameters from a flat vector (inverse of get_param_vector)."""
+        """Set parameters from a flat vector (inverse of get_param_vector).
+
+        Iterates every slot of every param.  Frozen params are skipped:
+        their value is taken from *vec* but not written through, which
+        keeps the function callable with full-length vectors produced by
+        :meth:`get_param_vector` even when some params are frozen.
+        """
         if len(vec) != self.n_params:
             raise ValueError(f"Parameter vector length {len(vec)} does not match expected {self.n_params} parameters.")
         idx = 0
         for attr, slots in self._PARAM_SLOTS:
             for param in getattr(self, attr):
                 for s in slots:
-                    setattr(param, s, vec[idx])
+                    if not getattr(param, "frozen", False):
+                        setattr(param, s, vec[idx])
                     idx += 1
         for angle in self._ub_angles:
-            angle.ub_force_constant = vec[idx]
-            angle.ub_equilibrium = vec[idx + 1]
+            if not getattr(angle, "frozen", False):
+                angle.ub_force_constant = vec[idx]
+                angle.ub_equilibrium = vec[idx + 1]
             idx += 2
 
     def with_params(self, vec: np.ndarray) -> ForceField:
@@ -684,19 +766,27 @@ class ForceField:
         for attr, slots in self._PARAM_SLOTS:
             new_list = []
             for param in getattr(self, attr):
-                updates = {}
-                for s in slots:
-                    updates[s] = vec[idx]
-                    idx += 1
-                new_list.append(replace(param, **updates))
+                if getattr(param, "frozen", False):
+                    # Skip vec entries for frozen params — carry the
+                    # existing values forward unchanged.
+                    idx += len(slots)
+                    new_list.append(replace(param))
+                else:
+                    updates = {}
+                    for s in slots:
+                        updates[s] = vec[idx]
+                        idx += 1
+                    new_list.append(replace(param, **updates))
             new_collections[attr] = new_list
-        # Update UB params on the new angle list
+        # Update UB params on the new angle list (skip frozen, mirroring
+        # set_param_vector semantics — the optimizer never changes them).
         ub_angles = [
             a for a in new_collections["angles"] if a.ub_force_constant is not None and a.ub_equilibrium is not None
         ]
         for angle in ub_angles:
-            angle.ub_force_constant = float(vec[idx])
-            angle.ub_equilibrium = float(vec[idx + 1])
+            if not getattr(angle, "frozen", False):
+                angle.ub_force_constant = float(vec[idx])
+                angle.ub_equilibrium = float(vec[idx + 1])
             idx += 2
         return replace(self, **new_collections)
 
@@ -720,9 +810,9 @@ class ForceField:
         """Mark all parameters as frozen (not optimizable)."""
         for attr, _ in self._PARAM_SLOTS:
             for param in getattr(self, attr):
-                param.frozen = True
+                param.freeze()
         for angle in self._ub_angles:
-            angle.frozen = True
+            angle.freeze()
 
     def freeze_standard_params(self, opt_ff: ForceField) -> None:
         """Mark params as frozen unless they match an OPT-substructure param."""
@@ -746,12 +836,12 @@ class ForceField:
             for param in getattr(self, attr):
                 if same_source and param.ff_row is not None:
                     if opt_rows[attr][param.ff_row] > 0:
-                        param.frozen = False
+                        param.unfreeze()
                         opt_rows[attr][param.ff_row] -= 1
                     continue
                 ident = self._param_identity(attr, param)
                 if opt_ids[attr][ident] > 0:
-                    param.frozen = False
+                    param.unfreeze()
                     opt_ids[attr][ident] -= 1
 
         opt_ub_rows = Counter(angle.ff_row for angle in opt_ff._ub_angles if angle.ff_row is not None)
@@ -759,12 +849,12 @@ class ForceField:
         for angle in self._ub_angles:
             if same_source and angle.ff_row is not None:
                 if opt_ub_rows[angle.ff_row] > 0:
-                    angle.frozen = False
+                    angle.unfreeze()
                     opt_ub_rows[angle.ff_row] -= 1
                 continue
             ident = self._param_identity("angles", angle)
             if opt_ub_ids[ident] > 0:
-                angle.frozen = False
+                angle.unfreeze()
                 opt_ub_ids[ident] -= 1
 
     # Default bounds per parameter type (min, max) in canonical units.

--- a/q2mm/models/loaders.py
+++ b/q2mm/models/loaders.py
@@ -1,0 +1,213 @@
+"""Force-field assembly strategies for the published-FF benchmark systems.
+
+Each function in this module implements one named strategy for
+turning a force-field file (or a set of training molecules) into a
+ready-to-use :class:`~q2mm.models.forcefield.ForceField`.  The
+strategies are deliberately *named* rather than composed at the call
+site to prevent the silent-overwrite class of bugs that produced the
+load_heck_relay regression (q2mm#277).
+
+The methodology of record is **Farrugia, Helquist, Norrby & Wiest 2025**
+("Rapid FF Generation via Hessian-Informed Initial Parameters and
+Automated Refinement", *J. Chem. Theory Comput.* **22**, 469;
+DOI 10.1021/acs.jctc.5c01751) — see AGENTS.md "Key Papers" for the
+broader context.  Farrugia 2025 §"Methods" identifies four parameter
+generation strategies (Approxn, FUERZA, γ-FUERZA, QFUERZA); the
+loaders below correspond to the three that Q2MM ships for published
+FFs:
+
+- :func:`load_published_opt` — use literature OPT parameter values
+  as-published.  Standard MM3 backbone is frozen; OPT block is active.
+  Matches the "mixing parameter sources" workflow Farrugia 2025
+  describes for published TSFFs.
+- :func:`load_qfuerza_fresh` — no literature FF at all.  Build a brand
+  new FF from one molecule's QM Hessian via QFUERZA.  For small
+  single-molecule benchmarks like CH3F.
+- :func:`compose_opt_with_mm3_base` — Wahlers-style composition
+  primitive: append an OPT block to a standard MM3 base FF.  Returns
+  the composed FF with no frozen/active partition set.
+- :func:`load_published_opt_composed` — convenience wrapper that
+  combines :func:`compose_opt_with_mm3_base` with the
+  ``freeze_standard_params`` partition.  This is the
+  :func:`load_published_opt` equivalent for Wahlers FFs that ship as
+  standalone OPT-substructure-only files.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from q2mm.models.forcefield import ForceField, FunctionalForm, VdwParam
+from q2mm.models.seminario import qfuerza_fresh
+
+if TYPE_CHECKING:
+    from q2mm.models.molecule import Q2MMMolecule
+
+
+__all__ = [
+    "load_published_opt",
+    "load_qfuerza_fresh",
+    "compose_opt_with_mm3_base",
+    "load_published_opt_composed",
+]
+
+
+# Published metal vdW parameters for systems whose MM3 base file lacks them.
+# Today only PD (sourced from Rosales 2020 Heck FF mm3.FF1.fld:1063); promote
+# to its own module (e.g. ``q2mm/models/metals.py``) if this grows past a
+# handful of entries.
+_METAL_VDW: dict[str, VdwParam] = {
+    "PD": VdwParam(atom_type="PD", radius=1.70, epsilon=0.414, element="Pd"),
+}
+
+
+def load_published_opt(ff_path: str | Path) -> ForceField:
+    """Load a self-contained published MM3 .fld using its OPT values as-is.
+
+    Used for FFs (e.g. Donoghue 2008 Rh-enamide, Rosales 2020 Heck relay)
+    whose .fld file already contains both the standard MM3 backbone AND
+    a custom OPT-substructure block with literature-fitted values.  The
+    standard MM3 backbone is frozen; the OPT block is left active so an
+    optimizer can refine it further.
+
+    No QFUERZA projection is run — the published OPT values are
+    preserved exactly.  This is the strategy that fixes the
+    ``load_heck_relay`` regression from q2mm#277.
+
+    Returned FF invariants:
+        - ``functional_form`` is :attr:`FunctionalForm.MM3`.
+        - Standard MM3 params (non-OPT) are frozen.
+        - OPT-substructure params are unfrozen.
+        - All param *values* come from the .fld file unchanged.
+
+    Args:
+        ff_path: Path to the published .fld file.
+
+    Returns:
+        The loaded force field with the frozen/active partition set.
+
+    """
+    ff_path = Path(ff_path)
+    ff = ForceField.from_mm3_fld(str(ff_path), include_standard=True)
+    opt_only = ForceField.from_mm3_fld(str(ff_path), include_standard=False)
+    ff.freeze_standard_params(opt_only)
+    ff.functional_form = FunctionalForm.MM3
+    return ff
+
+
+def load_qfuerza_fresh(
+    molecule: Q2MMMolecule,
+    *,
+    invert_ts_curvature: bool = True,
+) -> ForceField:
+    """Build a brand-new FF from one molecule's QM Hessian via QFUERZA.
+
+    For small single-molecule benchmarks (CH3F-style) where there is no
+    published OPT block to start from.  Every parameter in the returned
+    FF comes from the QFUERZA projection and is unfrozen.
+
+    Args:
+        molecule: One molecule with a QM Hessian attached.
+        invert_ts_curvature: Whether to invert the TS reaction
+            coordinate before projection (Limé & Norrby 2015).  Default
+            ``True`` because the only system using this strategy today
+            is the CH3F SN2 transition state.
+
+    Returns:
+        Fresh force field; every parameter unfrozen.
+
+    """
+    return qfuerza_fresh(molecule, invert_ts_curvature=invert_ts_curvature)
+
+
+def compose_opt_with_mm3_base(
+    opt_path: str | Path,
+    base_path: str | Path,
+    *,
+    metal: str | None = None,
+) -> tuple[ForceField, ForceField]:
+    """Compose a Wahlers-style standalone OPT .fld with a standard MM3 base.
+
+    Wahlers TSFFs (pd-allyl, pd 1,4-conjugate addition, rh 1,4-conjugate
+    addition) ship as standalone OPT-substructure-only files (~100-500
+    parameters) that depend on a separate standard MM3 base file
+    (~2,500 backbone params).  This primitive concatenates the two
+    into a single :class:`ForceField`, with the OPT block appearing
+    first so that matching prefers OPT over the corresponding base
+    entries.
+
+    Does *not* set a frozen/active partition — use
+    :func:`load_published_opt_composed` for that.
+
+    Args:
+        opt_path: Path to the standalone OPT-only .fld file.
+        base_path: Path to the standard MM3 .fld file.
+        metal: Optional element symbol (e.g. ``"PD"``) whose
+            vdW parameters should be added to the composed FF if not
+            already present.  Sources from :data:`_METAL_VDW`.
+
+    Returns:
+        ``(composed, opt_only)`` — the composed force field
+        (``functional_form = MM3``, no frozen/active partition set),
+        and the OPT-only FF used to build it (returned so callers
+        such as :func:`load_published_opt_composed` can reuse it to
+        set the frozen/active partition without re-parsing the file).
+
+    """
+    opt_ff = ForceField.from_mm3_fld(str(Path(opt_path)), include_standard=False)
+    base_ff = ForceField.from_mm3_fld(str(Path(base_path)))
+
+    composed = ForceField(
+        bonds=list(opt_ff.bonds) + list(base_ff.bonds),
+        angles=list(opt_ff.angles) + list(base_ff.angles),
+        torsions=list(opt_ff.torsions) + list(base_ff.torsions),
+        vdws=list(opt_ff.vdws) + list(base_ff.vdws),
+        stretch_bends=list(opt_ff.stretch_bends) + list(base_ff.stretch_bends),
+        functional_form=FunctionalForm.MM3,
+    )
+
+    if metal:
+        metal_key = metal.upper()
+        if metal_key in _METAL_VDW:
+            has_metal_vdw = any(
+                v.atom_type == metal_key or (v.element or "").capitalize() == metal.capitalize() for v in composed.vdws
+            )
+            if not has_metal_vdw:
+                composed.vdws.append(_METAL_VDW[metal_key])
+
+    return composed, opt_ff
+
+
+def load_published_opt_composed(
+    opt_path: str | Path,
+    base_path: str | Path,
+    *,
+    metal: str | None = None,
+) -> ForceField:
+    """Compose Wahlers OPT + MM3 base, then freeze the standard backbone.
+
+    The :func:`load_published_opt` equivalent for systems whose OPT
+    block lives in a separate .fld file from the base MM3 parameters.
+    Uses the published Wahlers OPT values as-published (no QFUERZA
+    overwrite).
+
+    Returned FF invariants:
+        - ``functional_form`` is :attr:`FunctionalForm.MM3`.
+        - Standard MM3 backbone params are frozen.
+        - OPT-substructure params are unfrozen.
+        - All param *values* come from the .fld files unchanged.
+
+    Args:
+        opt_path: Path to the standalone OPT-only .fld file (Wahlers).
+        base_path: Path to the standard MM3 .fld file.
+        metal: Optional element symbol for vdW injection (see
+            :func:`compose_opt_with_mm3_base`).
+
+    Returns:
+        Composed force field with the frozen/active partition set.
+
+    """
+    composed, opt_only = compose_opt_with_mm3_base(opt_path, base_path, metal=metal)
+    composed.freeze_standard_params(opt_only)
+    return composed

--- a/q2mm/models/seminario.py
+++ b/q2mm/models/seminario.py
@@ -336,9 +336,16 @@ def estimate_force_constants(
     else:
         ff = forcefield.copy()
 
-    # Estimate bond force constants
+    # Estimate bond force constants.  Skip frozen params: their values
+    # are caller-owned commitments (e.g. literature OPT params held
+    # fixed via freeze_standard_params) and overwriting them silently
+    # was the load_heck_relay bug (q2mm#277).  This loop matches the
+    # skip-frozen convention in ForceField.set_param_vector /
+    # with_params; commit 3 will replace this function entirely with
+    # qfuerza_fresh / qfuerza_into which take an explicit target list
+    # and never iterate frozen params.
     for bond_param in ff.bonds:
-        if getattr(bond_param, "frozen", False):
+        if bond_param.frozen:
             continue
         matching_bonds = _collect_matching(molecules, bond_param, "bonds", "element_pair")
 
@@ -377,9 +384,9 @@ def estimate_force_constants(
         else:
             logger.warning(f"  Bond {bond_param.key}: no valid force constants found, keeping existing force constant")
 
-    # Estimate angle force constants
+    # Estimate angle force constants.  Skip frozen params (see bond loop above).
     for angle_param in ff.angles:
-        if getattr(angle_param, "frozen", False):
+        if angle_param.frozen:
             continue
         matching_angles = _collect_matching(molecules, angle_param, "angles", "element_triple")
 
@@ -429,10 +436,10 @@ def estimate_force_constants(
                 f"  Angle {angle_param.key}: no valid force constants found, keeping existing force constant"
             )
 
-    # Zero torsions if requested
+    # Zero torsions if requested.  Skip frozen torsions (see bond loop above).
     if zero_torsions:
         for t in ff.torsions:
-            if getattr(t, "frozen", False):
+            if t.frozen:
                 continue
             t.force_constant = 0.0
 

--- a/q2mm/models/seminario.py
+++ b/q2mm/models/seminario.py
@@ -60,7 +60,7 @@ def _coerce_molecules(
     if not molecules:
         raise ValueError("At least one molecule is required")
     if not all(isinstance(item, Q2MMMolecule) for item in molecules):
-        raise TypeError("estimate_force_constants expects Q2MMMolecule instances")
+        raise TypeError("qfuerza_fresh/qfuerza_into expects Q2MMMolecule instances")
     return molecules
 
 
@@ -183,7 +183,7 @@ def seminario_angle_fc(
     Computes the standard Seminario reciprocal-sum angle formula with
     |dot| projection and DFT scaling. Note that FUERZA overestimates
     H-angle FCs by ~2×; the QFUERZA substitution is applied downstream
-    in ``estimate_force_constants()``, not here.
+    in ``qfuerza_into()`` (or ``qfuerza_fresh()``), not here.
 
     Args:
         atom_i: outer atom (0-based)
@@ -256,7 +256,7 @@ def seminario_angle_fc(
     # Combine via reciprocal sum: 1/k = 1/(k_ij·r_ij²) + 1/(k_kj·r_kj²)
     # Standard Seminario angle formula. Note: FUERZA still overestimates
     # H-angle FCs by ~2× (Allen et al. 2018); QFUERZA addresses this via
-    # substitution in estimate_force_constants().
+    # substitution in qfuerza_into().
     denom_ij = k_ij * r_ij_len**2
     denom_kj = k_kj * r_kj_len**2
 
@@ -275,39 +275,119 @@ def seminario_angle_fc(
     return k_angle
 
 
-def estimate_force_constants(
+def qfuerza_fresh(
     molecule: Q2MMMolecule | Iterable[Q2MMMolecule],
-    forcefield: ForceField | None = None,
+    *,
     zero_torsions: bool = True,
     au_hessian: bool = True,
     invalid_policy: Literal["keep", "skip"] = "keep",
     invert_ts_curvature: bool = False,
     strategy: Literal["fuerza", "qfuerza"] = "qfuerza",
 ) -> ForceField:
-    """Estimate force constants from one or more QM Hessians.
+    """Build a fresh force field from one molecule's QM Hessian.
 
-    Uses Seminario projection (FUERZA) to extract initial bond and angle
-    force constants, with QFUERZA post-processing by default.
+    Use this when you have no published FF to start from — e.g.
+    ``load_ch3f``.  All params come from the QFUERZA projection
+    (Farrugia et al. *J. Chem. Theory Comput.* **2025**, *22*, 469;
+    DOI 10.1021/acs.jctc.5c01751) and are returned unfrozen.
 
     Args:
-        molecule: Molecule with Hessian attached, or an iterable of molecules.
-        forcefield: Starting force field (if None, auto-creates from one molecule)
-        zero_torsions: Whether to zero out torsional parameters
-        au_hessian: Whether Hessian is in atomic units (Hartree/Bohr^2)
-        invalid_policy: Whether to keep negative force constants ("keep") or
-            mimic legacy MM3 Seminario averaging by skipping non-positive
-            estimates ("skip")
-        invert_ts_curvature: If ``True``, invert the reaction-coordinate
-            curvature before projection so that the transition-state Hessian
-            produces valid positive force constants (Limé & Norrby 2015).
-            ``False`` (default) uses the Hessian as-is.
-        strategy: ``"qfuerza"`` (default) substitutes empirical defaults
-            for hydrogen angle bends, where Seminario projection overestimates
-            by ~2× (Farrugia et al. JCTC 2025).  ``"fuerza"`` uses pure
-            Seminario projection without substitution.
+        molecule: A single molecule with a Hessian attached, or an
+            iterable containing exactly one such molecule.  Multi-molecule
+            averaging requires an explicit forcefield — use
+            :func:`qfuerza_into` for that case.
+        zero_torsions: Whether to zero out torsional parameters.  Per
+            Farrugia 2025, torsions are not well-suited for FUERZA-style
+            parametrization from vibrational data and are zeroed at
+            initial-parameter time to be fit in a later Q2MM optimization
+            stage.  Default ``True``; do not override unless you are
+            sure you know what that means for your downstream pipeline.
+        au_hessian: Whether the Hessian is in atomic units (Hartree/Bohr²).
+        invalid_policy: ``"keep"`` retains negative force constants
+            (TS reaction coordinates); ``"skip"`` mimics legacy MM3
+            Seminario averaging by dropping non-positive estimates.
+        invert_ts_curvature: When the molecule is a transition state,
+            inverts the reaction-coordinate eigenvalue before projection
+            so that the TS Hessian produces valid positive force
+            constants (Limé & Norrby 2015).
+        strategy: ``"qfuerza"`` (default) applies the H-angle substitution
+            for hydrogen angle bends where pure Seminario projection
+            overestimates by ~2× (Farrugia 2025).  ``"fuerza"`` uses
+            pure Seminario projection.
 
     Returns:
-        ForceField with estimated parameters
+        A new :class:`ForceField` whose every parameter is unfrozen and
+        populated from the QFUERZA projection.
+
+    Raises:
+        ValueError: If ``molecule`` is an iterable with anything other
+            than one element (use :func:`qfuerza_into` for the multi-
+            molecule averaging case), or if a Hessian is missing.
+
+    """
+    molecules = _coerce_molecules(molecule)
+    if len(molecules) != 1:
+        raise ValueError(
+            f"qfuerza_fresh expects exactly one molecule, got {len(molecules)}.  "
+            "Multi-molecule averaging requires an explicit forcefield — use "
+            "qfuerza_into(ff, molecules, ...) instead."
+        )
+    ff = ForceField.create_for_molecule(
+        molecules[0],
+        name=f"QFUERZA FF for {molecules[0].name}",
+    )
+    qfuerza_into(
+        ff,
+        molecules,
+        zero_torsions=zero_torsions,
+        au_hessian=au_hessian,
+        invalid_policy=invalid_policy,
+        invert_ts_curvature=invert_ts_curvature,
+        strategy=strategy,
+    )
+    return ff
+
+
+def qfuerza_into(
+    ff: ForceField,
+    molecule: Q2MMMolecule | Iterable[Q2MMMolecule],
+    *,
+    zero_torsions: bool = True,
+    au_hessian: bool = True,
+    invalid_policy: Literal["keep", "skip"] = "keep",
+    invert_ts_curvature: bool = False,
+    strategy: Literal["fuerza", "qfuerza"] = "qfuerza",
+) -> None:
+    """Overwrite *unfrozen* parameter values in *ff* using QFUERZA projection.
+
+    Iterates every parameter slot in *ff* and writes new values from
+    the QFUERZA projection (Farrugia et al. *J. Chem. Theory Comput.*
+    **2026**, *22*, 469).  **Frozen parameters are skipped** — they
+    represent caller commitments (e.g. published OPT values held fixed
+    via :meth:`ForceField.freeze_standard_params`) and silently
+    overwriting them was the q2mm#277 Heck-relay bug.
+
+    To deliberately re-estimate a frozen param, call ``.unfreeze()``
+    on it first.
+
+    Args:
+        ff: Force field to mutate in place.  The caller is responsible
+            for setting the active/frozen partition before calling.
+        molecule: Molecule(s) with Hessians; multi-molecule values are
+            averaged per param.
+        zero_torsions: See :func:`qfuerza_fresh` (default ``True`` per
+            Farrugia 2025).
+        au_hessian: Whether Hessians are in atomic units.
+        invalid_policy: ``"keep"`` or ``"skip"`` for non-positive
+            estimates.
+        invert_ts_curvature: TS Hessian inversion flag (Limé & Norrby
+            2015).
+        strategy: ``"qfuerza"`` (with H-angle substitution) or
+            ``"fuerza"`` (pure Seminario).
+
+    Raises:
+        ValueError: If ``strategy`` is not recognised or if any
+            molecule is missing a Hessian.
 
     """
     if strategy not in ("fuerza", "qfuerza"):
@@ -325,25 +405,34 @@ def estimate_force_constants(
     else:
         processed_hessians = None
 
-    # Create or copy force field
-    if forcefield is None:
-        if len(molecules) != 1:
-            raise ValueError("An explicit force field is required when averaging across multiple molecules")
-        ff = ForceField.create_for_molecule(
-            molecules[0],
-            name=f"Seminario FF for {molecules[0].name}",
-        )
-    else:
-        ff = forcefield.copy()
+    _estimate_into_ff(
+        ff,
+        molecules,
+        zero_torsions=zero_torsions,
+        au_hessian=au_hessian,
+        invalid_policy=invalid_policy,
+        processed_hessians=processed_hessians,
+        strategy=strategy,
+    )
 
+
+def _estimate_into_ff(
+    ff: ForceField,
+    molecules: list[Q2MMMolecule],
+    *,
+    zero_torsions: bool,
+    au_hessian: bool,
+    invalid_policy: Literal["keep", "skip"],
+    processed_hessians: dict[int, np.ndarray] | None,
+    strategy: Literal["fuerza", "qfuerza"],
+) -> None:
+    """Inner per-parameter QFUERZA estimation loop.  Skips frozen params."""
     # Estimate bond force constants.  Skip frozen params: their values
     # are caller-owned commitments (e.g. literature OPT params held
     # fixed via freeze_standard_params) and overwriting them silently
-    # was the load_heck_relay bug (q2mm#277).  This loop matches the
-    # skip-frozen convention in ForceField.set_param_vector /
-    # with_params; commit 3 will replace this function entirely with
-    # qfuerza_fresh / qfuerza_into which take an explicit target list
-    # and never iterate frozen params.
+    # was the load_heck_relay bug (q2mm#277).  The FrozenParamError
+    # guard on _FrozenAwareParam is the backstop; this check is the
+    # explicit fast-path.
     for bond_param in ff.bonds:
         if bond_param.frozen:
             continue
@@ -442,5 +531,3 @@ def estimate_force_constants(
             if t.frozen:
                 continue
             t.force_constant = 0.0
-
-    return ff

--- a/scripts/bench_composed.py
+++ b/scripts/bench_composed.py
@@ -215,7 +215,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    from q2mm.diagnostics.systems import load_ch3f
+    from q2mm.diagnostics.systems import load_system
 
     output_dir = args.output
     all_results: list[dict] = []
@@ -259,7 +259,7 @@ def main() -> None:
 
     for backend_name, engine in backends_to_run:
         try:
-            sys_data = load_ch3f(engine, functional_form=form)
+            sys_data = load_system("ch3f", engine=engine, functional_form=form)
         except Exception as e:
             print(f"  Cannot load CH3F {form} for {backend_name}: {e}")
             continue

--- a/scripts/diagnose_heck_relay.py
+++ b/scripts/diagnose_heck_relay.py
@@ -6,9 +6,10 @@ evaluates each against the QM training set:
 A. Untouched Rosales FF — ForceField.from_mm3_fld(include_standard=True),
    no freeze_standard_params, no Seminario re-estimation.
 B. Pre-fix loader pattern — the BUGGY combination that load_heck_relay
-   used before #277 was fixed: ForceField.from_mm3_fld + freeze_standard_params
-   + estimate_force_constants(forcefield=ff).  Reconstructed inline (NOT
-   by calling the current loader), so this diagnostic stays valid as a
+   used before #277 was fixed: ForceField.from_mm3_fld +
+   freeze_standard_params + qfuerza_into(ff, molecules,
+   invert_ts_curvature=True).  Reconstructed inline (NOT by calling
+   the current loader), so this diagnostic stays valid as a
    regression-detection tool after the fix lands.
 C. Seminario-only — ForceField.from_mm3_fld(include_standard=False)
    (Rosales OPT block as the template), then Seminario re-estimates
@@ -222,20 +223,21 @@ def build_ff_b_prefix_loader_pattern(molecules: list[Any]) -> Any:
     """Build baseline B — explicit reconstruction of the PRE-FIX loader bug.
 
     Reproduces the pre-#277 ``load_heck_relay()`` exactly:
-    ``from_mm3_fld(include_standard=True)`` + ``freeze_standard_params`` +
-    ``estimate_force_constants(forcefield=ff)``.  This is the bug we are
-    diagnosing — we do **not** call the current loader, because the
-    current loader was fixed in #280 and no longer reproduces the bug.
-    Keeping the buggy pattern inline here means the diagnostic stays
-    valid as a regression-detection tool even after the fix lands.
+    ``from_mm3_fld(include_standard=True)`` + ``freeze_standard_params``
+    + ``qfuerza_into(ff, molecules, invert_ts_curvature=True)``.  This
+    is the bug we are diagnosing — we do **not** call the current
+    loader, because the current loader was fixed in #280 and no longer
+    reproduces the bug.  Keeping the buggy pattern inline here means
+    the diagnostic stays valid as a regression-detection tool even
+    after the fix lands.
     """
     from q2mm.models.forcefield import ForceField, FunctionalForm
-    from q2mm.models.seminario import estimate_force_constants
+    from q2mm.models.seminario import qfuerza_into
 
     ff = ForceField.from_mm3_fld(str(_ff_path()), include_standard=True)
     opt_ff = ForceField.from_mm3_fld(str(_ff_path()), include_standard=False)
     ff.freeze_standard_params(opt_ff)
-    ff = estimate_force_constants(molecules, forcefield=ff, invert_ts_curvature=True)
+    qfuerza_into(ff, molecules, invert_ts_curvature=True)
     ff.functional_form = FunctionalForm.MM3
     return ff
 
@@ -243,10 +245,11 @@ def build_ff_b_prefix_loader_pattern(molecules: list[Any]) -> Any:
 def build_ff_c_seminario_only(molecules: list[Any]) -> Any:
     """Build baseline C — Seminario over the OPT block, no published values."""
     from q2mm.models.forcefield import ForceField, FunctionalForm
-    from q2mm.models.seminario import estimate_force_constants
+    from q2mm.models.seminario import qfuerza_into
 
     ff_template = ForceField.from_mm3_fld(str(_ff_path()), include_standard=False)
-    ff = estimate_force_constants(molecules, forcefield=ff_template, invert_ts_curvature=True)
+    ff = ff_template.copy()
+    qfuerza_into(ff, molecules, invert_ts_curvature=True)
     ff.functional_form = FunctionalForm.MM3
     return ff
 

--- a/scripts/regenerate_convergence_results.py
+++ b/scripts/regenerate_convergence_results.py
@@ -341,7 +341,7 @@ def process_system(
 ) -> dict[str, Any]:
     """Process one system end-to-end and write its artifacts."""
     from q2mm.backends.mm.jax_engine import JaxEngine
-    from q2mm.diagnostics.systems import SYSTEMS
+    from q2mm.diagnostics.systems import SYSTEMS, load_system
     from q2mm.optimizers.objective import ObjectiveFunction
 
     if system_key not in SYSTEMS:
@@ -349,7 +349,7 @@ def process_system(
 
     logger.info("[%s] loading", system_key)
     engine = JaxEngine()
-    sys_data = SYSTEMS[system_key].loader(engine)
+    sys_data = load_system(system_key, engine=engine)
     ff = sys_data.forcefield
 
     # ---- Seminario fit quality ------------------------------------------

--- a/scripts/regenerate_full_loop_fixtures.py
+++ b/scripts/regenerate_full_loop_fixtures.py
@@ -31,7 +31,7 @@ from q2mm.constants import (
     MASSES,
     SPEED_OF_LIGHT_MS,
 )
-from q2mm.models.seminario import estimate_force_constants
+from q2mm.models.seminario import qfuerza_fresh
 from q2mm.optimizers.objective import ObjectiveFunction, ReferenceData
 from q2mm.optimizers.scipy_opt import ScipyOptimizer
 
@@ -65,7 +65,7 @@ def main() -> None:
 
     # Seminario
     t0 = time.perf_counter()
-    ff = estimate_force_constants(mol, au_hessian=True)
+    ff = qfuerza_fresh(mol, au_hessian=True)
     t_sem = time.perf_counter() - t0
     sem_vec = ff.get_param_vector().copy()
 

--- a/scripts/run_rh_benchmarks.sh
+++ b/scripts/run_rh_benchmarks.sh
@@ -124,12 +124,12 @@ sys.path.insert(0, '.')
 # JAX_PLATFORMS left unset — let JAX auto-detect GPU
 
 from q2mm.backends.mm.jax_engine import JaxEngine
-from q2mm.diagnostics.systems import load_rh_enamide
+from q2mm.diagnostics.systems import load_system
 from q2mm.io.mm3 import _mm3_import_ff
 from q2mm.optimizers.objective import ObjectiveFunction
 
 engine = JaxEngine()
-sys_data = load_rh_enamide(engine)
+sys_data = load_system('rh-enamide', engine=engine)
 qfuerza_dir = Path(os.environ['Q2MM_DATA_REPO']) / 'qfuerza-zenodo'
 
 # Load Zenodo optimized FF (final iteration)

--- a/scripts/validate_against_upstream.py
+++ b/scripts/validate_against_upstream.py
@@ -24,7 +24,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from q2mm.models.forcefield import ForceField
 from q2mm.models.molecule import Q2MMMolecule
-from q2mm.models.seminario import estimate_force_constants, seminario_bond_fc
+from q2mm.models.seminario import qfuerza_into, seminario_bond_fc
 from q2mm.io.jaguar import JaguarIn
 from q2mm.io.macromodel import MacroModel
 from q2mm.io.mol2 import Mol2
@@ -259,13 +259,8 @@ def _run_rh_pipeline_case(fixture_dir: Path, mode: Mode) -> CaseResult:
     ]
     clean_start = ForceField.from_mm3_fld(MM3_PATH)
     with _DisableLogging():
-        clean_estimated = estimate_force_constants(
-            molecules,
-            forcefield=clean_start,
-            zero_torsions=True,
-            au_hessian=True,
-            invalid_policy="skip",
-        )
+        clean_estimated = clean_start.copy()
+        qfuerza_into(clean_estimated, molecules, zero_torsions=True, au_hessian=True, invalid_policy="skip")
 
     fixture_bf = _int_keyed_map(fixture["parameters"]["bond_force_constants_mdyn_a"])
     fixture_be = _int_keyed_map(fixture["parameters"]["bond_equilibria_angstrom"])

--- a/test/benchmarks/test_optimization.py
+++ b/test/benchmarks/test_optimization.py
@@ -19,9 +19,9 @@ pytestmark = [pytest.mark.benchmark, pytest.mark.nightly]
 def _run_and_validate(engine: object) -> None:
     """Run the benchmark pipeline and validate structure."""
     from q2mm.diagnostics.benchmark import run_combo
-    from q2mm.diagnostics.systems import load_ch3f
+    from q2mm.diagnostics.systems import load_system
 
-    sys_data = load_ch3f(engine)
+    sys_data = load_system("ch3f", engine=engine)
     result = run_combo(
         engine=engine,
         sys_data=sys_data,

--- a/test/integration/test_backend_optimizer_matrix.py
+++ b/test/integration/test_backend_optimizer_matrix.py
@@ -186,10 +186,10 @@ class TestBenchmarkPipeline:
     def result(self) -> BenchmarkResult:
         from q2mm.backends.mm.openmm import OpenMMEngine
         from q2mm.diagnostics.benchmark import run_combo
-        from q2mm.diagnostics.systems import load_ch3f
+        from q2mm.diagnostics.systems import load_system
 
         engine = OpenMMEngine()
-        sys_data = load_ch3f(engine)
+        sys_data = load_system("ch3f", engine=engine)
 
         return run_combo(
             engine=engine,

--- a/test/integration/test_e2e_sn2_validation.py
+++ b/test/integration/test_e2e_sn2_validation.py
@@ -45,7 +45,7 @@ from q2mm.diagnostics import TablePrinter, compute_distortions, frequency_mae, f
 from q2mm.diagnostics.benchmark import real_frequencies
 from q2mm.models.forcefield import ForceField
 from q2mm.models.molecule import Q2MMMolecule
-from q2mm.models.seminario import estimate_force_constants
+from q2mm.models.seminario import qfuerza_fresh
 from q2mm.optimizers.objective import ObjectiveFunction, ReferenceData
 from q2mm.optimizers.scipy_opt import ScipyOptimizer
 
@@ -129,7 +129,7 @@ class TestCH3FGroundState:
         hess = np.load(CH3F_HESS)
         mol_h = ch3f_mol.with_hessian(hess)
         t0 = time.perf_counter()
-        ff = estimate_force_constants(mol_h)
+        ff = qfuerza_fresh(mol_h)
         elapsed = time.perf_counter() - t0
         return ff, elapsed
 
@@ -538,7 +538,7 @@ class TestSN2TransitionState:
         hess = np.load(TS_HESS)
         mol_h = ts_mol.with_hessian(hess)
         t0 = time.perf_counter()
-        ff = estimate_force_constants(mol_h)
+        ff = qfuerza_fresh(mol_h)
         elapsed = time.perf_counter() - t0
         return ff, elapsed
 
@@ -734,14 +734,14 @@ class TestSN2ReactionProfile:
         """Seminario FF for CH3F ground state."""
         mol = Q2MMMolecule.from_xyz(CH3F_XYZ, bond_tolerance=1.5)
         hess = np.load(CH3F_HESS)
-        return estimate_force_constants(mol.with_hessian(hess))
+        return qfuerza_fresh(mol.with_hessian(hess))
 
     @pytest.fixture(scope="class")
     def ts_ff(self) -> ForceField:
         """Seminario FF for SN2 TS."""
         mol = Q2MMMolecule.from_xyz(TS_XYZ, bond_tolerance=1.6)
         hess = np.load(TS_HESS)
-        return estimate_force_constants(mol.with_hessian(hess))
+        return qfuerza_fresh(mol.with_hessian(hess))
 
     def test_qm_barrier_matches_literature(self, qm_energies: dict[str, float], ext_ref: dict[str, object]) -> None:
         """Our QM barrier should be in the ballpark of published values."""

--- a/test/integration/test_ethane_seminario.py
+++ b/test/integration/test_ethane_seminario.py
@@ -20,7 +20,8 @@ import pytest
 
 from q2mm.models.forcefield import ForceField
 from q2mm.models.seminario import (
-    estimate_force_constants,
+    qfuerza_fresh,
+    qfuerza_into,
     seminario_angle_fc,
     seminario_bond_fc,
 )
@@ -201,11 +202,11 @@ class TestIndividualAngles:
 # Full pipeline (averaged parameters)
 # ---------------------------------------------------------------------------
 class TestFullPipeline:
-    """End-to-end: .fchk → estimate_force_constants → ForceField."""
+    """End-to-end: .fchk → qfuerza_fresh → ForceField."""
 
     def test_gs_averaged_bond_force_constants(self, reference: dict[str, object]) -> None:
         _, mol = ReferenceData.from_fchk(GS_FCHK)
-        ff = estimate_force_constants(mol)
+        ff = qfuerza_fresh(mol)
         for ref_bond, param in zip(reference["GS"]["averaged_bonds"], ff.bonds):
             np.testing.assert_allclose(
                 param.force_constant,
@@ -216,7 +217,7 @@ class TestFullPipeline:
 
     def test_gs_averaged_bond_equilibria(self, reference: dict[str, object]) -> None:
         _, mol = ReferenceData.from_fchk(GS_FCHK)
-        ff = estimate_force_constants(mol)
+        ff = qfuerza_fresh(mol)
         for ref_bond, param in zip(reference["GS"]["averaged_bonds"], ff.bonds):
             np.testing.assert_allclose(
                 param.equilibrium,
@@ -227,7 +228,7 @@ class TestFullPipeline:
 
     def test_gs_averaged_angle_force_constants(self, reference: dict[str, object]) -> None:
         _, mol = ReferenceData.from_fchk(GS_FCHK)
-        ff = estimate_force_constants(mol)
+        ff = qfuerza_fresh(mol)
         for ref_angle, param in zip(reference["GS"]["averaged_angles"], ff.angles):
             np.testing.assert_allclose(
                 param.force_constant,
@@ -238,7 +239,7 @@ class TestFullPipeline:
 
     def test_gs_averaged_angle_equilibria(self, reference: dict[str, object]) -> None:
         _, mol = ReferenceData.from_fchk(GS_FCHK)
-        ff = estimate_force_constants(mol)
+        ff = qfuerza_fresh(mol)
         for ref_angle, param in zip(reference["GS"]["averaged_angles"], ff.angles):
             np.testing.assert_allclose(
                 param.equilibrium,
@@ -249,7 +250,7 @@ class TestFullPipeline:
 
     def test_ts_averaged_bond_force_constants(self, reference: dict[str, object]) -> None:
         _, mol = ReferenceData.from_fchk(TS_FCHK, bond_tolerance=1.4)
-        ff = estimate_force_constants(mol)
+        ff = qfuerza_fresh(mol)
         for ref_bond, param in zip(reference["TS"]["averaged_bonds"], ff.bonds):
             np.testing.assert_allclose(
                 param.force_constant,
@@ -260,7 +261,7 @@ class TestFullPipeline:
 
     def test_ts_averaged_angle_force_constants(self, reference: dict[str, object]) -> None:
         _, mol = ReferenceData.from_fchk(TS_FCHK, bond_tolerance=1.4)
-        ff = estimate_force_constants(mol)
+        ff = qfuerza_fresh(mol)
         for ref_angle, param in zip(reference["TS"]["averaged_angles"], ff.angles):
             np.testing.assert_allclose(
                 param.force_constant,
@@ -271,12 +272,12 @@ class TestFullPipeline:
 
     def test_forcefield_returns_correct_type(self) -> None:
         _, mol = ReferenceData.from_fchk(GS_FCHK)
-        ff = estimate_force_constants(mol)
+        ff = qfuerza_fresh(mol)
         assert isinstance(ff, ForceField)
 
     def test_torsions_zeroed_by_default(self) -> None:
         _, mol = ReferenceData.from_fchk(GS_FCHK)
-        ff = estimate_force_constants(mol)
+        ff = qfuerza_fresh(mol)
         for t in ff.torsions:
             assert t.force_constant == 0.0
 
@@ -290,12 +291,12 @@ class TestGSvsTSComparison:
     @pytest.fixture(scope="class")
     def gs_ff(self) -> ForceField:
         _, mol = ReferenceData.from_fchk(GS_FCHK)
-        return estimate_force_constants(mol)
+        return qfuerza_fresh(mol)
 
     @pytest.fixture(scope="class")
     def ts_ff(self) -> ForceField:
         _, mol = ReferenceData.from_fchk(TS_FCHK, bond_tolerance=1.4)
-        return estimate_force_constants(mol)
+        return qfuerza_fresh(mol)
 
     def test_ts_cc_bond_longer(self, gs_ff: ForceField, ts_ff: ForceField) -> None:
         """Eclipsed TS has longer C-C bond due to steric repulsion."""
@@ -362,14 +363,15 @@ class TestMultiMoleculeAveraging:
         _, ts_mol = ReferenceData.from_fchk(TS_FCHK, bond_tolerance=1.4)
 
         # Get individual values
-        gs_ff = estimate_force_constants(gs_mol)
-        ts_ff = estimate_force_constants(ts_mol)
+        gs_ff = qfuerza_fresh(gs_mol)
+        ts_ff = qfuerza_fresh(ts_mol)
         gs_cc = next(b for b in gs_ff.bonds if b.elements == ("C", "C"))
         ts_cc = next(b for b in ts_ff.bonds if b.elements == ("C", "C"))
 
         # Create shared force field for averaging
         shared_ff = ForceField.create_for_molecule(gs_mol, name="shared")
-        avg_ff = estimate_force_constants([gs_mol, ts_mol], forcefield=shared_ff)
+        avg_ff = shared_ff.copy()
+        qfuerza_into(avg_ff, [gs_mol, ts_mol])
         avg_cc = next(b for b in avg_ff.bonds if b.elements == ("C", "C"))
 
         lo = min(gs_cc.force_constant, ts_cc.force_constant)
@@ -396,7 +398,7 @@ class TestLiteratureValidation:
     @pytest.fixture(scope="class")
     def gs_ff(self) -> ForceField:
         _, mol = ReferenceData.from_fchk(GS_FCHK)
-        return estimate_force_constants(mol)
+        return qfuerza_fresh(mol)
 
     def test_cc_fc_in_literature_range(self, gs_ff: ForceField) -> None:
         """C-C stretch FC should be ~180-468 kcal/(mol·Å²) (Seminario from DFT can be softer than MM3)."""

--- a/test/integration/test_full_loop_parity.py
+++ b/test/integration/test_full_loop_parity.py
@@ -153,7 +153,7 @@ class TestRhEnamideSeminarioTiming:
     ) -> None:
         """Time the full Seminario pipeline on 9 rh-enamide structures."""
         from q2mm.models.forcefield import ForceField
-        from q2mm.models.seminario import estimate_force_constants
+        from q2mm.models.seminario import qfuerza_into
 
         mm3_path = RH_DIR / "mm3.fld"
         if not mm3_path.exists():
@@ -161,7 +161,8 @@ class TestRhEnamideSeminarioTiming:
         ff_template = ForceField.from_mm3_fld(str(mm3_path))
 
         t0 = time.perf_counter()
-        ff = estimate_force_constants(rh_molecules, forcefield=ff_template)
+        ff = ff_template.copy()
+        qfuerza_into(ff, rh_molecules)
         elapsed = time.perf_counter() - t0
 
         with capsys.disabled():
@@ -176,15 +177,17 @@ class TestRhEnamideSeminarioTiming:
     def test_seminario_is_deterministic(self, rh_molecules: list[Q2MMMolecule]) -> None:
         """Two consecutive Seminario runs produce identical results."""
         from q2mm.models.forcefield import ForceField
-        from q2mm.models.seminario import estimate_force_constants
+        from q2mm.models.seminario import qfuerza_into
 
         mm3_path = RH_DIR / "mm3.fld"
         if not mm3_path.exists():
             pytest.skip("mm3.fld not found")
         ff_template = ForceField.from_mm3_fld(str(mm3_path))
 
-        ff1 = estimate_force_constants(rh_molecules, forcefield=ff_template)
-        ff2 = estimate_force_constants(rh_molecules, forcefield=ff_template)
+        ff1 = ff_template.copy()
+        qfuerza_into(ff1, rh_molecules)
+        ff2 = ff_template.copy()
+        qfuerza_into(ff2, rh_molecules)
 
         np.testing.assert_array_equal(
             ff1.get_param_vector(),
@@ -224,7 +227,7 @@ class TestRhEnamideFullLoop:
         """Run the full rh-enamide pipeline."""
         from q2mm.backends.mm import OpenMMEngine
         from q2mm.models.forcefield import ForceField
-        from q2mm.models.seminario import estimate_force_constants
+        from q2mm.models.seminario import qfuerza_into
         from q2mm.optimizers.objective import ObjectiveFunction
         from q2mm.optimizers.scipy_opt import ScipyOptimizer
 
@@ -240,7 +243,8 @@ class TestRhEnamideFullLoop:
 
         # Seminario estimation
         t0 = time.perf_counter()
-        ff = estimate_force_constants(molecules, forcefield=ff_template)
+        ff = ff_template.copy()
+        qfuerza_into(ff, molecules)
         t_seminario = time.perf_counter() - t0
         seminario_params = ff.get_param_vector().copy()
 
@@ -368,7 +372,7 @@ class TestEthaneFullLoop:
     def pipeline_result(self) -> dict[str, object]:
         """Run the full pipeline and return all intermediate results."""
         from q2mm.backends.mm import OpenMMEngine
-        from q2mm.models.seminario import estimate_force_constants
+        from q2mm.models.seminario import qfuerza_fresh
         from q2mm.optimizers.objective import ObjectiveFunction, ReferenceData
         from q2mm.optimizers.scipy_opt import ScipyOptimizer
 
@@ -382,7 +386,7 @@ class TestEthaneFullLoop:
 
         # Seminario estimation
         t_sem_start = time.perf_counter()
-        ff = estimate_force_constants(mol, au_hessian=True)
+        ff = qfuerza_fresh(mol, au_hessian=True)
         t_sem = time.perf_counter() - t_sem_start
         seminario_params = ff.get_param_vector().copy()
 
@@ -541,14 +545,14 @@ class TestEthaneTSSeminario:
 
     @pytest.fixture(scope="class")
     def ts_result(self) -> dict[str, object]:
-        from q2mm.models.seminario import estimate_force_constants
+        from q2mm.models.seminario import qfuerza_fresh
         from q2mm.optimizers.objective import ReferenceData
 
         if not TS_FCHK.exists():
             pytest.skip("Ethane TS.fchk not found")
 
         ref, mol = ReferenceData.from_fchk(str(TS_FCHK), bond_tolerance=1.4)
-        ff = estimate_force_constants(mol, au_hessian=True)
+        ff = qfuerza_fresh(mol, au_hessian=True)
         qm_freqs = _qm_frequencies_from_hessian(mol.hessian, mol.symbols)
         return {"mol": mol, "ff": ff, "qm_freqs": qm_freqs}
 
@@ -572,11 +576,11 @@ class TestEthaneTSSeminario:
 
     def test_ts_seminario_matches_gs_approximately(self, ts_result: dict[str, object]) -> None:
         """TS and GS Seminario parameters should be similar (same molecule)."""
-        from q2mm.models.seminario import estimate_force_constants
+        from q2mm.models.seminario import qfuerza_fresh
         from q2mm.optimizers.objective import ReferenceData
 
         ref_gs, mol_gs = ReferenceData.from_fchk(str(GS_FCHK), bond_tolerance=1.4)
-        ff_gs = estimate_force_constants(mol_gs, au_hessian=True)
+        ff_gs = qfuerza_fresh(mol_gs, au_hessian=True)
 
         ff_ts = ts_result["ff"]
         gs_params = ff_gs.get_param_vector()
@@ -606,7 +610,7 @@ class TestPipelineDeterminism:
     def test_full_pipeline_is_deterministic(self) -> None:
         """Two independent pipeline runs yield identical scores and params."""
         from q2mm.backends.mm import OpenMMEngine
-        from q2mm.models.seminario import estimate_force_constants
+        from q2mm.models.seminario import qfuerza_fresh
         from q2mm.optimizers.objective import ObjectiveFunction, ReferenceData
         from q2mm.optimizers.scipy_opt import ScipyOptimizer
 
@@ -616,7 +620,7 @@ class TestPipelineDeterminism:
         results = []
         for _ in range(2):
             ref, mol = ReferenceData.from_fchk(str(GS_FCHK), bond_tolerance=1.4)
-            ff = estimate_force_constants(mol, au_hessian=True)
+            ff = qfuerza_fresh(mol, au_hessian=True)
             engine = OpenMMEngine()
 
             qm_freqs = _qm_frequencies_from_hessian(mol.hessian, mol.symbols)
@@ -653,7 +657,7 @@ def _rh_enamide_harmonic_pipeline(
     regardless of the template FF's functional form).
     """
     from q2mm.models.forcefield import ForceField, FunctionalForm
-    from q2mm.models.seminario import estimate_force_constants
+    from q2mm.models.seminario import qfuerza_into
     from q2mm.optimizers.objective import ObjectiveFunction
     from q2mm.optimizers.scipy_opt import ScipyOptimizer
 
@@ -665,7 +669,8 @@ def _rh_enamide_harmonic_pipeline(
 
     # Seminario estimation produces harmonic force constants
     t0 = time.perf_counter()
-    ff = estimate_force_constants(molecules, forcefield=ff_template)
+    ff = ff_template.copy()
+    qfuerza_into(ff, molecules)
     t_seminario = time.perf_counter() - t0
 
     # Switch to harmonic functional form for JAX compatibility

--- a/test/integration/test_heck_validation.py
+++ b/test/integration/test_heck_validation.py
@@ -208,13 +208,14 @@ class TestHeckRelayPublishedFF:
     def seminario_ff(self, molecules: list[Any]) -> Any:
         """Build a Seminario-estimated FF as the unoptimized baseline."""
         from q2mm.models.forcefield import ForceField
-        from q2mm.models.seminario import estimate_force_constants
+        from q2mm.models.seminario import qfuerza_into
 
         if HECK_DIR is None:
             pytest.skip("Heck relay supporting data not found")
         ff_path = HECK_DIR / "mm3.FF1.fld"
         ff_template = ForceField.from_mm3_fld(str(ff_path))
-        return estimate_force_constants(molecules, forcefield=ff_template)
+        qfuerza_into(ff_template, molecules)
+        return ff_template
 
     @pytest.fixture(scope="class")
     def engine(self) -> Any:
@@ -377,7 +378,7 @@ class TestHeckRelayPublishedFF:
 def test_load_heck_relay_preserves_published_opt_values() -> None:
     """Regression: loader must NOT overwrite published Rosales OPT params.
 
-    Before #277, ``load_heck_relay()`` called ``estimate_force_constants``
+    Before #277, ``load_heck_relay()`` called `qfuerza_fresh` / `qfuerza_into`
     after ``freeze_standard_params``, which silently re-projected the
     OPT-substructure parameter values via FUERZA — discarding Rosales'
     fitted values.  After the fix, the loader should keep those values

--- a/test/integration/test_heck_validation.py
+++ b/test/integration/test_heck_validation.py
@@ -389,7 +389,7 @@ def test_load_heck_relay_preserves_published_opt_values() -> None:
     if HECK_DIR is None:
         pytest.skip("Heck relay supporting data not found")
 
-    from q2mm.diagnostics.systems import load_heck_relay
+    from q2mm.diagnostics.systems import load_system
     from q2mm.models.forcefield import ForceField
 
     ff_path = HECK_DIR / "mm3.FF1.fld"
@@ -397,7 +397,7 @@ def test_load_heck_relay_preserves_published_opt_values() -> None:
         pytest.skip(f"mm3.FF1.fld not found: {ff_path}")
 
     # Loader output (what users get today).
-    sys_data = load_heck_relay(engine=None)
+    sys_data = load_system("heck-relay")
     loader_active = sys_data.forcefield.get_active_param_vector()
 
     # Same .fld file, same active-mask partition, but no Seminario.

--- a/test/integration/test_jax_backend.py
+++ b/test/integration/test_jax_backend.py
@@ -652,7 +652,7 @@ class TestCH3FAnalyticalGradients:
     """Validate analytical gradients on CH₃F (5 atoms, 8 params).
 
     Uses pinned QFUERZA force field parameters — does NOT depend on
-    ``estimate_force_constants()`` or Seminario defaults.  The frequency
+    ``qfuerza_fresh()`` or Seminario defaults.  The frequency
     gradient vs FD test is intentionally excluded: CH₃F's C₃v symmetry
     produces near-degenerate E-mode frequency pairs (57 cm⁻¹ gap with
     QFUERZA), and FD diverges at eigenvalue crossings.  Frequency gradient

--- a/test/integration/test_jaxopt.py
+++ b/test/integration/test_jaxopt.py
@@ -35,7 +35,7 @@ from test._shared import (
 
 from q2mm.models.forcefield import AngleParam, BondParam, ForceField
 from q2mm.models.molecule import Q2MMMolecule
-from q2mm.models.seminario import estimate_force_constants
+from q2mm.models.seminario import qfuerza_fresh
 
 JaxEngine = None
 
@@ -151,7 +151,7 @@ class TestJaxOptCH3FValidation:
     def seminario_ff(self, ch3f_mol: Q2MMMolecule) -> ForceField:
         hess = np.load(CH3F_HESS)
         mol_h = ch3f_mol.with_hessian(hess)
-        return estimate_force_constants(mol_h)
+        return qfuerza_fresh(mol_h)
 
     def test_freq_only_convergence(
         self,
@@ -324,7 +324,7 @@ class TestJaxOptSN2TSValidation:
     def ts_seminario_ff(self, ts_mol: Q2MMMolecule) -> ForceField:
         hess = np.load(SN2_HESSIAN)
         mol_h = ts_mol.with_hessian(hess)
-        return estimate_force_constants(mol_h, invert_ts_curvature=True)
+        return qfuerza_fresh(mol_h, invert_ts_curvature=True)
 
     def test_sn2_ts_freq_convergence(
         self,

--- a/test/integration/test_openmm_backend.py
+++ b/test/integration/test_openmm_backend.py
@@ -23,7 +23,7 @@ from test._shared import SN2_HESSIAN as TS_HESS, SN2_XYZ as TS_XYZ, make_diatomi
 from q2mm.backends.mm.openmm import OpenMMEngine
 from q2mm.models.forcefield import AngleParam, BondParam, ForceField, VdwParam
 from q2mm.models.molecule import Q2MMMolecule
-from q2mm.models.seminario import estimate_force_constants
+from q2mm.models.seminario import qfuerza_fresh
 
 try:
     from q2mm.backends.mm.tinker import TinkerEngine
@@ -120,7 +120,7 @@ class TestOpenMMEngine:
 
     def test_sn2_seminario_pipeline_energy_is_finite(self) -> None:
         molecule = Q2MMMolecule.from_xyz(TS_XYZ, bond_tolerance=1.5).with_hessian(np.load(TS_HESS))
-        forcefield = estimate_force_constants(molecule)
+        forcefield = qfuerza_fresh(molecule)
 
         energy = self.engine.energy(molecule, forcefield)
         hessian = self.engine.hessian(molecule, forcefield)
@@ -131,7 +131,7 @@ class TestOpenMMEngine:
 
     def test_sn2_seminario_pipeline_has_imaginary_mode(self) -> None:
         molecule = Q2MMMolecule.from_xyz(TS_XYZ, bond_tolerance=1.5).with_hessian(np.load(TS_HESS))
-        forcefield = estimate_force_constants(molecule)
+        forcefield = qfuerza_fresh(molecule)
 
         frequencies = self.engine.frequencies(molecule, forcefield)
 

--- a/test/integration/test_openmm_export.py
+++ b/test/integration/test_openmm_export.py
@@ -131,10 +131,10 @@ class TestSystemXMLExport:
         assert loaded_energy == pytest.approx(original_energy, abs=1e-8)
 
     def test_sn2_system_xml_round_trip(self, tmp_path: Path) -> None:
-        from q2mm.models.seminario import estimate_force_constants
+        from q2mm.models.seminario import qfuerza_fresh
 
         molecule = Q2MMMolecule.from_xyz(TS_XYZ, bond_tolerance=1.5).with_hessian(np.load(TS_HESS))
-        ff = estimate_force_constants(molecule)
+        ff = qfuerza_fresh(molecule)
 
         original_energy = self.engine.energy(molecule, ff)
 
@@ -333,10 +333,10 @@ class TestForceFieldXMLExport:
 
     def test_sn2_forcefield_xml_export(self, tmp_path: Path) -> None:
         """Export Seminario-estimated SN2 force field to ForceField XML."""
-        from q2mm.models.seminario import estimate_force_constants
+        from q2mm.models.seminario import qfuerza_fresh
 
         molecule = Q2MMMolecule.from_xyz(TS_XYZ, bond_tolerance=1.5).with_hessian(np.load(TS_HESS))
-        ff = estimate_force_constants(molecule)
+        ff = qfuerza_fresh(molecule)
 
         out = ff.to_openmm_xml(tmp_path / "sn2_ff.xml", molecule=molecule)
 

--- a/test/integration/test_optimization_validation.py
+++ b/test/integration/test_optimization_validation.py
@@ -31,7 +31,7 @@ from q2mm.backends.base import MMEngine
 from q2mm.backends.mm.openmm import OpenMMEngine
 from q2mm.models.forcefield import AngleParam, BondParam, ForceField
 from q2mm.models.molecule import Q2MMMolecule
-from q2mm.models.seminario import estimate_force_constants
+from q2mm.models.seminario import qfuerza_fresh
 from q2mm.optimizers.objective import ObjectiveFunction, ReferenceData, ReferenceValue
 from q2mm.optimizers.scipy_opt import ScipyOptimizer
 
@@ -161,7 +161,7 @@ class TestSeminarioOptimizePipeline:
         mol = Q2MMMolecule.from_xyz(CH3F_XYZ)
         hess = np.load(CH3F_HESS)
         mol_h = mol.with_hessian(hess)
-        return estimate_force_constants(mol_h), mol
+        return qfuerza_fresh(mol_h), mol
 
     def test_seminario_ff_can_evaluate(self, ch3f_seminario_ff: tuple[ForceField, Q2MMMolecule]) -> None:
         """Seminario-derived FF can compute energy via OpenMM."""

--- a/test/integration/test_published_ff_validation.py
+++ b/test/integration/test_published_ff_validation.py
@@ -326,12 +326,13 @@ class TestPublishedFFEvaluation:
     def seminario_ff(self, molecules: list[Any]) -> Any:
         """Build a Seminario-estimated FF as the unoptimized baseline."""
         from q2mm.models.forcefield import ForceField
-        from q2mm.models.seminario import estimate_force_constants
+        from q2mm.models.seminario import qfuerza_into
 
         if not MM3_FLD_PATH.exists():
             pytest.skip(f"mm3.fld not found: {MM3_FLD_PATH}")
         ff_template = ForceField.from_mm3_fld(str(MM3_FLD_PATH))
-        return estimate_force_constants(molecules, forcefield=ff_template)
+        qfuerza_into(ff_template, molecules)
+        return ff_template
 
     @pytest.fixture(scope="class")
     def engine(self) -> Any:

--- a/test/integration/test_seminario_parity.py
+++ b/test/integration/test_seminario_parity.py
@@ -33,7 +33,8 @@ from test._shared import REPO_ROOT, SN2_XYZ, SN2_HESSIAN
 from q2mm.models.forcefield import ForceField
 from q2mm.models.molecule import Q2MMMolecule
 from q2mm.models.seminario import (
-    estimate_force_constants,
+    qfuerza_fresh,
+    qfuerza_into,
     seminario_bond_fc,
     QFUERZA_H_ANGLE_DEFAULT_MDYNA,
     _is_hydrogen_angle,
@@ -126,13 +127,8 @@ def rh_enamide_clean_results() -> dict[str, ForceField]:
         for index, (structure, hessian) in enumerate(zip(structures, hessians))
     ]
     clean_start = ForceField.from_mm3_fld(MM3_PATH, include_standard=False)
-    clean_estimated = estimate_force_constants(
-        molecules,
-        forcefield=clean_start,
-        zero_torsions=True,
-        au_hessian=True,
-        invalid_policy="skip",
-    )
+    clean_estimated = clean_start.copy()
+    qfuerza_into(clean_estimated, molecules, zero_torsions=True, au_hessian=True, invalid_policy="skip")
 
     return {
         "clean_start": clean_start,
@@ -257,11 +253,13 @@ def test_rh_enamide_forcefield_roundtrip() -> None:
     ]
 
     ff1 = ForceField.from_mm3_fld(MM3_PATH)
-    est1 = estimate_force_constants(molecules, forcefield=ff1, invalid_policy="skip")
+    est1 = ff1.copy()
+    qfuerza_into(est1, molecules, invalid_policy="skip")
 
     # Re-estimate from the same starting point — must be deterministic
     ff2 = ForceField.from_mm3_fld(MM3_PATH)
-    est2 = estimate_force_constants(molecules, forcefield=ff2, invalid_policy="skip")
+    est2 = ff2.copy()
+    qfuerza_into(est2, molecules, invalid_policy="skip")
 
     for b1, b2 in zip(est1.bonds, est2.bonds):
         assert b1.force_constant == pytest.approx(b2.force_constant, abs=1e-12)
@@ -346,7 +344,7 @@ def test_rh_enamide_seminario_benchmark(
     for _ in range(10):
         ff = ff_template.copy()
         t0 = time.perf_counter()
-        estimate_force_constants(molecules, forcefield=ff, invalid_policy="skip")
+        qfuerza_into(ff, molecules, invalid_policy="skip")
         times.append(time.perf_counter() - t0)
 
     t_est_mean = np.mean(times)
@@ -645,7 +643,7 @@ class TestCisplatinHessianParity:
         Tests self-consistency: our code produces stable values from the
         Gaussian log.  Uses default dft_scaling=0.963.
         """
-        ff = estimate_force_constants(cisplatin_molecule, strategy="fuerza")
+        ff = qfuerza_fresh(cisplatin_molecule, strategy="fuerza")
 
         # Expected values from our pipeline (mdyne/Å, with default DFT scaling)
         expected = {
@@ -663,7 +661,7 @@ class TestCisplatinHessianParity:
 
     def test_fuerza_bond_equilibria(self, cisplatin_molecule: Q2MMMolecule) -> None:
         """Bond equilibrium lengths must match the optimized QM geometry."""
-        ff = estimate_force_constants(cisplatin_molecule, strategy="fuerza")
+        ff = qfuerza_fresh(cisplatin_molecule, strategy="fuerza")
 
         expected_eq = {
             ("Cl", "Pt"): 2.32,
@@ -681,7 +679,7 @@ class TestCisplatinHessianParity:
 
     def test_fuerza_angle_fcs_self_consistent(self, cisplatin_molecule: Q2MMMolecule) -> None:
         """FUERZA angle FCs must be reproducible from the Hessian."""
-        ff = estimate_force_constants(cisplatin_molecule, strategy="fuerza")
+        ff = qfuerza_fresh(cisplatin_molecule, strategy="fuerza")
 
         # Expected values (kcal/(mol·rad²), with default DFT scaling)
         expected = {
@@ -702,8 +700,8 @@ class TestCisplatinHessianParity:
 
     def test_qfuerza_bonds_same_as_fuerza(self, cisplatin_molecule: Q2MMMolecule) -> None:
         """QFUERZA must not modify bond force constants."""
-        ff_f = estimate_force_constants(cisplatin_molecule, strategy="fuerza")
-        ff_q = estimate_force_constants(cisplatin_molecule, strategy="qfuerza")
+        ff_f = qfuerza_fresh(cisplatin_molecule, strategy="fuerza")
+        ff_q = qfuerza_fresh(cisplatin_molecule, strategy="qfuerza")
 
         ff_f_bonds = {bp.key: bp for bp in ff_f.bonds}
         ff_q_bonds = {bp.key: bp for bp in ff_q.bonds}
@@ -717,7 +715,7 @@ class TestCisplatinHessianParity:
 
         This matches the paper's QFUERZA definition exactly.
         """
-        ff = estimate_force_constants(cisplatin_molecule, strategy="qfuerza")
+        ff = qfuerza_fresh(cisplatin_molecule, strategy="qfuerza")
 
         h_angle_keys = [("H", "N", "Pt"), ("H", "N", "H")]
         for ap in ff.angles:
@@ -729,8 +727,8 @@ class TestCisplatinHessianParity:
 
     def test_qfuerza_heavy_angles_unchanged(self, cisplatin_molecule: Q2MMMolecule) -> None:
         """QFUERZA must not modify non-hydrogen angle FCs."""
-        ff_f = estimate_force_constants(cisplatin_molecule, strategy="fuerza")
-        ff_q = estimate_force_constants(cisplatin_molecule, strategy="qfuerza")
+        ff_f = qfuerza_fresh(cisplatin_molecule, strategy="fuerza")
+        ff_q = qfuerza_fresh(cisplatin_molecule, strategy="qfuerza")
 
         ff_f_angles = {ap.key: ap for ap in ff_f.angles}
         ff_q_angles = {ap.key: ap for ap in ff_q.angles}
@@ -745,8 +743,8 @@ class TestCisplatinHessianParity:
 
     def test_qfuerza_h_angles_reduced_from_fuerza(self, cisplatin_molecule: Q2MMMolecule) -> None:
         """QFUERZA H-angle FCs must be smaller than FUERZA (corrects overestimation)."""
-        ff_f = estimate_force_constants(cisplatin_molecule, strategy="fuerza")
-        ff_q = estimate_force_constants(cisplatin_molecule, strategy="qfuerza")
+        ff_f = qfuerza_fresh(cisplatin_molecule, strategy="fuerza")
+        ff_q = qfuerza_fresh(cisplatin_molecule, strategy="qfuerza")
 
         ff_f_angles = {ap.key: ap for ap in ff_f.angles}
         ff_q_angles = {ap.key: ap for ap in ff_q.angles}

--- a/test/test_jaxopt_optimizer.py
+++ b/test/test_jaxopt_optimizer.py
@@ -242,7 +242,7 @@ class TestJaxOptFrequencyConvergence:
         """L-BFGS converges on CH3F frequency optimization."""
         from q2mm.models.hessian import hessian_to_frequencies
         from q2mm.models.molecule import Q2MMMolecule
-        from q2mm.models.seminario import estimate_force_constants
+        from q2mm.models.seminario import qfuerza_fresh
         from q2mm.optimizers.jaxopt_opt import JaxOptOptimizer
         from q2mm.optimizers.objective import ObjectiveFunction, ReferenceData
 
@@ -253,7 +253,7 @@ class TestJaxOptFrequencyConvergence:
         mol = mol.with_hessian(hess_qm)
 
         # Build a real FF and perturb it
-        ff = estimate_force_constants(mol)
+        ff = qfuerza_fresh(mol)
         freqs_qm = hessian_to_frequencies(hess_qm, list(mol.symbols))
 
         # Perturb bond force constants by 20%

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -746,8 +746,14 @@ class TestForceField:
     def test_mm3_export_updates_template(self, tmp_path: Path) -> None:
         ff = ForceField.from_mm3_fld(RH_MM3)
         first_bond = ff.bonds[0]
+        # Mutating a value field on a frozen param now raises FrozenParamError
+        # (q2mm#277 follow-up). The test's intent is roundtrip fidelity, not
+        # frozenness, so unfreeze for the edit and re-freeze for parity with
+        # the original FF state.
+        first_bond.unfreeze()
         first_bond.force_constant += 1.234
         first_bond.equilibrium += 0.123
+        first_bond.freeze()
 
         out_path = tmp_path / "updated_mm3.fld"
         ff.to_mm3_fld(out_path)
@@ -1783,3 +1789,134 @@ class TestSaverFormValidation:
         assert ff.functional_form is None
         result = save_amber_frcmod(ff, tmp_path / "out.frcmod")
         assert result.exists()
+
+
+class TestFrozenParamInvariant:
+    """Frozen params raise FrozenParamError when value fields are mutated.
+
+    The invariant exists to prevent silent overwriting of literature /
+    held-fixed parameter values (the q2mm#277 bug).  See the docstring
+    of :class:`q2mm.models.forcefield.FrozenParamError` for the user
+    workflow (``.unfreeze()`` to opt in to the override).
+    """
+
+    def test_setting_value_on_frozen_bond_raises(self) -> None:
+        from q2mm.models.forcefield import BondParam, FrozenParamError
+
+        b = BondParam(("C", "F"), 1.38, 359.7, frozen=True)
+        with pytest.raises(FrozenParamError, match="BondParam.force_constant"):
+            b.force_constant = 500.0
+        with pytest.raises(FrozenParamError, match="BondParam.equilibrium"):
+            b.equilibrium = 1.5
+
+    def test_setting_value_on_frozen_angle_raises(self) -> None:
+        from q2mm.models.forcefield import AngleParam, FrozenParamError
+
+        a = AngleParam(("H", "C", "F"), 109.5, 50.0, frozen=True)
+        with pytest.raises(FrozenParamError, match="AngleParam.force_constant"):
+            a.force_constant = 80.0
+        with pytest.raises(FrozenParamError, match="AngleParam.ub_force_constant"):
+            a.ub_force_constant = 10.0
+
+    def test_setting_value_on_frozen_torsion_raises(self) -> None:
+        from q2mm.models.forcefield import FrozenParamError, TorsionParam
+
+        t = TorsionParam(("H", "C", "C", "H"), periodicity=3, force_constant=0.16, frozen=True)
+        with pytest.raises(FrozenParamError, match="TorsionParam.force_constant"):
+            t.force_constant = 0.5
+
+    def test_setting_value_on_frozen_vdw_raises(self) -> None:
+        from q2mm.models.forcefield import FrozenParamError, VdwParam
+
+        v = VdwParam("C1", 1.96, 0.044, frozen=True)
+        with pytest.raises(FrozenParamError, match="VdwParam.radius"):
+            v.radius = 2.0
+
+    def test_setting_value_on_frozen_stretch_bend_raises(self) -> None:
+        from q2mm.models.forcefield import FrozenParamError, StretchBendParam
+
+        sb = StretchBendParam(("H", "C", "F"), force_constant=0.75, frozen=True)
+        with pytest.raises(FrozenParamError, match="StretchBendParam.force_constant"):
+            sb.force_constant = 1.0
+
+    def test_setting_value_on_unfrozen_param_works(self) -> None:
+        from q2mm.models.forcefield import BondParam
+
+        b = BondParam(("C", "F"), 1.38, 359.7, frozen=False)
+        b.force_constant = 500.0
+        assert b.force_constant == 500.0
+
+    def test_freeze_unfreeze_methods_toggle_invariant(self) -> None:
+        from q2mm.models.forcefield import BondParam, FrozenParamError
+
+        b = BondParam(("C", "F"), 1.38, 359.7)
+        assert not b.frozen
+
+        b.freeze()
+        assert b.frozen
+        with pytest.raises(FrozenParamError):
+            b.force_constant = 999.0
+
+        b.unfreeze()
+        assert not b.frozen
+        b.force_constant = 999.0
+        assert b.force_constant == 999.0
+
+    def test_construction_with_frozen_true_assigns_initial_values(self) -> None:
+        """Bypass the guard during __init__ so ``frozen=True`` constructs work."""
+        from q2mm.models.forcefield import BondParam
+
+        b = BondParam(("C", "F"), 1.38, 359.7, frozen=True)
+        assert b.frozen
+        assert b.force_constant == 359.7
+        assert b.equilibrium == 1.38
+
+    def test_assigning_frozen_directly_is_not_guarded(self) -> None:
+        """``frozen`` itself is not a value field; direct assignment works.
+
+        This is the documented escape hatch for code that prefers
+        ``param.frozen = False`` over ``param.unfreeze()``.
+        """
+        from q2mm.models.forcefield import BondParam
+
+        b = BondParam(("C", "F"), 1.38, 359.7, frozen=True)
+        b.frozen = False
+        b.force_constant = 999.0
+        assert b.force_constant == 999.0
+
+    def test_estimate_force_constants_does_not_overwrite_frozen_opt_block(self) -> None:
+        """Regression for the q2mm#277 pattern at the unit level.
+
+        ``estimate_force_constants(forcefield=ff)`` must not overwrite
+        the values of any frozen param.  The Heck-relay loader bug fell
+        out of this contract being silently violated; now both the
+        skip-frozen shortcut in seminario.py and the FrozenParamError
+        guard back it up.
+        """
+        import numpy as np
+
+        from q2mm.models.forcefield import BondParam, ForceField
+        from q2mm.models.molecule import Q2MMMolecule
+        from q2mm.models.seminario import estimate_force_constants
+
+        # Build a tiny FF whose only bond is frozen at a marker value.
+        marker_k = 12345.67
+        ff = ForceField(
+            bonds=[BondParam(("C", "F"), 1.38, marker_k, frozen=True)],
+        )
+
+        # Minimal two-atom molecule with a dummy Hessian — Seminario's
+        # bond loop will iterate ff.bonds; the skip-frozen branch must
+        # bypass it without touching the value.
+        mol = Q2MMMolecule(
+            symbols=["C", "F"],
+            geometry=np.array([[0.0, 0.0, 0.0], [1.38, 0.0, 0.0]]),
+            bond_tolerance=1.5,
+            hessian=np.eye(6),
+        )
+
+        result = estimate_force_constants(mol, forcefield=ff)
+        assert result.bonds[0].force_constant == marker_k, (
+            "Frozen bond force constant was silently overwritten by estimate_force_constants — "
+            "this is the q2mm#277 bug pattern."
+        )

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -21,7 +21,8 @@ from q2mm.models.forcefield import (
     _extract_element,
 )
 from q2mm.models.seminario import (
-    estimate_force_constants,
+    qfuerza_fresh,
+    qfuerza_into,
     _is_hydrogen_angle,
     QFUERZA_H_ANGLE_DEFAULT_CANONICAL,
 )
@@ -1565,18 +1566,18 @@ class TestSeminario:
         return mol.with_hessian(hess)
 
     def test_estimate_runs(self, ch3f_mol_with_hess: Q2MMMolecule) -> None:
-        ff = estimate_force_constants(ch3f_mol_with_hess)
+        ff = qfuerza_fresh(ch3f_mol_with_hess)
         assert len(ff.bonds) > 0
         assert len(ff.angles) > 0
 
     def test_fc_values_positive_ground_state(self, ch3f_mol_with_hess: Q2MMMolecule) -> None:
-        ff = estimate_force_constants(ch3f_mol_with_hess)
+        ff = qfuerza_fresh(ch3f_mol_with_hess)
         for b in ff.bonds:
             assert b.force_constant > 0, f"Bond {b.key} has non-positive FC"
 
     def test_negative_fc_included_for_ts(self, ts_mol_with_hess: Q2MMMolecule) -> None:
         """Negative FCs from TS reaction coordinates should be included, not dropped."""
-        ff = estimate_force_constants(ts_mol_with_hess)
+        ff = qfuerza_fresh(ts_mol_with_hess)
         bond_fcs = [b.force_constant for b in ff.bonds]
         # The C-F bond in the TS is partially breaking — may have negative FC
         # At minimum, verify the estimation completes and produces values
@@ -1595,7 +1596,8 @@ class TestSeminario:
             TorsionParam(("H", "C", "C", "F"), periodicity=1, force_constant=8.0),
         ]
 
-        estimated = estimate_force_constants(ch3f_mol_with_hess, forcefield=ff)
+        estimated = ff.copy()
+        qfuerza_into(estimated, ch3f_mol_with_hess)
 
         assert estimated.bonds[0].force_constant == pytest.approx(123.0)
         assert estimated.bonds[0].equilibrium == pytest.approx(9.9)
@@ -1607,7 +1609,7 @@ class TestSeminario:
     def test_raises_without_hessian(self) -> None:
         mol = Q2MMMolecule.from_xyz(CH3F_XYZ)
         with pytest.raises(ValueError, match="Hessian"):
-            estimate_force_constants(mol)
+            qfuerza_fresh(mol)
 
 
 class TestQFUERZA:
@@ -1651,8 +1653,8 @@ class TestQFUERZA:
 
     def test_fuerza_strategy_deterministic(self, ch3f_mol_with_hess: Q2MMMolecule) -> None:
         """strategy='fuerza' is deterministic across repeated calls."""
-        ff_first = estimate_force_constants(ch3f_mol_with_hess, strategy="fuerza")
-        ff_second = estimate_force_constants(ch3f_mol_with_hess, strategy="fuerza")
+        ff_first = qfuerza_fresh(ch3f_mol_with_hess, strategy="fuerza")
+        ff_second = qfuerza_fresh(ch3f_mol_with_hess, strategy="fuerza")
 
         assert len(ff_first.bonds) == len(ff_second.bonds)
         for b1, b2 in zip(ff_first.bonds, ff_second.bonds):
@@ -1663,8 +1665,8 @@ class TestQFUERZA:
 
     def test_default_is_qfuerza(self, ch3f_mol_with_hess: Q2MMMolecule) -> None:
         """Default strategy is QFUERZA."""
-        ff_default = estimate_force_constants(ch3f_mol_with_hess)
-        ff_qfuerza = estimate_force_constants(ch3f_mol_with_hess, strategy="qfuerza")
+        ff_default = qfuerza_fresh(ch3f_mol_with_hess)
+        ff_qfuerza = qfuerza_fresh(ch3f_mol_with_hess, strategy="qfuerza")
 
         assert len(ff_default.bonds) == len(ff_qfuerza.bonds)
         for b_def, b_qf in zip(ff_default.bonds, ff_qfuerza.bonds):
@@ -1677,7 +1679,7 @@ class TestQFUERZA:
 
     def test_qfuerza_substitutes_h_angles(self, water_mol_with_hess: Q2MMMolecule) -> None:
         """QFUERZA replaces the H-O-H angle force constant with the empirical default."""
-        ff = estimate_force_constants(water_mol_with_hess, strategy="qfuerza")
+        ff = qfuerza_fresh(water_mol_with_hess, strategy="qfuerza")
         h_angles = [a for a in ff.angles if _is_hydrogen_angle(a.elements)]
         assert len(h_angles) > 0, "Expected at least one H-angle in water"
         for angle in h_angles:
@@ -1685,8 +1687,8 @@ class TestQFUERZA:
 
     def test_qfuerza_keeps_bonds_unchanged(self, ch3f_mol_with_hess: Q2MMMolecule) -> None:
         """QFUERZA does not alter bond force constants."""
-        ff_fuerza = estimate_force_constants(ch3f_mol_with_hess, strategy="fuerza")
-        ff_qfuerza = estimate_force_constants(ch3f_mol_with_hess, strategy="qfuerza")
+        ff_fuerza = qfuerza_fresh(ch3f_mol_with_hess, strategy="fuerza")
+        ff_qfuerza = qfuerza_fresh(ch3f_mol_with_hess, strategy="qfuerza")
 
         for b_fur, b_qf in zip(ff_fuerza.bonds, ff_qfuerza.bonds):
             assert b_fur.force_constant == pytest.approx(b_qf.force_constant)
@@ -1698,8 +1700,8 @@ class TestQFUERZA:
         hess = np.load(TS_HESS)
         mol = mol.with_hessian(hess)
 
-        ff_fuerza = estimate_force_constants(mol, strategy="fuerza")
-        ff_qfuerza = estimate_force_constants(mol, strategy="qfuerza")
+        ff_fuerza = qfuerza_fresh(mol, strategy="fuerza")
+        ff_qfuerza = qfuerza_fresh(mol, strategy="qfuerza")
 
         non_h_angles = [
             (a_fur, a_qf)
@@ -1712,7 +1714,7 @@ class TestQFUERZA:
 
     def test_qfuerza_ch3f_all_h_angles_substituted(self, ch3f_mol_with_hess: Q2MMMolecule) -> None:
         """CH₃F has H-C-F and H-C-H angles — all have H outer atoms."""
-        ff = estimate_force_constants(ch3f_mol_with_hess, strategy="qfuerza")
+        ff = qfuerza_fresh(ch3f_mol_with_hess, strategy="qfuerza")
 
         for angle in ff.angles:
             if _is_hydrogen_angle(angle.elements):
@@ -1722,8 +1724,8 @@ class TestQFUERZA:
 
     def test_qfuerza_equilibria_unchanged(self, ch3f_mol_with_hess: Q2MMMolecule) -> None:
         """QFUERZA only changes force constants, not equilibrium values."""
-        ff_fuerza = estimate_force_constants(ch3f_mol_with_hess, strategy="fuerza")
-        ff_qfuerza = estimate_force_constants(ch3f_mol_with_hess, strategy="qfuerza")
+        ff_fuerza = qfuerza_fresh(ch3f_mol_with_hess, strategy="fuerza")
+        ff_qfuerza = qfuerza_fresh(ch3f_mol_with_hess, strategy="qfuerza")
 
         for a_fur, a_qf in zip(ff_fuerza.angles, ff_qfuerza.angles):
             assert a_fur.equilibrium == pytest.approx(a_qf.equilibrium)
@@ -1884,12 +1886,12 @@ class TestFrozenParamInvariant:
         b.force_constant = 999.0
         assert b.force_constant == 999.0
 
-    def test_estimate_force_constants_does_not_overwrite_frozen_opt_block(self) -> None:
+    def test_qfuerza_into_does_not_overwrite_frozen_opt_block(self) -> None:
         """Regression for the q2mm#277 pattern at the unit level.
 
-        ``estimate_force_constants(forcefield=ff)`` must not overwrite
-        the values of any frozen param.  The Heck-relay loader bug fell
-        out of this contract being silently violated; now both the
+        ``qfuerza_into(ff, molecules)`` must not overwrite the values
+        of any frozen param.  The Heck-relay loader bug fell out of
+        this contract being silently violated; now both the
         skip-frozen shortcut in seminario.py and the FrozenParamError
         guard back it up.
         """
@@ -1897,7 +1899,7 @@ class TestFrozenParamInvariant:
 
         from q2mm.models.forcefield import BondParam, ForceField
         from q2mm.models.molecule import Q2MMMolecule
-        from q2mm.models.seminario import estimate_force_constants
+        from q2mm.models.seminario import qfuerza_into
 
         # Build a tiny FF whose only bond is frozen at a marker value.
         marker_k = 12345.67
@@ -1915,8 +1917,7 @@ class TestFrozenParamInvariant:
             hessian=np.eye(6),
         )
 
-        result = estimate_force_constants(mol, forcefield=ff)
-        assert result.bonds[0].force_constant == marker_k, (
-            "Frozen bond force constant was silently overwritten by estimate_force_constants — "
-            "this is the q2mm#277 bug pattern."
+        qfuerza_into(ff, mol)
+        assert ff.bonds[0].force_constant == marker_k, (
+            "Frozen bond force constant was silently overwritten by qfuerza_into — this is the q2mm#277 bug pattern."
         )


### PR DESCRIPTION
**Companion data PR**: [ericchansen/q2mm-data#?](https://github.com/ericchansen/q2mm-data/pulls) (regenerated baselines for all 5 systems).

## TL;DR

After our long discussion, this PR makes `frozen` a load-bearing invariant, splits `estimate_force_constants` into two named functions, and rewrites the per-system loaders into a single declarative `SystemSpec` registry — the design we converged on by mid-conversation.

The headline result is that the bug pattern from #277 (Heck-relay) was actually a slow-burn problem in **four** loaders, not one. Fixing the loaders properly means the ratio gate now passes for four of five published-FF systems, up from two.

## Methodology citation

This work is grounded in **Farrugia, Helquist, Norrby & Wiest 2025** (the QFUERZA paper, *J. Chem. Theory Comput.* **22**, 469; DOI [10.1021/acs.jctc.5c01751](https://doi.org/10.1021/acs.jctc.5c01751)).  AGENTS.md now has a "Key Papers" section calling this out (commit 1) so the next agent doesn't cite Seminario 1996 when they mean Farrugia 2025.

## Five logical commits

| # | Commit | What |
|---|---|---|
| 1 | `docs(agents): add "Key Papers" section` | Methodology references with DOIs and what part of q2mm each governs. |
| 2 | `refactor(forcefield): make frozen a load-bearing invariant` | `FrozenParamError` + `__setattr__` guard on physical value fields. `.freeze()` / `.unfreeze()` methods. Construction still works because `frozen` is the last dataclass field (init assigns it last). |
| 3 | `refactor(seminario): split estimate_force_constants → qfuerza_fresh + qfuerza_into` | No more overloaded `forcefield=None` argument. Each name does one thing. The dangerous "overwrite via forcefield=" path is gone. |
| 4 | `refactor(loaders): consolidate per-system loaders into SystemSpec + load_system` | New `q2mm/models/loaders.py` with named FF-assembly strategies. `q2mm/diagnostics/systems.py` becomes a declarative `SystemSpec` registry + one `load_system(key)` dispatcher. Six per-system loaders + `_load_wahlers_system` + `BenchmarkSystem` deleted (no shims, alpha discipline). All callers migrated in the same commit. |
| 5 | `docs: refresh convergence numbers` | All affected docs updated against the regenerated baseline. |

## The ratio-gate change

| System | Before | After | Gate after |
|---|---:|---:|:---:|
| ch3f | 1.000 | 1.000 | ✓ |
| Rh-enamide | 1.05 | 1.07 | ✓ |
| Pd-allyl | 1.09 | 1.10 | ✓ |
| Heck relay | 1.30 | 1.30 | ✗ |
| **Pd 1,4-conj** | **1.20** | **0.96** | ✅ |
| **Rh 1,4-conj** | **~4 × 10³** | **1.04** | ✅ |

Pd 1,4-conj and Rh 1,4-conj were previously misclassified as gate-failures.  The QFUERZA overwrite was corrupting their published Wahlers OPT values and sending JaxLoss's inner geometry minimization into pathological regions.  This **also fully explains the rh-conjugate non-determinism** tracked in #278 (ratios of 0.46 / 0.96 / ~4 × 10³ across sessions): the overwrite was chaotic.

## What got deleted (no shims)

- `estimate_force_constants` — replaced by `qfuerza_fresh` / `qfuerza_into`.
- `load_ch3f`, `load_rh_enamide`, `load_heck_relay`, `load_pd_allyl`, `load_pd_conjugate`, `load_rh_conjugate` — six per-system loaders.
- `_load_wahlers_system` — private helper.
- `BenchmarkSystem` — replaced by `SystemSpec`.

All 85+ callers (across CLI, regen script, bench_composed, run_rh_benchmarks, ~10 test files, 2 example scripts) migrated in the same commits.

## Adding new systems is now easy

Append a ~10-line `SystemSpec` to `SYSTEMS` in `q2mm/diagnostics/systems.py`. No new code; no module-level functions. The spec declares: molecule loader callable, ff_strategy literal, ff_paths mapping, metadata dict.

## Validation

- **656 unit tests pass** after every commit (each commit is independently green).
- `ruff check q2mm/ test/ scripts/` clean.
- `ruff format --check q2mm test scripts examples` clean.
- `uv run --extra docs properdocs build -f properdocs.yml` clean.
- End-to-end regen on all 5 systems against the new loaders produces the numbers documented in commit 5.
- Heck-relay regression test from #280 still passes.
- 10 new tests in `TestFrozenParamInvariant` exercise the new setter contract on every Param class.

## Closes / Refs

- Closes #278 (rh-conjugate non-determinism — fully explained by the corruption pattern, fixed by the loader refactor).
- Provides foundation for #275 (end-to-end opt runs on the gate-passing systems).
- Refs #276 (pd-conjugate ratio_tol=None experiment) — pd-conjugate no longer needs that bypass; the gate passes now.
- Refs #277 (Heck-relay diagnosis — already merged in PR #280; this PR generalises the fix to the other affected loaders).
