### PR TITLE
chore: remove dead code, add geometry/fchk tests, CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: python -m pip install -e ".[dev]"
-      - run: python -m pytest -m "not (openmm or tinker or jax or jax_md or psi4)" -q
+      - run: python -m pytest -m "not (openmm or tinker or jax or jax_md or psi4)" -q --cov=q2mm --cov-report=term-missing --cov-report=xml:coverage.xml
+      - name: Upload coverage
+        if: matrix.python-version == '3.12'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml
 
   # ================================================================
   # Tier 2 — Backend unit tests on every push (~1-5 min)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ qcel = [
 dev = [
     "pytest",
     "pytest-benchmark",
+    "pytest-cov",
     "ruff",
     "scipy",
     "parmed",

--- a/q2mm/diagnostics/systems.py
+++ b/q2mm/diagnostics/systems.py
@@ -278,6 +278,20 @@ _METAL_ELEMENTS: frozenset[str] = frozenset(
 )
 
 # MM3 atom-type assignment from element + bond count.
+#
+# Keys are element symbols; values map the number of *organic* bonds
+# (i.e. bonds to non-metal atoms) to an MM3 type string.  Metal atoms
+# always use bond-count 0 because ``_assign_mm3_atom_types`` excludes
+# metal-metal and metal-organic bonds from the count.
+#
+# Examples:
+#   C with 4 organic bonds → C3 (sp3)
+#   C with 3 organic bonds → C2 (sp2)
+#   N with 2 organic bonds → N2
+#   Pd (any)               → PD  (0-bond fallback)
+#
+# Source: standard MM3 atom-type conventions; see Allinger, Yuh & Lii,
+# J. Am. Chem. Soc. 1989, 111, 8551.
 _MM3_TYPE_MAP: dict[str, dict[int, str]] = {
     "C": {4: "C3", 3: "C2", 2: "C1", 1: "C1"},
     "H": {1: "H1", 0: "H1"},

--- a/q2mm/optimizers/jaxloss.py
+++ b/q2mm/optimizers/jaxloss.py
@@ -53,19 +53,10 @@ if TYPE_CHECKING:
 # implicit-function theorem applies.
 _GEOM_INNER_TOL = 1e-8
 _GEOM_INNER_MAXITER = 500
-# Penalty added per geometry reference when the inner solver does not
-# converge.  Set to 0.0 because:
-# 1. The actual geometry residuals (bonds/angles) naturally penalize poor
-#    convergence — wrong structures yield large residuals.
-# 2. A large binary penalty (the original 1e4) caused 40× score inflation
-#    for nearly-converged geometries where jaxopt's L-BFGS didn't reach
-#    the strict 1e-8 gradient-norm tolerance, making the optimizer report
-#    false divergence.
-_GEOM_NONCONV_PENALTY = 0.0
 
 
 def _relax_coords(energy_fn, params, coords0):  # noqa: ANN001, ANN202
-    """Return the relaxed geometry and convergence flag for a molecule.
+    """Return the relaxed geometry for a molecule.
 
     Uses ``jaxopt.LBFGS(fun=energy_of_coords, implicit_diff=True)`` so the
     outer ``jax.grad`` sees the exact parameter-gradient of ``x*`` via the
@@ -78,8 +69,14 @@ def _relax_coords(energy_fn, params, coords0):  # noqa: ANN001, ANN202
     Seminario starting FFs (deeply negative R²), the relaxation may
     converge to wrong local minima, producing unreliable loss values.
 
-    When the inner solver does not converge (gradient norm > tol after
-    maxiter), the caller should add a penalty to the loss.
+    A previous version of this function also returned a ``converged``
+    boolean so the caller could add a fixed-magnitude penalty per
+    non-converged geometry ref.  That penalty was zeroed in commit
+    ``8c56fe9`` (it inflated nearly-converged scores by ~40×) and the
+    dead branch was removed in PR #285.  Callers that need
+    convergence diagnostics should inspect ``solver.state.error``
+    directly rather than relying on a returned flag — see q2mm#284 for
+    the broader engine-non-determinism discussion.
 
     Args:
         energy_fn: ``(params, coords) -> scalar`` energy function
@@ -88,8 +85,7 @@ def _relax_coords(energy_fn, params, coords0):  # noqa: ANN001, ANN202
         coords0: Initial coordinates, shape ``(N, 3)``.
 
     Returns:
-        tuple: ``(relaxed_coords, converged)`` where ``converged`` is a
-        scalar boolean (JAX array).
+        Relaxed coordinates, shape ``(N, 3)`` (JAX array).
 
     """
     import jaxopt
@@ -104,8 +100,7 @@ def _relax_coords(energy_fn, params, coords0):  # noqa: ANN001, ANN202
         implicit_diff=True,
     )
     sol = solver.run(coords0, params)
-    converged = sol.state.error <= _GEOM_INNER_TOL
-    return sol.params, converged
+    return sol.params
 
 
 def _bond_lengths(coords, atoms):  # noqa: ANN001, ANN202
@@ -340,9 +335,6 @@ class JaxLoss:
                 entry["torsion_atoms"] = jnp.array(mol_spec.torsion_atoms, dtype=jnp.int32)
                 entry["torsion_refs"] = jnp.array(mol_spec.torsion_refs)
                 entry["torsion_weights"] = jnp.array(mol_spec.torsion_weights)
-            if mol_spec.has_geometry:
-                entry["n_geom_refs"] = len(mol_spec.bond_refs) + len(mol_spec.angle_refs) + len(mol_spec.torsion_refs)
-
             mol_data.append(entry)
 
         # ---- Per-molecule Hessian functions ----
@@ -449,12 +441,7 @@ class JaxLoss:
             mol_spec = entry["mol_spec"]
             energy_fn = handle._energy_fn
 
-            relaxed, geom_converged = _relax_coords(energy_fn, params, coords)
-            total = total + jnp.where(
-                geom_converged,
-                0.0,
-                _GEOM_NONCONV_PENALTY * entry["n_geom_refs"],
-            )
+            relaxed = _relax_coords(energy_fn, params, coords)
 
             if mol_spec.has_bond_length:
                 calc = _bond_lengths(relaxed, entry["bond_atoms"])

--- a/test/test_geometry.py
+++ b/test/test_geometry.py
@@ -1,0 +1,103 @@
+"""Tests for q2mm.geometry — canonical bond length, angle, and dihedral calculations."""
+
+import math
+
+import numpy as np
+import pytest
+
+from q2mm.geometry import bond_angle, bond_length, dihedral_angle
+
+
+# ---------------------------------------------------------------------------
+# bond_length
+# ---------------------------------------------------------------------------
+
+
+class TestBondLength:
+    def test_unit_x(self) -> None:
+        assert bond_length([0, 0, 0], [1, 0, 0]) == pytest.approx(1.0)
+
+    def test_diagonal(self) -> None:
+        assert bond_length([0, 0, 0], [1, 1, 1]) == pytest.approx(math.sqrt(3))
+
+    def test_same_point(self) -> None:
+        assert bond_length([2, 3, 4], [2, 3, 4]) == pytest.approx(0.0)
+
+    def test_negative_coords(self) -> None:
+        assert bond_length([-1, 0, 0], [1, 0, 0]) == pytest.approx(2.0)
+
+    def test_numpy_arrays(self) -> None:
+        p0 = np.array([0.0, 0.0, 0.0])
+        p1 = np.array([3.0, 4.0, 0.0])
+        assert bond_length(p0, p1) == pytest.approx(5.0)
+
+
+# ---------------------------------------------------------------------------
+# bond_angle
+# ---------------------------------------------------------------------------
+
+
+class TestBondAngle:
+    def test_right_angle(self) -> None:
+        assert bond_angle([1, 0, 0], [0, 0, 0], [0, 1, 0]) == pytest.approx(90.0)
+
+    def test_linear(self) -> None:
+        assert bond_angle([-1, 0, 0], [0, 0, 0], [1, 0, 0]) == pytest.approx(180.0)
+
+    def test_acute_60(self) -> None:
+        # Equilateral triangle vertices in 2D
+        p0 = np.array([1.0, 0.0, 0.0])
+        p1 = np.array([0.0, 0.0, 0.0])
+        p2 = np.array([0.5, math.sqrt(3) / 2, 0.0])
+        assert bond_angle(p0, p1, p2) == pytest.approx(60.0)
+
+    def test_symmetric(self) -> None:
+        # Angle is the same regardless of which outer atom is first.
+        p0, p1, p2 = [1, 0, 0], [0, 0, 0], [0, 1, 0]
+        assert bond_angle(p0, p1, p2) == pytest.approx(bond_angle(p2, p1, p0))
+
+
+# ---------------------------------------------------------------------------
+# dihedral_angle
+# ---------------------------------------------------------------------------
+
+
+class TestDihedralAngle:
+    def test_cis_zero(self) -> None:
+        # cis / eclipsed -> 0 degrees
+        p0 = [1, 0, 0]
+        p1 = [0, 0, 0]
+        p2 = [0, 1, 0]
+        p3 = [1, 1, 0]
+        assert dihedral_angle(p0, p1, p2, p3) == pytest.approx(0.0, abs=1e-6)
+
+    def test_trans_180(self) -> None:
+        # trans / anti -> +/-180 degrees
+        p0 = [1, 0, 0]
+        p1 = [0, 0, 0]
+        p2 = [0, 1, 0]
+        p3 = [-1, 1, 0]
+        assert abs(dihedral_angle(p0, p1, p2, p3)) == pytest.approx(180.0, abs=1e-6)
+
+    def test_gauche_90(self) -> None:
+        p0 = [1, 0, 0]
+        p1 = [0, 0, 0]
+        p2 = [0, 1, 0]
+        p3 = [0, 1, 1]
+        assert dihedral_angle(p0, p1, p2, p3) == pytest.approx(90.0, abs=1e-6)
+
+    def test_degenerate_collinear_returns_zero(self) -> None:
+        # Collinear atoms: degenerate, should return 0.0
+        p0, p1, p2, p3 = [0, 0, 0], [1, 0, 0], [2, 0, 0], [3, 0, 0]
+        assert dihedral_angle(p0, p1, p2, p3) == pytest.approx(0.0, abs=1e-6)
+
+    def test_sign_convention(self) -> None:
+        # Positive and negative rotations should differ in sign
+        p0 = [1, 0, 0]
+        p1 = [0, 0, 0]
+        p2 = [0, 1, 0]
+        p3_pos = [0, 1, 1]
+        p3_neg = [0, 1, -1]
+        d_pos = dihedral_angle(p0, p1, p2, p3_pos)
+        d_neg = dihedral_angle(p0, p1, p2, p3_neg)
+        assert d_pos == pytest.approx(-d_neg, abs=1e-6)

--- a/test/test_io_fchk.py
+++ b/test/test_io_fchk.py
@@ -1,0 +1,87 @@
+"""Tests for q2mm.io.fchk — Gaussian formatted checkpoint file parser."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from q2mm.io.fchk import parse_fchk
+from test._shared import GS_FCHK, TS_FCHK
+
+# Match the return type of parse_fchk exactly.
+FchkResult = tuple[list[str], np.ndarray, np.ndarray | None, int | None, int | None]
+
+
+@pytest.fixture()
+def ethane_gs() -> FchkResult:
+    """Parse the ethane ground-state .fchk fixture."""
+    return parse_fchk(GS_FCHK)
+
+
+@pytest.fixture()
+def ethane_ts() -> FchkResult:
+    """Parse the ethane transition-state .fchk fixture."""
+    return parse_fchk(TS_FCHK)
+
+
+class TestParseFchkEthaneGS:
+    def test_symbols(self, ethane_gs: FchkResult) -> None:
+        symbols, _, _, _, _ = ethane_gs
+        assert len(symbols) == 8
+        assert symbols.count("C") == 2
+        assert symbols.count("H") == 6
+
+    def test_coords_shape(self, ethane_gs: FchkResult) -> None:
+        _, coords, _, _, _ = ethane_gs
+        assert coords.shape == (8, 3)
+
+    def test_coords_in_angstrom(self, ethane_gs: FchkResult) -> None:
+        symbols, coords, _, _, _ = ethane_gs
+        # C-H bond should be ~1.09 A; verify we're in Angstrom, not Bohr (~2 Bohr)
+        c_idx = symbols.index("C")
+        h_idx = symbols.index("H")
+        ch_dist = np.linalg.norm(coords[c_idx] - coords[h_idx])
+        assert 0.9 < ch_dist < 1.3, f"C-H distance {ch_dist} not in Angstrom range"
+
+    def test_hessian_present_and_symmetric(self, ethane_gs: FchkResult) -> None:
+        _, _, hessian, _, _ = ethane_gs
+        assert hessian is not None
+        n = 8 * 3
+        assert hessian.shape == (n, n)
+        np.testing.assert_allclose(hessian, hessian.T, atol=1e-15)
+
+    def test_charge_and_multiplicity(self, ethane_gs: FchkResult) -> None:
+        _, _, _, charge, mult = ethane_gs
+        assert charge == 0
+        assert mult == 1
+
+
+class TestParseFchkEthaneTS:
+    def test_symbols(self, ethane_ts: FchkResult) -> None:
+        symbols, _, _, _, _ = ethane_ts
+        assert len(symbols) == 8
+        assert symbols.count("C") == 2
+
+    def test_has_hessian(self, ethane_ts: FchkResult) -> None:
+        _, _, hessian, _, _ = ethane_ts
+        assert hessian is not None
+
+    def test_ts_hessian_has_negative_eigenvalue(self, ethane_ts: FchkResult) -> None:
+        """A TS .fchk should have at least one negative Hessian eigenvalue."""
+        _, _, hessian, _, _ = ethane_ts
+        eigenvalues = np.linalg.eigvalsh(hessian)
+        assert np.any(eigenvalues < -1e-6), "TS Hessian should have a negative eigenvalue"
+
+
+class TestParseFchkErrors:
+    def test_nonexistent_file(self, tmp_path: Path) -> None:
+        with pytest.raises((FileNotFoundError, OSError)):
+            parse_fchk(tmp_path / "nonexistent.fchk")
+
+    def test_empty_file(self, tmp_path: Path) -> None:
+        empty = tmp_path / "empty.fchk"
+        empty.write_text("")
+        with pytest.raises(ValueError, match="Could not parse"):
+            parse_fchk(empty)

--- a/test/test_jax_loss.py
+++ b/test/test_jax_loss.py
@@ -701,11 +701,21 @@ class TestJaxLossGeometryParity:
         assert loss < 10.0
         np.testing.assert_allclose(loss, 4.0, atol=1e-6)
 
-    def test_nonconvergence_penalty_is_finite(self) -> None:
-        """When inner solver cannot converge, loss includes a finite penalty."""
+    def test_nonconvergence_yields_finite_loss(self) -> None:
+        """When inner solver cannot converge, loss must still be finite.
+
+        Historically (before commit 8c56fe9) a ``_GEOM_NONCONV_PENALTY``
+        constant added a fixed penalty per geometry ref when the inner
+        geometry solver hit max-iter without reaching its gradient
+        tolerance.  That penalty was zeroed out and then removed (PR #285)
+        because it inflated scores for nearly-converged geometries by
+        ~40×.  This test still guards the underlying invariant: even
+        when the inner solver does not strictly converge, the outer
+        loss must be finite (not NaN, not Inf).
+        """
         import jax.numpy as jnp
 
-        from q2mm.optimizers.jaxloss import JaxLoss, _GEOM_NONCONV_PENALTY
+        from q2mm.optimizers.jaxloss import JaxLoss
         from q2mm.optimizers.objective import ObjectiveFunction, ReferenceData
 
         # Use a very stretched geometry far from equilibrium — the inner
@@ -724,10 +734,7 @@ class TestJaxLossGeometryParity:
         params = jnp.array(ff.get_param_vector(), dtype=jnp.float64)
         loss, _grad = jax_loss.loss_and_grad(params)
         loss = float(loss)
-        # Loss must be finite regardless of convergence
         assert np.isfinite(loss), f"Loss is not finite: {loss}"
-        # The _GEOM_NONCONV_PENALTY constant must be accessible and non-negative
-        assert _GEOM_NONCONV_PENALTY >= 0
 
 
 class TestJaxLossTopologyBatching:


### PR DESCRIPTION
## Summary

Remove dead code, improve documentation, add missing tests, and wire up coverage reporting in CI.

### Changes

**Dead code removal**
- Remove `_GEOM_NONCONV_PENALTY` constant from `jaxloss.py` — was hardcoded to `0.0`, so the penalty branch (`0.0 * n_geom_refs`) always contributed zero. Also removes the now-unused `n_geom_refs` computation from `_build()`.

**Documentation**
- Add docstring for `_MM3_TYPE_MAP` in `diagnostics/systems.py` explaining the element + bond-count → MM3 type mapping convention, with examples and literature reference.

**New tests**
- `test_geometry.py` — 14 tests covering `bond_length`, `bond_angle`, `dihedral_angle` (edge cases: collinear, sign convention, symmetry, numpy arrays).
- `test_io_fchk.py` — 10 tests covering `parse_fchk` with ethane GS/TS fixtures (symbols, coords shape, Angstrom units, Hessian symmetry, TS negative eigenvalue, error paths).

**CI coverage**
- Add `pytest-cov` to dev dependencies.
- Add `--cov=q2mm --cov-report=term-missing --cov-report=xml` to the `test-core` CI job.
- Upload `coverage.xml` as an artifact from the Python 3.12 matrix entry.

### No behavioral changes
All modifications are additive (tests, docs, CI) or remove provably dead code.