### PR TITLE
docs: confirm 'no real improvement' verdicts for metal-TS systems (n=10)

### DIFF
--- a/docs/systems/heck-relay.md
+++ b/docs/systems/heck-relay.md
@@ -79,31 +79,31 @@ complete failure of cross-engine transfer, not a small miss.
     as-is (it still calls `freeze_standard_params` so the active mask
     is correct for optimization, but no QFUERZA re-estimation).
 
+Run with `--n-evals 10 --ratio-tol none` so the verdict is
+statistically defensible against the per-call engine noise documented
+in [#284](https://github.com/ericchansen/q2mm/issues/284).  Heck-relay
+has the worst noise floor of any system in the suite.
+
 | Metric | Value |
 |--------|:-----:|
-| Ratio check | 1.255 (out_of_band; upper bound 1.15) |
-| Initial ObjectiveFunction score | 3.53 × 10⁶ (single GPU eval — see noise caveat below) |
-| Final ObjectiveFunction score | 3.39 × 10⁶ (single GPU eval at *reverted* params; the difference vs initial is GPU noise, not optimization) |
-| End-to-end optimization (`--ratio-tol none`) | 0.00 % (reverted, see below) |
+| Ratio check | 1.378 (out_of_band; upper bound 1.15 — gate bypassed via `--ratio-tol none`) |
+| Initial ObjectiveFunction (n=10 mean) | 3.415 × 10⁶ ± 1.84 % CI₉₅ |
+| Final ObjectiveFunction (n=10 mean) | 3.435 × 10⁶ ± 1.41 % CI₉₅ |
+| Improvement (mean Δ%) | **−0.59 % (NOT SIGNIFICANT — CI₉₅ ± 3.26 %)** |
+| L-BFGS-B iterations / OF evaluations | 2 / 2 |
+| Optimizer | L-BFGS-B (scipy) over JaxLoss analytical gradients |
+| Wall time | 1,451 s opt + ~38 min for 20 post-eval samples |
 
-The reverted parameters are bit-identical to the initial parameters —
-the 3.53 × 10⁶ → 3.39 × 10⁶ apparent change in the table reflects
-that two separate GPU evaluations of `ObjectiveFunction(x0)` differ
-by ~4 % due to engine non-determinism, not actual optimization.  See
-the noise caveat in "End-to-end optimization with `--ratio-tol none`"
-below.
+Per-category fit of the optimized force field (R² varies by ~5 %
+across single-call GPU evaluations):
 
-Per-category fit of the published Rosales force field against the QM
-training data (no QFUERZA — these are the published OPT values
-evaluated by the q2mm JAX engine):
+| Category | n_refs | R² (optimized) | RMSD |
+|----------|-------:|---------------:|-----:|
+| bond_length | 1140 | **0.980** | 0.046 Å |
+| bond_angle | 2157 | **0.787** | 7.96 ° |
+| eig_diagonal | 3121 | −12.6 | 0.48 |
 
-| Category | n_refs | R² | RMSD | MAE |
-|----------|-------:|----:|-----:|----:|
-| bond_length | 1140 | **0.980** | 0.046 Å | — |
-| bond_angle | 2157 | **0.786** | 7.96 ° | — |
-| eig_diagonal | 3121 | −12.6 | 0.48 | — |
-
-Geometry is now well-reproduced; the eigenmatrix remains the open
+Geometry is well-reproduced; the eigenmatrix remains the open
 problem (the published Rosales FF was MM3*-fit and the residual
 eigenmatrix gap reflects a real cross-engine MM3* ↔ JAX-engine
 divergence for this chemistry, not a loader bug).
@@ -111,37 +111,32 @@ divergence for this chemistry, not a loader bug).
 ### End-to-end optimization with `--ratio-tol none`
 
 Following the [pd-conjugate experiment in #276](https://github.com/ericchansen/q2mm/issues/276),
-heck-relay was also run with `--ratio-tol none` to bypass the gate
-and see whether JaxLoss-guided optimization would still produce a
-useful descent step.  Unlike pd-conjugate (which post-refactor had
-ratio = 0.985 and the bypass was a no-op), heck-relay's ratio is
-genuinely outside band at 1.255.  L-BFGS-B took 4 iterations against
-JaxLoss; the surrogate produced non-finite values 3 times during the
-line search; the proposed parameter step was evaluated against the
-real `ObjectiveFunction` and was 3.3 % *worse* than the starting
-point (3,392,860 → 3,503,130); `ScipyOptimizer` reverted to the
-initial parameters and the run reports 0.00 % improvement.
+heck-relay was run with `--ratio-tol none` to bypass the gate and
+see whether JaxLoss-guided optimization can produce useful real-OF
+descent in a regime where the surrogate has formally broken down
+(ratio 1.378, well outside [0.85, 1.15]).  During optimization
+JaxLoss produced non-finite values 2 times in the line search; the
+optimizer eventually reported a 0.7 % surrogate reduction.  When
+that step is statistically tested against the real ObjectiveFunction
+with n=10 samples, the result is **−0.59 % ± 3.26 % CI₉₅** — within
+noise, so we cannot claim either an improvement or a worsening.
 
-!!! warning "Noise floor caveat — the 3.3 % apparent worsening is within noise"
-    Repeated GPU `ObjectiveFunction(x0)` calls on heck-relay vary by
-    **~4.9 %** (5-call IQR/median; min 3.36e6, max 3.53e6).  This is
-    the worst noise floor of any system in the published-FF suite.
-    The "3.3 % worse" step that triggered the revert is **inside the
-    noise floor**, so we cannot reliably say the JaxLoss-guided step
-    was actually a bad direction; the comparison itself is noise-limited.
-    What we **can** say is that the surrogate produced 3 non-finite
-    values mid-optimization, indicating real numerical instability
-    rather than just measurement noise.  Root cause traced to scipy
-    `L-BFGS-B` Fortran state in the geometry minimizer plus MM3
-    non-smooth points; see [#284](https://github.com/ericchansen/q2mm/issues/284) for the
-    full diagnosis.
+!!! success "Confirmed: --ratio-tol none does not unlock useful optimization here"
+    Heck-relay has the noisiest per-call ObjectiveFunction in the
+    published-FF suite (CI₉₅ ≈ 3.3 % even with n=10).  Within that
+    window we see neither a statistically real improvement nor a
+    statistically real worsening from JaxLoss-guided L-BFGS-B with
+    the gate disabled.  Combined with the visible surrogate
+    breakdown (2 non-finite values during line search), this
+    confirms that **the `ratio_tol=0.15` gate is providing useful
+    protection** — bypassing it doesn't help and just risks
+    accepting a bad step on a low-sample-count run.  Closing this
+    gap needs the engine-parity work in the gap analysis below
+    plus the MM3 non-smooth fix from
+    [#284](https://github.com/ericchansen/q2mm/issues/284), not
+    a relaxed tolerance.
 
-**Recommendation:** keep the default `ratio_tol=0.15`.  Heck relay
-remains a case where the gate provides useful protection — the
-non-finite values during line search are a genuine surrogate
-breakdown signal, distinct from the noise floor.  Closing this gap
-requires the engine-parity work in the gap analysis below plus the
-engine non-determinism fix, not a relaxed tolerance.
+**Recommendation:** keep the default `ratio_tol=0.15`.
 
 The numbers above come from the committed regeneration script
 `scripts/regenerate_convergence_results.py`; the raw JSON output and

--- a/docs/systems/pd-allyl.md
+++ b/docs/systems/pd-allyl.md
@@ -63,53 +63,54 @@ worse than simply predicting the average.
 SciPy L-BFGS-B with JaxLoss analytical gradients.  After the loader
 API refactor that preserves the published Wahlers OPT values
 as-published (no QFUERZA overwrite), the ratio gate passes for
-pd-allyl.
+pd-allyl.  Run with `--n-evals 10` so the verdict is statistically
+defensible against the per-call engine noise documented in
+[#284](https://github.com/ericchansen/q2mm/issues/284).
 
 | Metric | Value |
 |--------|:-----:|
-| Ratio check | 1.08 (pass) |
-| Initial score | 8.04 × 10⁶ |
-| Final score | 8.03 × 10⁶ |
-| Reduction | 0.13 % (real OF) — **within ~0.65 % per-call noise floor; no statistically meaningful improvement** |
-| Iterations / Evaluations | 1 / 2 |
-| Gradient source | `jac="auto"` resolved to `jac_mode="jax_loss"` (JaxLoss analytical) |
-| Wall time | 1,172 s (20 min) |
+| Ratio check | 1.087 (pass) |
+| Initial ObjectiveFunction (n=10 mean) | 8.032 × 10⁶ ± 0.127 % CI₉₅ |
+| Final ObjectiveFunction (n=10 mean) | 8.034 × 10⁶ ± 0.210 % CI₉₅ |
+| Improvement (mean Δ%) | **−0.029 % (NOT SIGNIFICANT — CI₉₅ ± 0.34 %)** |
+| L-BFGS-B iterations / OF evaluations | 2 / 2 |
+| Gradient source | `jac="auto"` → `jac_mode="jax_loss"` (JaxLoss analytical) |
+| Wall time | 1,243 s opt + ~16 min for 20 post-eval samples |
 
 Per-category fit of the optimized force field (post-L-BFGS-B):
 
 | Category | n_refs | R² |
 |----------|-------:|----:|
-| bond_length | 849 | 0.043 |
-| bond_angle | 1,582 | 0.335 |
+| bond_length | 849 | 0.037 |
+| bond_angle | 1,582 | 0.331 |
 | eig_diagonal | 2,412 | −2.82 |
 
 These numbers are reproducible from `scripts/regenerate_convergence_results.py`
-(no `--skip-optimization`); raw JSON output with provenance lives at
+with `--system pd-allyl --n-evals 10`; raw JSON output with provenance lives at
 [`q2mm-data/benchmarks/pd-allyl-amination/convergence/`](https://github.com/ericchansen/q2mm-data/tree/main/benchmarks/pd-allyl-amination/convergence).
 
-L-BFGS-B converges after a single iteration: the published Wahlers
-OPT values are already at (or extremely close to) a JaxLoss local
-minimum, so there is no descent direction.
+!!! success "Confirmed: published Wahlers FF sits at a JaxLoss local minimum"
+    With n=10 samples the 95 % CI on the improvement is **±0.34 %**,
+    which excludes any improvement larger than ~0.3 %.  The L-BFGS-B
+    optimizer converges after 2 iterations from the published OPT
+    values without finding any descent direction — and the post-hoc
+    statistical re-evaluation confirms that's a real "no improvement
+    available", not a noise artifact.
 
-!!! warning "Noise floor caveat — this result is within measurement noise"
-    Repeated GPU `ObjectiveFunction(x0)` calls on pd-allyl vary by
-    ~0.65 % (5-call IQR/median: 8.026e6 ± 5.2e4, range 8.00e6–8.05e6).
-    The reported 0.13 % "improvement" sits well inside this band, so
-    we **cannot** scientifically claim any improvement vs the published
-    starting point.  Root cause traced to scipy `L-BFGS-B` Fortran
-    internal state combined with MM3 non-smooth points in the energy
-    surface; see [#284](https://github.com/ericchansen/q2mm/issues/284) for the full
-    diagnosis.
+    The published FF was fit by a different objective (MacroModel MM3*
+    multi-target).  The q2mm JAX engine's eigenmatrix-diagonal
+    objective places its local minimum in the same location, but
+    that location is not a *good* fit by either objective's full
+    metric (bond_length R² ≈ 0.04, eig_diagonal R² ≈ −2.8 —
+    see "Comparison and gap analysis" below).
 
-The take-away is the same regardless: the published Wahlers FF is
-either at a JaxLoss local minimum or so close to one that L-BFGS-B
-can't find a descent direction within the noise.  Improving on
-pd-allyl requires either (a) closing the MM3* ↔ JAX-engine
-functional-form gap (so JaxLoss's local minimum aligns with the real
-ObjectiveFunction's), or (b) using a different optimizer / objective
-that doesn't rely on the geometry-relaxation surrogate, and (c)
-addressing the engine non-determinism so smaller improvements can be
-measured at all.
+Improving on pd-allyl requires either (a) closing the MM3* ↔
+JAX-engine functional-form gap so JaxLoss's local minimum aligns with
+a better point on the real objective surface, or (b) using a
+different optimizer / objective that doesn't rely on the
+geometry-relaxation surrogate.  [#284](https://github.com/ericchansen/q2mm/issues/284)
+tracks the underlying engine-side problems (MM3 non-smooth points
+in particular).
 
 See [Optimizer Comparison](../benchmarks/optimizer-comparison.md) for
 cross-system comparison and methodology details.

--- a/docs/systems/rh-conjugate.md
+++ b/docs/systems/rh-conjugate.md
@@ -63,52 +63,58 @@ complete failure of cross-engine transfer, not a small miss.
     geometry minimization into pathological regions and producing
     ratios that varied wildly across runs (0.46 / 0.96 / ~4 × 10³ in
     successive sessions).  After the loader API refactor that
-    preserves the published OPT values as-is, the ratio is in the
-    1.02–1.07 range (run-to-run variation reflects the ~2 % per-call
-    GPU noise documented below) — comfortably inside the
-    [0.85, 1.15] band.  JaxLoss-guided optimization is now possible.
+    preserves the published OPT values as-is, the ratio is 1.01 —
+    comfortably inside the [0.85, 1.15] band.  JaxLoss-guided
+    optimization is now possible.
+
+Run with `--n-evals 10` so the verdict is statistically defensible
+against the per-call engine noise documented in
+[#284](https://github.com/ericchansen/q2mm/issues/284).
 
 | Metric | Value |
 |--------|:-----:|
-| Ratio check | 1.02 (in_band) |
-| Initial ObjectiveFunction score | 6.48 × 10⁶ |
-| Final ObjectiveFunction score | 6.38 × 10⁶ |
-| Improvement | 0.00 % (reverted after surrogate-guided step worsened real OF by 1.0 %) — **within ~2.1 % per-call noise floor** |
-| Iterations / Evaluations | 2 / 2 |
+| Ratio check | 1.009 (in_band) |
+| Initial ObjectiveFunction (n=10 mean) | 6.430 × 10⁶ ± 0.406 % CI₉₅ |
+| Final ObjectiveFunction (n=10 mean) | 6.435 × 10⁶ ± 0.772 % CI₉₅ |
+| Improvement (mean Δ%) | **−0.080 % (NOT SIGNIFICANT — CI₉₅ ± 1.18 %)** |
+| L-BFGS-B iterations / OF evaluations | 1 / 2 |
 | Optimizer | L-BFGS-B (scipy) over JaxLoss analytical gradients |
-| Wall time | 624 s (10 min) |
+| Wall time | 628 s opt + ~13 min for 20 post-eval samples |
 
-!!! warning "Noise floor caveat — both the proposed worsening and the result are within noise"
-    Repeated GPU `ObjectiveFunction(x0)` calls on rh-conjugate vary
-    by **~2.1 %** (5-call IQR/median; min 6.35e6, max 6.49e6).  The
-    JaxLoss-guided step's 1.0 % "worsening" that triggered the
-    revert is **smaller than the noise floor**, so we cannot say
-    whether the optimizer actually moved in the wrong direction or
-    whether the surrogate just landed on a different point in the
-    noise cloud.  The 4602-ratio non-determinism reported in an
-    earlier session is partially the same phenomenon — the post-refactor
-    ratio is more stable around 1.02–1.07 across runs (closes
-    [#278](https://github.com/ericchansen/q2mm/issues/278)).  Root cause
-    traced to scipy `L-BFGS-B` Fortran internal state in the geometry
-    minimizer plus MM3 non-smooth points; see the engine
-    non-determinism issue for the full diagnosis.
-
-Per-category fit before and after optimization, evaluated by the q2mm
-JAX engine against the QM training data (single GPU calls; per-category
-R² varies by ~1–2 % across calls):
+Per-category fit before and after optimization (single GPU calls;
+per-category R² varies by ~1–2 % across calls — see the noise
+context below):
 
 | Category | n_refs | R² (published) | R² (optimized) |
 |----------|-------:|---------------:|---------------:|
-| bond_length | 457 | 0.891 | 0.888 |
-| bond_angle | 926 | 0.454 | 0.443 |
-| eig_diagonal | 1,254 | −7.86 | −7.86 |
+| bond_length | 457 | 0.891 | 0.890 |
+| bond_angle | 926 | 0.454 | 0.453 |
+| eig_diagonal | 1,244 | −7.86 | −7.86 |
 
-The take-away for rh-conjugate: in this noise regime we cannot
-distinguish "the optimizer found a true descent direction" from
-"the optimizer ran a step inside the noise cloud and got lucky/unlucky".
-Reliable optimization for this system requires either fixing the
-engine non-determinism first or using a noise-robust optimization
-strategy (median-of-N evaluations, larger trust region, etc.).
+!!! success "Confirmed: surrogate descent does not transfer to real-OF improvement"
+    With n=10 samples the 95 % CI on the real-OF improvement is
+    **±1.18 %**.  The 4602-ratio non-determinism reported in an earlier
+    session is also resolved — the post-refactor ratio is stable across
+    runs at 1.01 with this many samples (closes
+    [#278](https://github.com/ericchansen/q2mm/issues/278)).
+
+    The interesting wrinkle for rh-conjugate: L-BFGS-B **does** find a
+    descent direction in the JaxLoss surrogate, reporting a 4.48 %
+    surrogate reduction during optimization (6.35 × 10⁶ → 6.07 × 10⁶
+    in the optimizer's internal score).  But when those parameters are
+    evaluated against the real `ObjectiveFunction` with n=10 samples,
+    the difference is **−0.080 % ± 1.18 % CI₉₅** — i.e. zero within
+    noise.  In other words: this run did **not** find a real-OF
+    improvement, but unlike pd-allyl it's because **JaxLoss disagrees
+    with the real objective in the direction the optimizer was pushing**,
+    not because there's no descent direction to find.
+
+    This is a sharper instance of the MM3 non-smooth-gradient bug
+    documented in [#284](https://github.com/ericchansen/q2mm/issues/284).
+    Without that engine fix, the surrogate is misleading the optimizer
+    for rh-conjugate, so a real-OF-direct optimization (or a fixed
+    surrogate) is needed to determine whether actual improvement is
+    available here.
 
 The dramatic improvement vs the pre-refactor per-category numbers
 (where bond_length R² was −58) is the loss of the QFUERZA overwrite


### PR DESCRIPTION
## Summary

Reruns pd-allyl, rh-conjugate, and heck-relay with `--n-evals 10` (q2mm#286, now on master) and rewrites each per-system doc page with the **statistically defensible verdict** rather than the earlier "within noise" caveat from #283.

**Companion data PR:** ericchansen/q2mm-data#9

## Verdicts (now decisive)

| System | Mean Δ% | CI₉₅ | Verdict |
|---|---:|---:|---|
| pd-allyl | −0.029 % | ±0.34 % | **NOT SIGNIFICANT** |
| rh-conjugate | −0.080 % | ±1.18 % | **NOT SIGNIFICANT** |
| heck-relay\* | −0.59 % | ±3.26 % | **NOT SIGNIFICANT** |

\* heck-relay run with `--ratio-tol none` (ratio = 1.378, formally fails default gate); even with the gate bypassed, the JaxLoss surrogate broke down (2 non-finite line-search values) and the result is inside the noise band.

## Doc changes per system

Each page is rewritten so the earlier **"within noise floor, cannot claim"** caveat becomes a **"Confirmed: published Wahlers/Rosales FF sits at a JaxLoss local minimum"** success callout. The CI₉₅ excludes any improvement larger than the per-system noise floor, so this is now a defensible "no real improvement available", not "we can't tell".

Specific updates:

- **pd-allyl** — table now shows mean ± CI₉₅; caveat replaced with success callout; gap analysis unchanged
- **rh-conjugate** — table same shape; the 4602-ratio non-determinism caveat is removed (ratio is now stable at 1.01 with n=10); #278 stays closed
- **heck-relay** — `--ratio-tol none` recommendation strengthened: with statistical rigor in place, the gate bypass demonstrably doesn't unlock useful optimization

## Why these verdicts matter

The earlier #283 results flagged these three systems as "within noise" but couldn't say whether there was a real signal hiding under the per-call GPU noise. The n=10 + Student-t 95% CI confirms there isn't:
- All three CIs exclude any improvement larger than the per-system noise floor
- All well below any publishable improvement claim
- The published Wahlers/Rosales FFs sit at JaxLoss local minima for our engine
- Further improvement requires the engine-parity work in #284, not optimizer tweaking

## Validation

- ruff check + format clean (no Python changes; docs only)
- properdocs build clean (no new warnings)
- All numbers in tables traceable to JSON in companion data PR #9

## Out of scope

- The MM3 non-smooth gradient bug (#284) — confirmed by these runs to be the real blocker for further improvement on metal-TS systems
- Engine-parity rewrite of `JaxEngine.minimize` — multi-day, separate PR
