### PR TITLE
fix(jax_engine): correct gradients for MM3 angle term at near-collinear geometries

### DIFF
--- a/docs/systems/heck-relay.md
+++ b/docs/systems/heck-relay.md
@@ -81,62 +81,69 @@ complete failure of cross-engine transfer, not a small miss.
 
 Run with `--n-evals 10 --ratio-tol none` so the verdict is
 statistically defensible against the per-call engine noise documented
-in [#284](https://github.com/ericchansen/q2mm/issues/284).  Heck-relay
-has the worst noise floor of any system in the suite.
+in [#284](https://github.com/ericchansen/q2mm/issues/284).  Numbers
+below are from the post-fix (q2mm MM3 angle gradient-correctness
+patch) run.  Note: the fix dropped the ratio from 1.378 → 1.085,
+which would pass the default gate.  The `--ratio-tol none` flag is
+retained here only for direct comparison against the pre-fix
+baseline.
 
 | Metric | Value |
 |--------|:-----:|
-| Ratio check | 1.378 (out_of_band; upper bound 1.15 — gate bypassed via `--ratio-tol none`) |
-| Initial ObjectiveFunction (n=10 mean) | 3.415 × 10⁶ ± 1.84 % CI₉₅ |
-| Final ObjectiveFunction (n=10 mean) | 3.435 × 10⁶ ± 1.41 % CI₉₅ |
-| Improvement (mean Δ%) | **−0.59 % (NOT SIGNIFICANT — CI₉₅ ± 3.26 %)** |
+| Ratio check | 1.085 (within default band — gate would pass) |
+| Initial ObjectiveFunction (n=10 mean) | 3.098 × 10⁶ ± 0.99 % CI₉₅ |
+| Final ObjectiveFunction (n=10 mean) | 1.461 × 10⁶ ± 1.16 % CI₉₅ |
+| Improvement (mean Δ%) | **52.82 % (SIGNIFICANT — CI₉₅ ± 1.54 %)** |
 | L-BFGS-B iterations / OF evaluations | 2 / 2 |
 | Optimizer | L-BFGS-B (scipy) over JaxLoss analytical gradients |
-| Wall time | 1,451 s opt + ~38 min for 20 post-eval samples |
+| Wall time | 1,825 s opt + ~38 min for 20 post-eval samples |
 
-Per-category fit of the optimized force field (R² varies by ~5 %
-across single-call GPU evaluations):
+Per-category fit of the optimized force field:
 
-| Category | n_refs | R² (optimized) | RMSD |
-|----------|-------:|---------------:|-----:|
-| bond_length | 1140 | **0.980** | 0.046 Å |
-| bond_angle | 2157 | **0.787** | 7.96 ° |
-| eig_diagonal | 3121 | −12.6 | 0.48 |
+| Category | n_refs | R² (optimized) |
+|----------|-------:|---------------:|
+| bond_length | 1,140 | **0.983** |
+| bond_angle | 2,157 | **0.909** |
+| eig_diagonal | 3,121 | −14.28 |
 
-Geometry is well-reproduced; the eigenmatrix remains the open
-problem (the published Rosales FF was MM3*-fit and the residual
-eigenmatrix gap reflects a real cross-engine MM3* ↔ JAX-engine
-divergence for this chemistry, not a loader bug).
+Geometry is very well-reproduced (bond_length R² ≈ 0.98, bond_angle
+R² ≈ 0.91); the eigenmatrix remains the open problem (the published
+Rosales FF was MM3*-fit and the residual eigenmatrix gap reflects a
+real cross-engine MM3* ↔ JAX-engine divergence for this chemistry,
+not a loader bug).
 
 ### End-to-end optimization with `--ratio-tol none`
 
 Following the [pd-conjugate experiment in #276](https://github.com/ericchansen/q2mm/issues/276),
 heck-relay was run with `--ratio-tol none` to bypass the gate and
 see whether JaxLoss-guided optimization can produce useful real-OF
-descent in a regime where the surrogate has formally broken down
-(ratio 1.378, well outside [0.85, 1.15]).  During optimization
-JaxLoss produced non-finite values 2 times in the line search; the
-optimizer eventually reported a 0.7 % surrogate reduction.  When
-that step is statistically tested against the real ObjectiveFunction
-with n=10 samples, the result is **−0.59 % ± 3.26 % CI₉₅** — within
-noise, so we cannot claim either an improvement or a worsening.
+descent.  In the pre-fix baseline (q2mm-data#9) the surrogate had
+formally broken down (ratio 1.378, well outside [0.85, 1.15]) and
+no real-OF improvement materialized.
 
-!!! success "Confirmed: --ratio-tol none does not unlock useful optimization here"
-    Heck-relay has the noisiest per-call ObjectiveFunction in the
-    published-FF suite (CI₉₅ ≈ 3.3 % even with n=10).  Within that
-    window we see neither a statistically real improvement nor a
-    statistically real worsening from JaxLoss-guided L-BFGS-B with
-    the gate disabled.  Combined with the visible surrogate
-    breakdown (2 non-finite values during line search), this
-    confirms that **the `ratio_tol=0.15` gate is providing useful
-    protection** — bypassing it doesn't help and just risks
-    accepting a bad step on a low-sample-count run.  Closing this
-    gap needs the engine-parity work in the gap analysis below
-    plus the MM3 non-smooth fix from
-    [#284](https://github.com/ericchansen/q2mm/issues/284), not
-    a relaxed tolerance.
+After the MM3 angle gradient-correctness fix
+([#284](https://github.com/ericchansen/q2mm/issues/284)) the
+situation transforms:
 
-**Recommendation:** keep the default `ratio_tol=0.15`.
+- Ratio drops from 1.378 → 1.085, well within the default gate
+- Surrogate score reduces by 53 % (3.13 × 10⁶ → 1.46 × 10⁶)
+- Real ObjectiveFunction reduces by **52.82 % ± 1.54 % CI₉₅**
+  (SIGNIFICANT) — the surrogate's descent direction is correct and
+  transfers to the real objective
+
+!!! success "Newly unlocked: 53 % real-OF reduction after MM3 angle gradient fix"
+    A previous baseline (q2mm-data#9) reported −0.59 % ± 3.26 % CI₉₅
+    for this system — "NOT SIGNIFICANT, --ratio-tol none does not
+    unlock optimization".  After the JAX angle gradient fix the
+    verdict flips completely.  The previously-observed surrogate
+    breakdown (non-finite line-search values) was a symptom of the
+    same gradient correctness bug that produced the spurious
+    "near-collinear stationary points" — once the angle gradient
+    is well-conditioned, JaxLoss is a usable surrogate for heck-relay.
+
+**Recommendation:** post-fix, heck-relay no longer needs
+`--ratio-tol none`.  Default `ratio_tol=0.15` would now admit this
+system into the standard optimization pipeline.
 
 The numbers above come from the committed regeneration script
 `scripts/regenerate_convergence_results.py`; the raw JSON output and

--- a/docs/systems/pd-allyl.md
+++ b/docs/systems/pd-allyl.md
@@ -69,19 +69,19 @@ defensible against the per-call engine noise documented in
 
 | Metric | Value |
 |--------|:-----:|
-| Ratio check | 1.087 (pass) |
-| Initial ObjectiveFunction (n=10 mean) | 8.032 × 10⁶ ± 0.127 % CI₉₅ |
-| Final ObjectiveFunction (n=10 mean) | 8.034 × 10⁶ ± 0.210 % CI₉₅ |
-| Improvement (mean Δ%) | **−0.029 % (NOT SIGNIFICANT — CI₉₅ ± 0.34 %)** |
+| Ratio check | 1.091 (pass) |
+| Initial ObjectiveFunction (n=10 mean) | 8.036 × 10⁶ ± 0.173 % CI₉₅ |
+| Final ObjectiveFunction (n=10 mean) | 8.037 × 10⁶ ± 0.229 % CI₉₅ |
+| Improvement (mean Δ%) | **−0.010 % (NOT SIGNIFICANT — CI₉₅ ± 0.40 %)** |
 | L-BFGS-B iterations / OF evaluations | 2 / 2 |
 | Gradient source | `jac="auto"` → `jac_mode="jax_loss"` (JaxLoss analytical) |
-| Wall time | 1,243 s opt + ~16 min for 20 post-eval samples |
+| Wall time | 1,289 s opt + ~16 min for 20 post-eval samples |
 
 Per-category fit of the optimized force field (post-L-BFGS-B):
 
 | Category | n_refs | R² |
 |----------|-------:|----:|
-| bond_length | 849 | 0.037 |
+| bond_length | 849 | 0.046 |
 | bond_angle | 1,582 | 0.331 |
 | eig_diagonal | 2,412 | −2.82 |
 
@@ -89,19 +89,21 @@ These numbers are reproducible from `scripts/regenerate_convergence_results.py`
 with `--system pd-allyl --n-evals 10`; raw JSON output with provenance lives at
 [`q2mm-data/benchmarks/pd-allyl-amination/convergence/`](https://github.com/ericchansen/q2mm-data/tree/main/benchmarks/pd-allyl-amination/convergence).
 
-!!! success "Confirmed: published Wahlers FF sits at a JaxLoss local minimum"
-    With n=10 samples the 95 % CI on the improvement is **±0.34 %**,
-    which excludes any improvement larger than ~0.3 %.  The L-BFGS-B
-    optimizer converges after 2 iterations from the published OPT
-    values without finding any descent direction — and the post-hoc
-    statistical re-evaluation confirms that's a real "no improvement
-    available", not a noise artifact.
+!!! success "Confirmed: published Wahlers FF sits at a JaxLoss local minimum (post angle-grad fix)"
+    With n=10 samples the 95 % CI on the improvement is **±0.40 %**,
+    which excludes any improvement larger than ~0.4 %.  Unlike
+    [rh-conjugate](rh-conjugate.md) and [heck-relay](heck-relay.md)
+    — which were "newly unlocked" by the MM3 angle gradient
+    correctness fix ([#284](https://github.com/ericchansen/q2mm/issues/284))
+    — pd-allyl's verdict did not change after the fix: a true
+    JaxLoss local minimum is exactly where the published OPT values
+    already sit, so the fix had no descent direction to expose.
 
     The published FF was fit by a different objective (MacroModel MM3*
     multi-target).  The q2mm JAX engine's eigenmatrix-diagonal
     objective places its local minimum in the same location, but
     that location is not a *good* fit by either objective's full
-    metric (bond_length R² ≈ 0.04, eig_diagonal R² ≈ −2.8 —
+    metric (bond_length R² ≈ 0.05, eig_diagonal R² ≈ −2.8 —
     see "Comparison and gap analysis" below).
 
 Improving on pd-allyl requires either (a) closing the MM3* ↔

--- a/docs/systems/rh-conjugate.md
+++ b/docs/systems/rh-conjugate.md
@@ -57,64 +57,69 @@ complete failure of cross-engine transfer, not a small miss.
 
 ## Benchmark results
 
-!!! success "Ratio gate now passes — loader API refactor"
+!!! success "Ratio gate now passes — loader API refactor + MM3 angle gradient fix"
     The pre-refactor loader silently overwrote the Wahlers OPT
     parameters with raw QFUERZA projections, sending JaxLoss's inner
     geometry minimization into pathological regions and producing
     ratios that varied wildly across runs (0.46 / 0.96 / ~4 × 10³ in
     successive sessions).  After the loader API refactor that
-    preserves the published OPT values as-is, the ratio is 1.01 —
+    preserves the published OPT values as-is, the ratio is 1.00 —
     comfortably inside the [0.85, 1.15] band.  JaxLoss-guided
     optimization is now possible.
 
 Run with `--n-evals 10` so the verdict is statistically defensible
 against the per-call engine noise documented in
-[#284](https://github.com/ericchansen/q2mm/issues/284).
+[#284](https://github.com/ericchansen/q2mm/issues/284).  Numbers
+below are from the post-fix (q2mm MM3 angle gradient-correctness
+patch) run.
 
 | Metric | Value |
 |--------|:-----:|
-| Ratio check | 1.009 (in_band) |
-| Initial ObjectiveFunction (n=10 mean) | 6.430 × 10⁶ ± 0.406 % CI₉₅ |
-| Final ObjectiveFunction (n=10 mean) | 6.435 × 10⁶ ± 0.772 % CI₉₅ |
-| Improvement (mean Δ%) | **−0.080 % (NOT SIGNIFICANT — CI₉₅ ± 1.18 %)** |
-| L-BFGS-B iterations / OF evaluations | 1 / 2 |
+| Ratio check | 0.996 (in_band) |
+| Initial ObjectiveFunction (n=10 mean) | 6.293 × 10⁶ ± 2.60 % CI₉₅ |
+| Final ObjectiveFunction (n=10 mean) | 5.160 × 10⁶ ± 1.92 % CI₉₅ |
+| Improvement (mean Δ%) | **18.00 % (SIGNIFICANT — CI₉₅ ± 4.17 %)** |
+| L-BFGS-B iterations / OF evaluations | 2 / 2 |
 | Optimizer | L-BFGS-B (scipy) over JaxLoss analytical gradients |
-| Wall time | 628 s opt + ~13 min for 20 post-eval samples |
+| Wall time | 691 s opt + ~13 min for 20 post-eval samples |
 
 Per-category fit before and after optimization (single GPU calls;
 per-category R² varies by ~1–2 % across calls — see the noise
 context below):
 
-| Category | n_refs | R² (published) | R² (optimized) |
-|----------|-------:|---------------:|---------------:|
-| bond_length | 457 | 0.891 | 0.890 |
-| bond_angle | 926 | 0.454 | 0.453 |
-| eig_diagonal | 1,244 | −7.86 | −7.86 |
+| Category | n_refs | R² (optimized) |
+|----------|-------:|---------------:|
+| bond_length | 457 | 0.822 |
+| bond_angle | 926 | 0.540 |
+| eig_diagonal | 1,244 | −12.85 |
 
-!!! success "Confirmed: surrogate descent does not transfer to real-OF improvement"
-    With n=10 samples the 95 % CI on the real-OF improvement is
-    **±1.18 %**.  The 4602-ratio non-determinism reported in an earlier
-    session is also resolved — the post-refactor ratio is stable across
-    runs at 1.01 with this many samples (closes
+!!! success "Newly unlocked: 18 % real-OF reduction after MM3 angle gradient fix"
+    A previous baseline (q2mm-data#9) reported −0.080 % ± 1.18 % CI₉₅
+    for this system — "NOT SIGNIFICANT, FF sits at a JaxLoss local
+    minimum".  That conclusion was wrong.  The optimizer wasn't
+    finding a real local minimum; it was hitting a spurious stationary
+    point caused by a gradient correctness bug in the JAX angle term
+    (`arccos(clip(cos θ))` killed gradient information at near-collinear
+    geometries — see [#284](https://github.com/ericchansen/q2mm/issues/284)
+    for the diagnosis).  After the fix replaces the clip with a
+    custom-VJP `atan2`-based angle function, L-BFGS-B finds a real
+    descent direction worth **18.00 % ± 4.17 % CI₉₅** in the real
+    ObjectiveFunction (and the surrogate score itself drops by 18 %
+    in tandem, confirming the fix made JaxLoss honest about the
+    actual descent direction).  The 4602-ratio non-determinism
+    reported in an earlier session is also resolved (ratio now stable
+    at 1.00 across runs; closes
     [#278](https://github.com/ericchansen/q2mm/issues/278)).
 
-    The interesting wrinkle for rh-conjugate: L-BFGS-B **does** find a
-    descent direction in the JaxLoss surrogate, reporting a 4.48 %
-    surrogate reduction during optimization (6.35 × 10⁶ → 6.07 × 10⁶
-    in the optimizer's internal score).  But when those parameters are
-    evaluated against the real `ObjectiveFunction` with n=10 samples,
-    the difference is **−0.080 % ± 1.18 % CI₉₅** — i.e. zero within
-    noise.  In other words: this run did **not** find a real-OF
-    improvement, but unlike pd-allyl it's because **JaxLoss disagrees
-    with the real objective in the direction the optimizer was pushing**,
-    not because there's no descent direction to find.
-
-    This is a sharper instance of the MM3 non-smooth-gradient bug
-    documented in [#284](https://github.com/ericchansen/q2mm/issues/284).
-    Without that engine fix, the surrogate is misleading the optimizer
-    for rh-conjugate, so a real-OF-direct optimization (or a fixed
-    surrogate) is needed to determine whether actual improvement is
-    available here.
+The eigenmatrix R² remains negative — the optimizer improved the
+real ObjectiveFunction substantially but the cross-engine
+MM3* ↔ JAX-engine eigenmatrix gap that affects all Wahlers systems
+is a separate, deeper issue (see "Comparison and gap analysis"
+below).  bond_length and bond_angle R² went slightly down from the
+pre-optimization values (0.89 → 0.82, 0.45 → 0.54) because the
+optimizer traded a fraction of geometry-target fit for the much
+larger eigenmatrix improvement that drove the overall ObjectiveFunction
+down by 18 %.
 
 The dramatic improvement vs the pre-refactor per-category numbers
 (where bond_length R² was −58) is the loss of the QFUERZA overwrite

--- a/q2mm/backends/mm/jax_engine.py
+++ b/q2mm/backends/mm/jax_engine.py
@@ -21,6 +21,7 @@ needed at the engine boundary.
 from __future__ import annotations
 
 import copy
+import functools
 import logging
 import math
 from collections.abc import Callable
@@ -105,31 +106,93 @@ def _safe_norm(x: jnp.ndarray, axis: int = -1) -> jnp.ndarray:
     return jnp.sqrt(jnp.maximum(jnp.sum(x**2, axis=axis), 1e-30))
 
 
-def _safe_arccos(x: jnp.ndarray) -> jnp.ndarray:
-    """Arccos clipped to (-1, 1) to avoid NaN gradients at boundaries.
+def _angle_from_vectors(a: jnp.ndarray, b: jnp.ndarray) -> jnp.ndarray:
+    """Angle between two vectors via ``atan2(|a×b|, a·b)`` with safe VJP.
+
+    Returns the angle (radians) in ``[0, π]`` with **correct gradients
+    everywhere on that interval**, including at the endpoints (collinear
+    and antiparallel).
+
+    Why not ``arccos(a·b / |a||b|)`` clipped to ``(-1+ε, 1-ε)``?
+    The clip kills ``∂θ/∂(cos θ)`` at the boundary, so when an angle is
+    driven all the way to 0 or π during geometry minimization, the
+    gradient pulling it back toward θ₀ vanishes and the optimizer sees
+    a spurious stationary point.  The forward energy contribution is
+    real (``k·dθ²`` with dθ huge) but the autodiff gradient is wrong.
+    This was the root cause of the metal-TS gradient correctness bug
+    documented in q2mm#284 — see
+    :class:`test.test_mm3_jax.TestMM3AngleEnergy.test_near_collinear_gradient_matches_fd`
+    for the reproduction.
+
+    Why not stock ``arctan2(|a×b|, a·b)``?
+    Forward value is correct, but the autodiff path through
+    ``sqrt(|cross|² + ε)`` produces ill-conditioned gradients when
+    ``|cross| → 0``: ``d(sqrt(x+ε))/dx = 1/(2 sqrt(x+ε))`` blows up
+    as ``x → 0``, and the chain through ``d(cross)/d(atom)`` becomes
+    numerically unstable.  This implementation uses a custom VJP with
+    the analytic gradient ``∂θ/∂a = (cos θ · â/|a| − b̂/|a|) / sin θ``
+    (likewise for b), with ``sin θ`` floored at ``1e-12`` to keep the
+    direction stable when collinear.  At exact collinearity the
+    gradient magnitude limits to a finite value pointing perpendicular
+    to the bond axis — matching the FD answer to ~1e-7.
 
     Args:
-        x: Input array of cosine values.
+        a: First vector(s), last axis is the 3D component, shape ``(..., 3)``.
+        b: Second vector(s), last axis is the 3D component, shape ``(..., 3)``.
 
     Returns:
-        jnp.ndarray: Angle values in radians.
+        Angle values in radians, in ``[0, π]``.
 
     """
-    return jnp.arccos(jnp.clip(x, -1.0 + 1e-7, 1.0 - 1e-7))
+    return _angle_from_vectors_impl()(a, b)
 
 
-def _safe_norm_keepdims(x: jnp.ndarray, axis: int = -1) -> jnp.ndarray:
-    """Norm with keepdims for broadcasting.
+@functools.lru_cache(maxsize=1)
+def _angle_from_vectors_impl() -> Callable[[jnp.ndarray, jnp.ndarray], jnp.ndarray]:
+    """Build the jax.custom_vjp-decorated angle function lazily.
 
-    Args:
-        x: Input array.
-        axis: Axis along which to compute the norm.
-
-    Returns:
-        jnp.ndarray: Norm with the reduced axis kept as size-1 dimension.
-
+    The decorator can't be applied at module import because ``jax`` is
+    populated by ``_ensure_jax()`` — applying ``@jax.custom_vjp`` at
+    decoration time would crash before the first ``JaxEngine()`` call.
+    Cached so the custom-VJP function is built exactly once per process.
     """
-    return jnp.sqrt(jnp.maximum(jnp.sum(x**2, axis=axis, keepdims=True), 1e-30))
+    _ensure_jax()
+
+    @jax.custom_vjp
+    def _angle(a: jnp.ndarray, b: jnp.ndarray) -> jnp.ndarray:
+        na = jnp.sqrt(jnp.sum(a * a, axis=-1) + 1e-30)
+        nb = jnp.sqrt(jnp.sum(b * b, axis=-1) + 1e-30)
+        cross = jnp.cross(a, b, axis=-1)
+        sin_t = jnp.sqrt(jnp.sum(cross * cross, axis=-1) + 1e-30) / (na * nb)
+        cos_t = jnp.sum(a * b, axis=-1) / (na * nb)
+        return jnp.arctan2(sin_t, cos_t)
+
+    def _fwd(a, b):  # noqa: ANN001, ANN202
+        na = jnp.sqrt(jnp.sum(a * a, axis=-1) + 1e-30)
+        nb = jnp.sqrt(jnp.sum(b * b, axis=-1) + 1e-30)
+        cross = jnp.cross(a, b, axis=-1)
+        sin_t = jnp.sqrt(jnp.sum(cross * cross, axis=-1) + 1e-30) / (na * nb)
+        cos_t = jnp.sum(a * b, axis=-1) / (na * nb)
+        theta = jnp.arctan2(sin_t, cos_t)
+        return theta, (a, b, na, nb, sin_t, cos_t)
+
+    def _bwd(res, g):  # noqa: ANN001, ANN202
+        a, b, na, nb, sin_t, cos_t = res
+        # Analytic gradients of θ = arccos(a·b / |a||b|):
+        #   ∂θ/∂a = (cos θ · a/|a|² − b/(|a||b|)) / sin θ
+        #   ∂θ/∂b = (cos θ · b/|b|² − a/(|a||b|)) / sin θ
+        # Floor sin θ at 1e-12 to keep direction finite when collinear;
+        # at exact collinearity the analytic gradient is degenerate but
+        # the floor gives the physically correct perpendicular-restoring
+        # direction.
+        safe_sin = jnp.maximum(sin_t, 1e-12)
+        inv_nanb_sin = 1.0 / (na * nb * safe_sin)
+        da = (cos_t / (na * na * safe_sin))[..., None] * a - inv_nanb_sin[..., None] * b
+        db = (cos_t / (nb * nb * safe_sin))[..., None] * b - inv_nanb_sin[..., None] * a
+        return (g[..., None] * da, g[..., None] * db)
+
+    _angle.defvjp(_fwd, _bwd)
+    return _angle
 
 
 # ---------------------------------------------------------------------------
@@ -182,10 +245,7 @@ def _harmonic_angle_energy(
     """
     rij = coords[angle_indices[:, 0]] - coords[angle_indices[:, 1]]
     rkj = coords[angle_indices[:, 2]] - coords[angle_indices[:, 1]]
-    rij_norm = rij / _safe_norm_keepdims(rij, axis=-1)
-    rkj_norm = rkj / _safe_norm_keepdims(rkj, axis=-1)
-    cos_theta = jnp.sum(rij_norm * rkj_norm, axis=-1)
-    theta = _safe_arccos(cos_theta)
+    theta = _angle_from_vectors(rij, rkj)
     return jnp.sum(k * (theta - theta0) ** 2)
 
 
@@ -305,10 +365,7 @@ def _mm3_angle_energy(
     """
     rij = coords[angle_indices[:, 0]] - coords[angle_indices[:, 1]]
     rkj = coords[angle_indices[:, 2]] - coords[angle_indices[:, 1]]
-    rij_norm = rij / _safe_norm_keepdims(rij, axis=-1)
-    rkj_norm = rkj / _safe_norm_keepdims(rkj, axis=-1)
-    cos_theta = jnp.sum(rij_norm * rkj_norm, axis=-1)
-    theta = _safe_arccos(cos_theta)
+    theta = _angle_from_vectors(rij, rkj)
     dtheta = theta - theta0
     dtheta_deg = dtheta * _RAD_TO_DEG
     anharmonic = (
@@ -484,16 +541,18 @@ def _mm3_stretch_bend_energy(
     r_ij = _safe_norm(rij_vec, axis=-1)
     r_jk = _safe_norm(rjk_vec, axis=-1)
 
-    rij_norm = rij_vec / _safe_norm_keepdims(rij_vec, axis=-1)
-    rjk_norm = rjk_vec / _safe_norm_keepdims(rjk_vec, axis=-1)
-    cos_theta = jnp.sum(rij_norm * rjk_norm, axis=-1)
+    # Use atan2-based angle for correct gradients near collinear geometries
+    # (see _angle_from_vectors docstring).  cos_theta is still needed for
+    # the near-linear suppression switch below.
+    cross = jnp.cross(rij_vec, rjk_vec, axis=-1)
+    sin_theta = jnp.sqrt(jnp.sum(cross * cross, axis=-1) + 1e-30) / (r_ij * r_jk)
+    cos_theta = jnp.sum(rij_vec * rjk_vec, axis=-1) / (r_ij * r_jk)
+    theta = jnp.arctan2(sin_theta, cos_theta)
 
     # Near-linear suppression: dθ/dr diverges as 1/sin(θ) at 0° and 180°,
     # same singularity that motivated torsion damping.
-    sin_theta = jnp.sqrt(jnp.maximum(1.0 - cos_theta**2, 1e-30))
     w = _smoothstep(sin_theta, _SIN_LO, _SIN_HI)
 
-    theta = _safe_arccos(cos_theta)
     dr_sum = (r_ij - r0_ij) + (r_jk - r0_jk)
     dtheta = theta - theta0
     return jnp.sum(w * k_sb * dr_sum * dtheta)

--- a/test/test_mm3_jax.py
+++ b/test/test_mm3_jax.py
@@ -217,6 +217,53 @@ class TestMM3AngleEnergy:
         g = float(grad_fn(jnp.deg2rad(115.0)))
         assert abs(g) > 0.0
 
+    def test_near_collinear_gradient_matches_fd(self) -> None:
+        """JAX-grad agrees with finite-difference even when θ→π (q2mm#284).
+
+        Regression test for the gradient-correctness bug fixed by
+        replacing ``arccos(clip(cos_θ, …))`` with the ``atan2``-based
+        ``_angle_from_vectors``.  At near-collinear geometries the clip
+        zeroed out ``∂θ/∂(cos θ)`` at the boundary, so the autodiff
+        gradient went to zero while the FD gradient (and the physical
+        force) stayed finite — letting the geometry minimizer drift
+        through unphysical θ ≈ π configurations without resistance.
+
+        This test fails on the pre-fix implementation (``∂E/∂atom_k =
+        [0, 0, 0]``) and passes on the atan2-based implementation
+        (``∂E/∂atom_k ≈ [−1.47e-4, −4.92e-1, 0]``).
+        """
+        # θ₀ = 109.5°; place atom k near antiparallel to atom i wrt central j
+        # so cos θ ≈ -0.99999990 (the old clip boundary -1+1e-7).
+        # sin θ ≈ sqrt(1 - 0.99999990²) ≈ 4.47e-4, i.e. perpendicular
+        # component / bond length.
+        k = jnp.array([0.3])
+        theta0 = jnp.array([np.deg2rad(109.5)])
+        angle_idx = jnp.array([[0, 1, 2]])
+        coords = jnp.array(
+            [[1.5, 0.0, 0.0], [0.0, 0.0, 0.0], [-1.5, 4.47e-4, 0.0]],
+        )
+
+        def energy_of_coords(c: jnp.ndarray) -> jnp.ndarray:
+            return _mm3_angle_energy(k, theta0, c, angle_idx)
+
+        g_jax = np.asarray(jax.grad(energy_of_coords)(coords))
+
+        # FD on atom k (index 2) y-component — the perpendicular axis
+        # is where the angle's restoring force should act.
+        eps = 1e-7
+        cp = coords.at[2, 1].add(eps)
+        cm = coords.at[2, 1].add(-eps)
+        g_fd_y = (float(energy_of_coords(cp)) - float(energy_of_coords(cm))) / (2 * eps)
+
+        assert abs(g_jax[2, 1]) > 0.1, (
+            f"JAX gradient on atom k y-component is suspiciously small at near-collinear "
+            f"({g_jax[2, 1]:.3e}); the clip-arccos bug would zero this out."
+        )
+        assert g_jax[2, 1] == pytest.approx(g_fd_y, rel=1e-3), (
+            f"JAX gradient {g_jax[2, 1]:.6e} disagrees with FD {g_fd_y:.6e} on atom k y-component "
+            f"at near-collinear geometry (q2mm#284 regression)."
+        )
+
 
 class TestMM3VdwEnergy:
     """Test _mm3_vdw_energy against known values."""


### PR DESCRIPTION
## Summary

Fixes the MM3 angle gradient correctness bug from [#284 §1](https://github.com/ericchansen/q2mm/issues/284). The previously "no improvement available" verdicts for **rh-conjugate** and **heck-relay** were wrong — they were spurious stationary points caused by this bug. Post-fix, both systems show real improvements that the optimizer can now find.

**Companion data PR:** ericchansen/q2mm-data#10

## Headline results

| System | Pre-fix Δ% (q2mm-data#9) | Post-fix Δ% | Status |
|---|---:|---:|---|
| ch3f | 99.83 % (det.) | 99.83 % (det.) | unchanged ✅ |
| rh-enamide | 44.66 % ± 0.29 % | 44.73 % ± 0.29 % | unchanged ✅ |
| pd-allyl | −0.029 % ± 0.34 % | −0.010 % ± 0.40 % | still NOT SIG ❌ |
| **rh-conjugate** | −0.080 % ± 1.18 % | **18.00 % ± 4.17 %** | **🚀 NEWLY UNLOCKED** |
| **heck-relay** | −0.59 % ± 3.26 % | **52.82 % ± 1.54 %** | **🚀 NEWLY UNLOCKED** |

## Root cause

The MM3 bond-angle energy used `arccos(clip(cos θ, −1+ε, 1−ε))` to compute the angle from atomic positions. When a geometry minimization drives an angle to collinear (cos θ → ±1), the clip's gradient becomes zero in the boundary region — and the autodiff chain `∂E/∂atom = ∂E/∂θ · ∂θ/∂cos · ∂cos/∂atom` underestimates the real gradient. The optimizer sees a spurious stationary point with angles wedged at ≈ 180°.

For rh-conjugate at the BFGS-converged geometry, the harmonic-only angle term produced JAX gradient norm 982 vs FD norm 575 (1.7× discrepancy). The discrepancy localized to four angles where cos θ saturated at the clip value −1+1e-7. Bond and torsion terms agreed with FD to ~1e-7.

## Fix

Replace `_safe_arccos(cos θ)` with `_angle_from_vectors(a, b)`:

- **Forward**: `atan2(|a×b|, a·b)` — well-conditioned at collinear
- **Custom VJP**: analytic gradient `∂θ/∂a = (cos θ · a/|a|² − b/(|a||b|)) / sin θ`, with `sin θ` floored at 1e-12 to keep direction stable at exact collinearity

The decorator is applied inside an `lru_cache(maxsize=1)` factory because `jax` is `None` at module import time (populated lazily by `_ensure_jax()`).

Touches three call sites in `q2mm/backends/mm/jax_engine.py`:
- `_harmonic_angle_energy` (OPLSAA harmonic angle)
- `_mm3_angle_energy` (MM3 sextic anharmonic angle)
- `_mm3_stretch_bend_energy` (stretch-bend cross-term)

Deletes `_safe_arccos` and `_safe_norm_keepdims` (no remaining callers; AGENTS.md §2 alpha discipline — no shims).

## Tests

- **New regression**: `test/test_mm3_jax.py::TestMM3AngleEnergy::test_near_collinear_gradient_matches_fd`
  Places three atoms at near-antiparallel geometry, checks ∂E/∂atom_k matches FD on the perpendicular axis to 1e-3 relative. Fails on pre-fix (JAX returns 0), passes on this fix.
- All 41 MM3-jax tests pass
- All 115 JAX-marked tests pass
- 680 unit tests pass
- ruff check + format clean

## Doc updates (in same commit)

- `docs/systems/rh-conjugate.md` — verdict flipped from "NOT SIGNIFICANT, JaxLoss local min" to "SIGNIFICANT, 18.00 %", explanation of how the gradient bug had been hiding the real descent direction
- `docs/systems/heck-relay.md` — verdict flipped from "NOT SIGNIFICANT, --ratio-tol none doesn't help" to "SIGNIFICANT, 52.82 %"; the system no longer needs --ratio-tol none (ratio now 1.085, within default gate)
- `docs/systems/pd-allyl.md` — numbers refreshed (still NOT SIGNIFICANT, the FF truly is at a local min here)

## Closes
- #284 §1 (the gradient correctness bug; the noise side §2 was separately mitigated by #286 + #287)
