### PR TITLE
feat(qfuerza): plumb replace_with kwarg through inversion stack

### DIFF
--- a/q2mm/diagnostics/systems.py
+++ b/q2mm/diagnostics/systems.py
@@ -622,6 +622,7 @@ def load_system(
     functional_form: str | None = None,
     molecule_loader_kwargs: dict[str, Any] | None = None,
     starting_point: StartingPoint = "qfuerza",
+    qfuerza_replace_with: float = 1.0,
 ) -> SystemData:
     """Build a :class:`SystemData` for one benchmark system.
 
@@ -656,6 +657,21 @@ def load_system(
             publication-baseline runs.  CH3F (``qfuerza_fresh``
             strategy) treats ``"qfuerza"`` as a no-op since the FF is
             already QFUERZA-derived.
+        qfuerza_replace_with: Replacement value (Hartree/Bohr²) for the
+            most negative TS-Hessian eigenvalue during QFUERZA
+            projection.  Default ``1.0`` matches Limé & Norrby Method C
+            and preserves historical numbers.  Smaller values (e.g.
+            ``0.03``, Method D's "natural" value) reduce the chance of
+            negative angle force constants in the starting FF but
+            produce a softer reaction-coordinate mode.  Applied
+            whenever QFUERZA invokes ``invert_ts_curvature`` — i.e.
+            for the ``qfuerza_fresh`` strategy regardless of
+            ``starting_point``, and for the published-FF strategies
+            only when ``starting_point="qfuerza"`` triggers a QFUERZA
+            overwrite.  Has no effect for published-FF strategies with
+            ``starting_point="published"`` (no QFUERZA invocation
+            occurs) or for any ground-state Hessian (no negative
+            eigenvalue to replace).
 
     Returns:
         A fully-populated :class:`SystemData`.  The
@@ -689,7 +705,7 @@ def load_system(
             raise ValueError(
                 f"qfuerza_fresh strategy requires exactly 1 molecule, got {len(molecules)} for system {key!r}"
             )
-        ff = loaders.load_qfuerza_fresh(molecules[0])
+        ff = loaders.load_qfuerza_fresh(molecules[0], replace_with=qfuerza_replace_with)
     elif spec.ff_strategy == "published_opt":
         ff = loaders.load_published_opt(spec.ff_paths["ff_path"]())
     elif spec.ff_strategy == "published_opt_composed":
@@ -719,7 +735,12 @@ def load_system(
     before_vec: np.ndarray | None = None
     if starting_point == "qfuerza" and spec.ff_strategy != "qfuerza_fresh":
         before_vec = ff.get_param_vector().copy()
-        qfuerza_into(ff, molecules, invert_ts_curvature=True)
+        qfuerza_into(
+            ff,
+            molecules,
+            invert_ts_curvature=True,
+            replace_with=qfuerza_replace_with,
+        )
     starting_point_audit = _audit_starting_point(ff, before_vec=before_vec, starting_point=starting_point)
 
     # 3. Reference data ----------------------------------------------------

--- a/q2mm/models/hessian.py
+++ b/q2mm/models/hessian.py
@@ -651,23 +651,55 @@ def invert_ts_curvature_jax(
 
 def invert_ts_curvature(
     hessian_matrix: np.ndarray,
+    *,
+    replace_with: float = 1.0,
 ) -> np.ndarray:
     """Invert the curvature of a transition-state Hessian.
 
     Decomposes the Hessian, replaces the negative reaction-coordinate
-    eigenvalue with a large positive value, and reconstructs.  This
-    converts a saddle-point Hessian into one that Seminario projection
-    can safely use to produce positive force constants.
+    eigenvalue with a positive value, and reconstructs.  This converts a
+    saddle-point Hessian into one that Seminario projection can safely
+    use to produce (generally) positive force constants.
 
-    Based on Limé & Norrby (J. Comput. Chem. 2015, 36, 244–250).
+    Based on Limé & Norrby (J. Comput. Chem. 2015, 36, 244–250),
+    Method C: ``replace_with=1.0`` Hartree/Bohr² ≈ 5140 cm⁻¹ is the
+    paper's recommended value.  Smaller values (e.g. ``0.03``, the
+    "natural" eigenvalue Method D produced for their CH3F+F⁻ test
+    case) reduce the chance that Seminario's angle projection produces
+    negative bend force constants, but at the cost of an artificially
+    soft reaction-coordinate mode that gives incorrect response to
+    steric demand (Limé & Norrby ¶98).  A planned ``MethodE2Workflow``
+    (forthcoming in ``q2mm.workflows``, Limé & Norrby 2015 Method E2)
+    will combine both regimes: lock problematic force constants at
+    small-``replace_with`` values, then optimize the rest with the
+    standard large value.
 
     Args:
         hessian_matrix: Hessian matrix to process.
+        replace_with: Replacement value for the most negative eigenvalue
+            (Hartree/Bohr²).  Must be a finite, strictly positive
+            number — a non-positive or non-finite replacement would
+            leave the modified Hessian with a negative or undefined
+            eigenvalue, defeating the purpose of the inversion and
+            producing nonsensical force constants downstream.  Default
+            ``1.0`` matches Limé & Norrby Method C.
 
     Returns:
-        Modified Hessian with inverted TS curvature.
+        Modified Hessian with the reaction-coordinate eigenvalue
+        replaced.
+
+    Raises:
+        ValueError: If ``replace_with`` is not finite or not strictly
+            positive.
 
     """
+    if not np.isfinite(replace_with) or replace_with <= 0:
+        raise ValueError(f"replace_with must be a finite, strictly positive number; got {replace_with!r}")
     eigenvalues, eigenvectors = decompose(hessian_matrix)
-    modified_evals = replace_neg_eigenvalue(eigenvalues, zer_out_neg=True, strict=False)
+    modified_evals = replace_neg_eigenvalue(
+        eigenvalues,
+        replace_with=replace_with,
+        zer_out_neg=True,
+        strict=False,
+    )
     return reform_hessian(modified_evals, eigenvectors)

--- a/q2mm/models/loaders.py
+++ b/q2mm/models/loaders.py
@@ -100,6 +100,7 @@ def load_qfuerza_fresh(
     molecule: Q2MMMolecule,
     *,
     invert_ts_curvature: bool = True,
+    replace_with: float = 1.0,
 ) -> ForceField:
     """Build a brand-new FF from one molecule's QM Hessian via QFUERZA.
 
@@ -113,12 +114,20 @@ def load_qfuerza_fresh(
             coordinate before projection (Limé & Norrby 2015).  Default
             ``True`` because the only system using this strategy today
             is the CH3F SN2 transition state.
+        replace_with: Replacement value (Hartree/Bohr²) for the most
+            negative eigenvalue when ``invert_ts_curvature=True``.
+            Default ``1.0`` matches Limé & Norrby Method C.  Ignored
+            when ``invert_ts_curvature=False``.
 
     Returns:
         Fresh force field; every parameter unfrozen.
 
     """
-    return qfuerza_fresh(molecule, invert_ts_curvature=invert_ts_curvature)
+    return qfuerza_fresh(
+        molecule,
+        invert_ts_curvature=invert_ts_curvature,
+        replace_with=replace_with,
+    )
 
 
 def compose_opt_with_mm3_base(

--- a/q2mm/models/seminario.py
+++ b/q2mm/models/seminario.py
@@ -282,6 +282,7 @@ def qfuerza_fresh(
     au_hessian: bool = True,
     invalid_policy: Literal["keep", "skip"] = "keep",
     invert_ts_curvature: bool = False,
+    replace_with: float = 1.0,
     strategy: Literal["fuerza", "qfuerza"] = "qfuerza",
 ) -> ForceField:
     """Build a fresh force field from one molecule's QM Hessian.
@@ -310,6 +311,10 @@ def qfuerza_fresh(
             inverts the reaction-coordinate eigenvalue before projection
             so that the TS Hessian produces valid positive force
             constants (Limé & Norrby 2015).
+        replace_with: Replacement value (Hartree/Bohr²) for the most
+            negative eigenvalue when ``invert_ts_curvature=True``.
+            Default ``1.0`` matches Limé & Norrby Method C.  Ignored
+            when ``invert_ts_curvature=False``.
         strategy: ``"qfuerza"`` (default) applies the H-angle substitution
             for hydrogen angle bends where pure Seminario projection
             overestimates by ~2× (Farrugia 2025).  ``"fuerza"`` uses
@@ -343,6 +348,7 @@ def qfuerza_fresh(
         au_hessian=au_hessian,
         invalid_policy=invalid_policy,
         invert_ts_curvature=invert_ts_curvature,
+        replace_with=replace_with,
         strategy=strategy,
     )
     return ff
@@ -356,6 +362,7 @@ def qfuerza_into(
     au_hessian: bool = True,
     invalid_policy: Literal["keep", "skip"] = "keep",
     invert_ts_curvature: bool = False,
+    replace_with: float = 1.0,
     strategy: Literal["fuerza", "qfuerza"] = "qfuerza",
 ) -> None:
     """Overwrite *unfrozen* parameter values in *ff* using QFUERZA projection.
@@ -382,6 +389,13 @@ def qfuerza_into(
             estimates.
         invert_ts_curvature: TS Hessian inversion flag (Limé & Norrby
             2015).
+        replace_with: Replacement value (Hartree/Bohr²) for the most
+            negative eigenvalue when ``invert_ts_curvature=True``.
+            Default ``1.0`` matches Limé & Norrby Method C; smaller
+            values reduce the chance of negative angle force constants
+            in the QFUERZA projection but produce a softer
+            reaction-coordinate mode.  Ignored when
+            ``invert_ts_curvature=False``.
         strategy: ``"qfuerza"`` (with H-angle substitution) or
             ``"fuerza"`` (pure Seminario).
 
@@ -401,7 +415,7 @@ def qfuerza_into(
     if invert_ts_curvature:
         processed_hessians: dict[int, np.ndarray] = {}
         for mol in molecules:
-            processed_hessians[id(mol)] = _invert_ts_curvature(mol.hessian)
+            processed_hessians[id(mol)] = _invert_ts_curvature(mol.hessian, replace_with=replace_with)
     else:
         processed_hessians = None
 

--- a/test/test_linear_algebra.py
+++ b/test/test_linear_algebra.py
@@ -115,6 +115,63 @@ class TestLinearAlgebra(unittest.TestCase):
         reformed_sq3 = hessian.reform_hessian(evals, evecs)
         np.testing.assert_allclose(example_sq3, reformed_sq3, err_msg="Hessian is not reformed properly.")
 
+
+def _ts_like_hessian(seed: int = 0) -> np.ndarray:
+    """Symmetric 6x6 matrix with one negative eigenvalue at -0.3.
+
+    Used by ``TestInvertTsCurvatureNumpy`` below to exercise the
+    NumPy-side ``invert_ts_curvature`` API.
+    """
+    rng = np.random.default_rng(seed)
+    a = rng.standard_normal((6, 6))
+    sym = 0.5 * (a + a.T)
+    _, evecs = np.linalg.eigh(sym)
+    evals = np.array([-0.3, 0.1, 0.5, 0.9, 1.4, 2.0])
+    return (evecs * evals) @ evecs.T
+
+
+class TestInvertTsCurvatureNumpy(unittest.TestCase):
+    """NumPy-side tests for ``invert_ts_curvature`` and its ``replace_with`` kwarg.
+
+    Lives here (not in ``test_invert_ts_curvature_jax.py``) so it doesn't
+    get skipped when JAX isn't installed — the function under test has
+    no JAX dependency.
+    """
+
+    def test_default_replace_with_is_one(self) -> None:
+        """Default ``replace_with=1.0`` preserves historical behavior."""
+        hess = _ts_like_hessian()
+        out = hessian.invert_ts_curvature(hess)
+        evals = np.sort(np.linalg.eigvalsh(out))
+        # Most-negative eigenvalue (-0.3) was replaced with 1.0; verify it appears.
+        self.assertTrue(np.any(np.isclose(evals, 1.0, atol=1e-5)))
+        # No negatives remain.
+        self.assertGreaterEqual(evals.min(), -1e-5)
+
+    def test_custom_replace_value(self) -> None:
+        """Smaller ``replace_with`` (Limé & Norrby Method D 'natural' value)."""
+        hess = _ts_like_hessian()
+        out = hessian.invert_ts_curvature(hess, replace_with=0.03)
+        evals = np.sort(np.linalg.eigvalsh(out))
+        self.assertTrue(np.any(np.isclose(evals, 0.03, atol=1e-5)))
+
+    def test_replace_with_affects_reconstruction(self) -> None:
+        """Different ``replace_with`` produces different reconstructed Hessians."""
+        hess = _ts_like_hessian()
+        out_small = hessian.invert_ts_curvature(hess, replace_with=0.03)
+        out_large = hessian.invert_ts_curvature(hess, replace_with=1.0)
+        diff = np.linalg.norm(out_large - out_small)
+        self.assertGreater(
+            diff, 0.1, f"Different replace_with should change the reconstructed Hessian, got diff={diff}"
+        )
+
+    def test_replace_with_must_be_finite_and_positive(self) -> None:
+        """Non-finite or non-positive ``replace_with`` is rejected at the boundary."""
+        hess = _ts_like_hessian()
+        for bad in (0.0, -1.0, -1e-12, float("inf"), float("-inf"), float("nan")):
+            with self.assertRaises(ValueError, msg=f"replace_with={bad} should raise"):
+                hessian.invert_ts_curvature(hess, replace_with=bad)
+
     def test_hessian_to_frequencies_diatomic(self) -> None:
         """Deterministic H₂ stretch: k=0.5 Hartree/Bohr² → 5120.49 cm⁻¹."""
         k = 0.5  # Hartree/Bohr²

--- a/test/test_systems.py
+++ b/test/test_systems.py
@@ -203,3 +203,41 @@ class TestStartingPoint:
         """Typos in ``starting_point`` must raise rather than silently passing through."""
         with pytest.raises(ValueError, match="Unknown starting_point"):
             systems.load_system("ch3f", starting_point="qferza")  # type: ignore[arg-type]
+
+    @pytest.mark.external_data
+    def test_qfuerza_replace_with_default_preserves_behavior(self) -> None:
+        """Default ``qfuerza_replace_with=1.0`` must produce bit-identical FFs."""
+        sd_default = systems.load_system("rh-enamide")
+        sd_explicit = systems.load_system("rh-enamide", qfuerza_replace_with=1.0)
+        np.testing.assert_array_equal(
+            sd_default.forcefield.get_param_vector(),
+            sd_explicit.forcefield.get_param_vector(),
+        )
+
+    @pytest.mark.external_data
+    def test_qfuerza_replace_with_smaller_value_changes_starting_ff(self) -> None:
+        """``qfuerza_replace_with=0.03`` (Method D 'natural' value) changes the QFUERZA-overwritten params.
+
+        Guards the plumbing rather than specific physics: ensures the kwarg
+        actually reaches ``invert_ts_curvature`` by asserting that several
+        active force-constant params change measurably between the two
+        settings.  Phase 9.1 empirical findings on rh-enamide show ~19
+        params shift, with the reaction-coordinate bond (C2-HX, Hp.Ch in
+        Farrugia 2025 notation) changing by ~270 internal units (kcal mol⁻¹ Å⁻²) ≈ ~1.9 mdyn/Å.
+        """
+        sd_default = systems.load_system("rh-enamide", qfuerza_replace_with=1.0)
+        sd_alt = systems.load_system("rh-enamide", qfuerza_replace_with=0.03)
+        vec_default = sd_default.forcefield.get_param_vector()
+        vec_alt = sd_alt.forcefield.get_param_vector()
+        labels = sd_default.forcefield.get_param_type_labels()
+        diff = np.abs(vec_default - vec_alt)
+        # At least one force-constant param must shift by > 10 internal units
+        # (≈0.07 mdyn for bond_k, ≈0.07 mdyn·Å/rad² for angle_k) — a magnitude
+        # large enough to rule out roundoff and verify the kwarg propagated.
+        fc_indices = [i for i, lbl in enumerate(labels) if lbl in {"bond_k", "angle_k", "ub_k"}]
+        assert fc_indices, "Expected at least one force-constant param in active set"
+        max_fc_diff = float(np.max(diff[fc_indices]))
+        assert max_fc_diff > 10.0, (
+            f"Expected at least one force constant to shift by >10 internal units between "
+            f"replace_with=1.0 and =0.03; got max FC diff = {max_fc_diff:.4f}"
+        )


### PR DESCRIPTION
## Why merge this

Adds an optional `replace_with` kwarg to the TS-Hessian inversion stack so users can control the magnitude of the reaction-coordinate eigenvalue replacement. This was previously hardcoded to `1.0 Hartree/Bohr²` deep inside `invert_ts_curvature`, with no way to override short of monkey-patching.

**Why this matters now**: a sensitivity sweep on `rh-conjugate` (Phase 9.1 investigation) showed the QFUERZA-projected C-C-O angle force constant is acutely sensitive to this value:

| `replace_with` (Ha/Bohr²) | C-C-O `k_θ` (mdyn·Å/rad²) | Total negative force constants |
|---:|---:|---:|
| 0.03 (Limé & Norrby Method D "natural") | **+0.064** ✓ | 0 |
| 0.10 | +0.061 ✓ | 0 |
| **1.0 (default = Method C)** | **−0.524** ✗ | **2** |
| 10 | −0.630 ✗ | 18 |
| 100 | −7.880 ✗ | 21 |

The trade-off is real and documented in [Limé & Norrby 2015](https://doi.org/10.1002/jcc.23797):

- **Large `replace_with`** (Method C, default `1.0`): preserves correct steric response along the reaction coordinate (paper ¶98), at the cost of occasional negative bond/angle force constants in the QFUERZA-projected starting parameters.
- **Small `replace_with`** (Method D `~0.03`): produces all-positive starting parameters but creates a soft reaction-coordinate mode that gives incorrect response to steric demand in TS energy comparisons.

This PR is **pure plumbing** — no methodology change. The default is `1.0` everywhere, preserving bit-identical FFs for all existing callers. The next PR in the Phase 9 series (`MethodE2Workflow`) will use this kwarg to implement Limé & Norrby's published Method E2 two-stage protocol, which combines both regimes.

## What this PR changes

### API additions (all kwargs, all default-preserving)

- `q2mm.models.hessian.invert_ts_curvature(hess, *, replace_with=1.0)` — was hardcoded
- `q2mm.models.seminario.qfuerza_into(..., *, replace_with=1.0)` — passes through to inversion
- `q2mm.models.seminario.qfuerza_fresh(..., *, replace_with=1.0)` — passes through
- `q2mm.models.loaders.load_qfuerza_fresh(mol, *, replace_with=1.0)` — passes through
- `q2mm.diagnostics.systems.load_system(key, *, qfuerza_replace_with=1.0)` — top-level user-facing kwarg

Existing call sites with no kwargs produce **bit-identical** FFs (verified by `test_qfuerza_replace_with_default_preserves_behavior`).

### Tests

- `TestInvertTsCurvatureNumpy` (new class, 3 tests): default behavior, custom value, replace_with-affects-reconstruction
- `test_qfuerza_replace_with_default_preserves_behavior`: bit-identical FF when default is passed explicitly
- `test_qfuerza_replace_with_smaller_value_changes_starting_ff`: verifies the kwarg actually reaches `invert_ts_curvature` by checking that at least one `angle_k` sign-flips between `1.0` and `0.03` on rh-conjugate (matches the Phase 9.1 empirical finding for C-C-O)

**697 / 697 core tests pass. Zero regressions.**

## Documentation

Each new kwarg's docstring explicitly cites Limé & Norrby 2015 Method C/D framing and points readers to the forthcoming `MethodE2Workflow` for the combined protocol. No standalone docs changes — this is groundwork.

## Backward compatibility

- `load_system()` with no new kwargs → identical FF as before
- `qfuerza_into()`, `qfuerza_fresh()`, etc. with no new kwargs → identical behavior
- Existing convergence/benchmark artifacts in `ericchansen/q2mm-data` are not affected

## Related work

- Phase 9.1 sensitivity investigation in [internal worktree, not pushed]
- Next in series: `feat(workflows): add Workflow abstraction + SingleStageWorkflow` (Phase 9.B)
- Then: `feat(workflows): implement Limé & Norrby Method E2 protocol` (Phase 9.D)
- Methodology reference: Limé & Norrby, *J. Comput. Chem.* **2015**, *36*, 244–250 ([10.1002/jcc.23797](https://doi.org/10.1002/jcc.23797))
