### PR TITLE
feat(workflows): add Workflow Protocol + SingleStageWorkflow

### DIFF
--- a/q2mm/workflows/__init__.py
+++ b/q2mm/workflows/__init__.py
@@ -1,0 +1,41 @@
+"""Multi-stage force field parameterization workflows.
+
+A *workflow* composes preliminary parameter estimation, one or more
+optimization stages, and post-processing into a single ``run()``
+entry point.  Distinct from the search algorithms in
+:mod:`q2mm.optimizers` — those define *how* to search the parameter
+space; workflows define *what sequence of search problems to solve*.
+
+Implementations:
+
+- :class:`q2mm.workflows.SingleStageWorkflow` — the standard Q2MM
+  workflow: one optimization pass against the
+  :class:`~q2mm.optimizers.objective.ObjectiveFunction` built from
+  ``SystemData.reference``.  Equivalent to the current default
+  behavior used throughout the codebase; this class makes the pattern
+  composable and substitutable.
+- (Planned) ``MethodE2Workflow`` — Limé & Norrby 2015 two-stage TSFF
+  protocol: Method D Round 1, lock force-constants that decay to
+  zero/negative, Method C Round 2 on the remainder.  Forthcoming
+  per Phase 9.D of the QFUERZA-recovery work.
+
+References
+----------
+- Limé, E.; Norrby, P.-O. *J. Comput. Chem.* **2015**, *36*, 244–250.
+  DOI 10.1002/jcc.23797.
+- Farrugia, M. et al. *J. Chem. Theory Comput.* **2025**, *22*, 469.
+  DOI 10.1021/acs.jctc.5c01751.
+
+"""
+
+from __future__ import annotations
+
+from q2mm.workflows.base import StageResult, Workflow, WorkflowResult
+from q2mm.workflows.single_stage import SingleStageWorkflow
+
+__all__ = [
+    "SingleStageWorkflow",
+    "StageResult",
+    "Workflow",
+    "WorkflowResult",
+]

--- a/q2mm/workflows/base.py
+++ b/q2mm/workflows/base.py
@@ -1,0 +1,175 @@
+"""Workflow Protocol + result dataclasses.
+
+A workflow is a multi-stage orchestration of preliminary parameter
+estimation, optimization, and post-processing.  See the
+:mod:`q2mm.workflows` module docstring for the design rationale.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from q2mm.diagnostics.systems import SystemData
+    from q2mm.models.forcefield import ForceField
+
+
+@dataclass
+class StageResult:
+    """Result of a single optimization stage within a workflow.
+
+    Most workflows have one stage (``SingleStageWorkflow``); the
+    planned two-stage protocols (Method E2) report two
+    :class:`StageResult` instances back-to-back.
+
+    Attributes:
+        name: Human-readable stage label (e.g. ``"optimize"``,
+            ``"round-1-method-d"``, ``"round-2-method-c"``).
+        initial_score: Optimizer-reported objective value at the start
+            of this stage.  May be the surrogate (JaxLoss) when
+            ``jac_mode="auto"`` resolves to analytical gradients —
+            see ``OptimizationResult.final_score`` for the same
+            caveat.
+        final_score: Optimizer-reported objective value at the end of
+            this stage.  Same surrogate caveat as ``initial_score``.
+        n_iterations: Optimizer iteration count.
+        n_evaluations: Objective/gradient call count.
+        converged: Optimizer's convergence flag.
+        message: Optimizer's convergence message.
+        jac_mode: Resolved Jacobian strategy for this stage
+            (``"analytical"``, ``"finite-difference"``, or
+            ``"derivative-free"``).  May be ``"unknown"`` if the
+            optimizer didn't report.
+        elapsed_s: Wall time for the optimizer call.
+        locked_param_indices: Full-vector indices of parameters
+            frozen at the start of this stage by the workflow itself
+            (distinct from parameters frozen on the FF before
+            workflow invocation).  Empty for ``SingleStageWorkflow``;
+            populated by Method E2's Round 2.
+        notes: Free-form per-stage metadata (e.g. "method": "D",
+            "replace_with": 0.03) for downstream reporting.
+
+    """
+
+    name: str
+    initial_score: float
+    final_score: float
+    n_iterations: int
+    n_evaluations: int
+    converged: bool
+    message: str
+    jac_mode: str
+    elapsed_s: float
+    locked_param_indices: list[int] = field(default_factory=list)
+    notes: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class WorkflowResult:
+    """Complete output of a :meth:`Workflow.run` call.
+
+    Attributes:
+        workflow_name: Identifier of the workflow that produced this
+            result (e.g. ``"single-stage"``).
+        final_ff: Force field at the end of the workflow.
+        initial_ff: Snapshot of the force field as it was when the
+            workflow started.  Workflow implementations are
+            responsible for materializing this snapshot via
+            ``forcefield.with_params(initial_vector)`` before invoking
+            the optimizer — the current ``ScipyOptimizer`` mutates the
+            FF inside the ObjectiveFunction during the search, so a
+            bare reference to ``system.forcefield`` would point at the
+            *final* state.
+        stages: Per-stage diagnostics, ordered chronologically.  Length
+            1 for ``SingleStageWorkflow``; 2 for the planned
+            ``MethodE2Workflow``.
+        initial_obj_samples: ``n_evals`` samples of the *real*
+            :class:`~q2mm.optimizers.objective.ObjectiveFunction`
+            evaluated at the initial parameters.  Engine non-
+            determinism (geometry-relaxation seeding, etc.) means a
+            single eval is noisy; ``n_evals > 1`` quantifies that
+            noise.  Empty list is valid (``n_evals=0`` skip).
+        final_obj_samples: Same as ``initial_obj_samples`` but at the
+            final parameters.
+        optimized_categories: Per-reference-category fit metrics
+            (R², RMSD, MAE, n) for the final FF.  Keys depend on what
+            reference types are populated (bond_length, bond_angle,
+            eig_diagonal, ...).
+
+    """
+
+    workflow_name: str
+    final_ff: ForceField
+    initial_ff: ForceField
+    stages: list[StageResult]
+    initial_obj_samples: list[float] = field(default_factory=list)
+    final_obj_samples: list[float] = field(default_factory=list)
+    optimized_categories: dict[str, dict[str, float]] = field(default_factory=dict)
+
+
+@runtime_checkable
+class _Optimizer(Protocol):
+    """Minimal optimizer interface shared by ScipyOptimizer / multistart / etc.
+
+    Mirrors the existing ``_Optimizer`` protocol in
+    :mod:`q2mm.optimizers.multistart`.  Defined here so workflows
+    don't pull a hard dependency on a specific concrete optimizer.
+    """
+
+    def optimize(self, objective: Any) -> Any:  # noqa: ANN401
+        """Run the optimization; return an ``OptimizationResult``-shaped object."""
+        ...
+
+
+@runtime_checkable
+class Workflow(Protocol):
+    """Multi-stage force field parameterization workflow.
+
+    Implementations build the :class:`ObjectiveFunction` internally
+    from ``system``, call ``optimizer.optimize(...)`` one or more
+    times, and aggregate per-stage diagnostics into a
+    :class:`WorkflowResult`.
+    """
+
+    name: str
+
+    def run(
+        self,
+        system: SystemData,
+        engine: Any,  # noqa: ANN401
+        optimizer: _Optimizer,
+        *,
+        n_evals: int = 1,
+    ) -> WorkflowResult:
+        """Execute the workflow.
+
+        .. warning::
+
+           Implementations using the current :class:`ScipyOptimizer`
+           will see ``system.forcefield`` mutated in place during the
+           search (``ObjectiveFunction.forcefield.set_param_vector``
+           runs on every step).  Use ``WorkflowResult.initial_ff`` and
+           ``WorkflowResult.final_ff`` as the stable before/after
+           snapshots; do not rely on ``system.forcefield`` being
+           unchanged after the call.
+
+        Args:
+            system: Loaded benchmark system; supplies the force field,
+                molecules, and reference data.  ``system.forcefield``
+                may be mutated by the inner optimizer — see warning.
+            engine: MM backend used to evaluate the objective.
+            optimizer: Pre-configured search algorithm.  Constructor
+                kwargs (method, bounds strategy, ftol, etc.) belong
+                here, not on the workflow.
+            n_evals: Number of *real* objective samples to take at
+                the initial and final parameter vectors for noise-
+                floor quantification.  ``0`` skips post-hoc sampling
+                (final FF is still computed).
+
+        Returns:
+            :class:`WorkflowResult` with per-stage diagnostics, final
+            FF, and per-category fit metrics.
+
+        """
+        ...

--- a/q2mm/workflows/single_stage.py
+++ b/q2mm/workflows/single_stage.py
@@ -1,0 +1,207 @@
+"""The standard single-pass Q2MM workflow.
+
+Wraps the canonical pattern used throughout the codebase — build an
+``ObjectiveFunction`` from a loaded ``SystemData``, run one optimizer
+pass, sample the real objective at the endpoints for noise quantification
+— in the :class:`~q2mm.workflows.base.Workflow` Protocol so it composes
+with multi-stage protocols (forthcoming Method E2) and can be swapped
+without changing the call site.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from q2mm.workflows.base import StageResult, WorkflowResult
+
+if TYPE_CHECKING:
+    from q2mm.diagnostics.systems import SystemData
+    from q2mm.optimizers.objective import ObjectiveFunction
+    from q2mm.workflows.base import _Optimizer
+
+
+def _r2(ref: np.ndarray, calc: np.ndarray) -> float:
+    """Q2MM coefficient of determination; NaN when undefined.
+
+    Mirrors ``scripts/regenerate_convergence_results.py::_r2`` so this
+    workflow produces the same numbers when used as a drop-in
+    replacement for the script's inline orchestration.
+    """
+    if ref.size < 2:
+        return float("nan")
+    ss_res = float(np.sum((ref - calc) ** 2))
+    mean = float(np.mean(ref))
+    ss_tot = float(np.sum((ref - mean) ** 2))
+    if ss_tot == 0.0:
+        return float("nan")
+    return 1.0 - ss_res / ss_tot
+
+
+def _category_stats(ref_values: np.ndarray, calc_values: np.ndarray) -> dict[str, float]:
+    """Per-category n / R² / RMSD / MAE."""
+    n = int(ref_values.size)
+    if n == 0:
+        return {"n_refs": 0, "r2": float("nan"), "rmsd": float("nan"), "mae": float("nan")}
+    residuals = ref_values - calc_values
+    return {
+        "n_refs": n,
+        "r2": _r2(ref_values, calc_values),
+        "rmsd": float(np.sqrt(np.mean(residuals**2))),
+        "mae": float(np.mean(np.abs(residuals))),
+    }
+
+
+def _per_category_metrics(obj: ObjectiveFunction, ff: Any) -> dict[str, dict[str, float]]:
+    """Bucket residuals by reference kind, undo weights, compute stats.
+
+    ``ObjectiveFunction._compute_residuals(ff)`` returns
+    ``w_i * (ref - calc)`` for every reference value in order.  We
+    invert the weight to recover ``calc``, group by ``ref.kind``,
+    and apply :func:`_category_stats` per bucket.  References with
+    ``weight == 0.0`` are skipped (e.g. the imaginary mode in TS
+    eigenmatrix fits).
+    """
+    residuals = obj._compute_residuals(ff)  # noqa: SLF001 — diagnostics-only API
+    buckets: dict[str, list[tuple[float, float]]] = defaultdict(list)
+    for ref, weighted in zip(obj.reference.values, residuals, strict=True):
+        if ref.weight == 0.0:
+            continue
+        raw_residual = float(weighted) / float(ref.weight)
+        calc_value = float(ref.value) - raw_residual
+        buckets[ref.kind].append((float(ref.value), calc_value))
+    return {
+        kind: _category_stats(
+            np.array([p[0] for p in pairs]),
+            np.array([p[1] for p in pairs]),
+        )
+        for kind, pairs in buckets.items()
+    }
+
+
+def _evaluate_samples(obj: ObjectiveFunction, params: np.ndarray, n_evals: int) -> list[float]:
+    """Sample the real objective ``n_evals`` times at the given parameters.
+
+    Quantifies per-call engine non-determinism (geometry-relaxation
+    seeding, JIT compile order, etc.).  ``ObjectiveFunction.__call__``
+    appends to ``obj.history`` and increments ``obj.n_eval``; this
+    helper restores both after each call so that the optimizer's
+    bookkeeping is not polluted by post-hoc sampling.  Truncates
+    ``obj.history`` rather than copying it — O(1) vs O(len(history))
+    per sample, which matters when the optimizer has accumulated
+    thousands of evaluations.  Mirrors
+    ``scripts/regenerate_convergence_results.py::_evaluate_objective_samples``.
+    """
+    n_eval_before = obj.n_eval
+    history_len_before = len(obj.history)
+    scores: list[float] = []
+    for _ in range(n_evals):
+        try:
+            score = float(obj(params))
+        finally:
+            obj.n_eval = n_eval_before
+            del obj.history[history_len_before:]
+        scores.append(score)
+    return scores
+
+
+class SingleStageWorkflow:
+    """One optimization pass against the system's ``ObjectiveFunction``.
+
+    Equivalent to::
+
+        obj = ObjectiveFunction(system.forcefield, engine,
+                                system.molecules, system.reference)
+        result = optimizer.optimize(obj)
+        final_ff = system.forcefield.with_params(result.final_params)
+        # ... noise-floor sampling, per-category metrics ...
+
+    Use this as the default workflow.  For multi-stage TSFF
+    parameterization with negative-FC handling, use the planned
+    ``MethodE2Workflow`` (Phase 9.D).
+    """
+
+    name: str = "single-stage"
+
+    def run(
+        self,
+        system: SystemData,
+        engine: Any,  # noqa: ANN401
+        optimizer: _Optimizer,
+        *,
+        n_evals: int = 1,
+    ) -> WorkflowResult:
+        """Execute one optimizer pass; return a fully-populated WorkflowResult.
+
+        .. warning::
+
+           ``system.forcefield`` is mutated in place by the inner
+           optimizer (the current :class:`ScipyOptimizer` calls
+           ``ObjectiveFunction.forcefield.set_param_vector`` on every
+           step).  This workflow snapshots the initial parameter
+           vector into ``WorkflowResult.initial_ff`` before invoking
+           the optimizer so consumers have a stable before/after
+           diff; do not rely on ``system.forcefield`` itself being
+           unchanged after the call.
+
+        Args:
+            system: Loaded benchmark system.  ``system.forcefield``
+                supplies the starting point; it may be mutated by the
+                optimizer — use ``WorkflowResult.initial_ff`` /
+                ``final_ff`` for the stable snapshots.
+            engine: MM backend.
+            optimizer: Pre-configured optimizer (e.g. ``ScipyOptimizer``).
+            n_evals: Real-objective samples at initial and final params.
+                ``0`` skips sampling.
+
+        Returns:
+            :class:`WorkflowResult` with one :class:`StageResult` named
+            ``"optimize"`` and per-category metrics on the optimized FF.
+
+        """
+        from q2mm.optimizers.objective import ObjectiveFunction
+
+        # Snapshot the starting parameter vector BEFORE optimization.  The
+        # optimizer mutates the FF inside ObjectiveFunction in place during
+        # the search, so a bare reference to ``system.forcefield`` would
+        # point at the *final* state by the time we package it as
+        # ``initial_ff``.  Use ``with_params`` to materialize a stable
+        # snapshot.
+        initial_params = system.forcefield.get_param_vector().copy()
+        initial_ff = system.forcefield.with_params(initial_params)
+        obj = ObjectiveFunction(system.forcefield, engine, system.molecules, system.reference)
+
+        t0 = time.perf_counter()
+        opt_result = optimizer.optimize(obj)
+        elapsed = time.perf_counter() - t0
+
+        final_ff = initial_ff.with_params(opt_result.final_params)
+
+        initial_samples = _evaluate_samples(obj, opt_result.initial_params, n_evals)
+        final_samples = _evaluate_samples(obj, opt_result.final_params, n_evals)
+        optimized_categories = _per_category_metrics(obj, final_ff)
+
+        stage = StageResult(
+            name="optimize",
+            initial_score=float(opt_result.initial_score),
+            final_score=float(opt_result.final_score),
+            n_iterations=int(opt_result.n_iterations),
+            n_evaluations=int(opt_result.n_evaluations),
+            converged=bool(opt_result.success),
+            message=str(opt_result.message),
+            jac_mode=str(opt_result.jac_mode) if opt_result.jac_mode is not None else "unknown",
+            elapsed_s=elapsed,
+        )
+
+        return WorkflowResult(
+            workflow_name=self.name,
+            final_ff=final_ff,
+            initial_ff=initial_ff,
+            stages=[stage],
+            initial_obj_samples=initial_samples,
+            final_obj_samples=final_samples,
+            optimized_categories=optimized_categories,
+        )

--- a/test/test_workflows.py
+++ b/test/test_workflows.py
@@ -1,0 +1,202 @@
+"""Tests for :mod:`q2mm.workflows`.
+
+The acceptance criterion for ``SingleStageWorkflow`` is **bit-identical
+parity** with the inline ``ObjectiveFunction → ScipyOptimizer.optimize``
+pattern that the codebase has used to date.  These tests run both code
+paths on the smallest available system (CH3F) and assert the workflow
+produces the same final score, parameter vector, and per-category
+metrics as the direct call.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from q2mm.workflows import SingleStageWorkflow, StageResult, Workflow, WorkflowResult
+from q2mm.workflows.base import _Optimizer
+
+
+class TestWorkflowProtocol:
+    """The Protocol must accept conforming implementations."""
+
+    def test_single_stage_satisfies_workflow_protocol(self) -> None:
+        """``SingleStageWorkflow`` is runtime-checkable as ``Workflow``."""
+        assert isinstance(SingleStageWorkflow(), Workflow)
+
+    def test_optimizer_protocol_accepts_scipy_optimizer(self) -> None:
+        """``ScipyOptimizer`` satisfies the workflows' ``_Optimizer`` Protocol."""
+        from q2mm.optimizers.scipy_opt import ScipyOptimizer
+
+        assert isinstance(ScipyOptimizer(), _Optimizer)
+
+
+class TestStageResultDataclass:
+    """Field defaults and dataclass semantics."""
+
+    def test_stage_result_required_fields(self) -> None:
+        """All non-default fields must be supplied."""
+        sr = StageResult(
+            name="opt",
+            initial_score=1.0,
+            final_score=0.5,
+            n_iterations=10,
+            n_evaluations=20,
+            converged=True,
+            message="ok",
+            jac_mode="analytical",
+            elapsed_s=1.5,
+        )
+        assert sr.locked_param_indices == []
+        assert sr.notes == {}
+
+    @pytest.mark.jax
+    def test_workflow_result_default_lists(self) -> None:
+        """Default lists/dicts are per-instance (not shared)."""
+        from q2mm.backends.mm.jax_engine import JaxEngine
+        from q2mm.diagnostics.systems import load_system
+
+        sd = load_system("ch3f", engine=JaxEngine())
+        wr1 = WorkflowResult(
+            workflow_name="x",
+            final_ff=sd.forcefield,
+            initial_ff=sd.forcefield,
+            stages=[],
+        )
+        wr2 = WorkflowResult(
+            workflow_name="y",
+            final_ff=sd.forcefield,
+            initial_ff=sd.forcefield,
+            stages=[],
+        )
+        wr1.initial_obj_samples.append(1.0)
+        assert wr2.initial_obj_samples == []
+
+
+@pytest.mark.jax
+class TestSingleStageWorkflowParity:
+    """``SingleStageWorkflow.run()`` must match the direct optimizer call.
+
+    Each test loads its own SystemData; the optimizer mutates the FF
+    inside the ObjectiveFunction in place, so a class-scope fixture
+    would leak state between tests.
+    """
+
+    @staticmethod
+    def _load() -> tuple:
+        """Fresh ``(SystemData, engine)`` per test."""
+        from q2mm.backends.mm.jax_engine import JaxEngine
+        from q2mm.diagnostics.systems import load_system
+
+        engine = JaxEngine()
+        return load_system("ch3f", engine=engine), engine
+
+    def test_workflow_matches_direct_call(self) -> None:
+        """Same final score and parameter vector as the inline pattern."""
+        from q2mm.optimizers.objective import ObjectiveFunction
+        from q2mm.optimizers.scipy_opt import ScipyOptimizer
+
+        # Path 1: inline pattern (the historical default)
+        sd_direct, engine = self._load()
+        obj_direct = ObjectiveFunction(sd_direct.forcefield, engine, sd_direct.molecules, sd_direct.reference)
+        opt_direct = ScipyOptimizer(method="L-BFGS-B", maxiter=5, ftol=1e-6, verbose=False)
+        direct_result = opt_direct.optimize(obj_direct)
+
+        # Path 2: SingleStageWorkflow with the same optimizer config, fresh system
+        sd_workflow, engine = self._load()
+        opt_workflow = ScipyOptimizer(method="L-BFGS-B", maxiter=5, ftol=1e-6, verbose=False)
+        workflow_result = SingleStageWorkflow().run(sd_workflow, engine, opt_workflow, n_evals=0)
+
+        np.testing.assert_array_equal(
+            direct_result.final_params,
+            workflow_result.final_ff.get_param_vector()[sd_workflow.forcefield.active_mask],
+        )
+        assert direct_result.final_score == workflow_result.stages[0].final_score
+        assert direct_result.n_iterations == workflow_result.stages[0].n_iterations
+        assert direct_result.n_evaluations == workflow_result.stages[0].n_evaluations
+
+    def test_workflow_returns_optimized_categories(self) -> None:
+        """Per-category metrics dict is populated for systems with eigenmatrix refs."""
+        from q2mm.optimizers.scipy_opt import ScipyOptimizer
+
+        sd, engine = self._load()
+        opt = ScipyOptimizer(method="L-BFGS-B", maxiter=1, ftol=1e-6, verbose=False)
+        result = SingleStageWorkflow().run(sd, engine, opt, n_evals=0)
+
+        # CH3F has eigenmatrix-diagonal refs by default
+        assert result.optimized_categories, "expected at least one residual category"
+        for kind, stats in result.optimized_categories.items():
+            assert {"n_refs", "r2", "rmsd", "mae"} <= set(stats.keys()), f"missing keys for {kind}"
+
+    def test_workflow_result_preserves_initial_ff_snapshot(self) -> None:
+        """``WorkflowResult.initial_ff`` snapshots starting params even after the optimizer mutates the original.
+
+        The current ``ScipyOptimizer`` mutates the FF inside the
+        ObjectiveFunction in place as it searches.  The workflow
+        guards against that by snapshotting the initial parameter
+        vector before invoking the optimizer, so consumers comparing
+        before/after have a stable reference.
+        """
+        from q2mm.optimizers.scipy_opt import ScipyOptimizer
+
+        sd, engine = self._load()
+        before = sd.forcefield.get_param_vector().copy()
+
+        opt = ScipyOptimizer(method="L-BFGS-B", maxiter=2, ftol=1e-6, verbose=False)
+        result = SingleStageWorkflow().run(sd, engine, opt, n_evals=0)
+
+        np.testing.assert_array_equal(result.initial_ff.get_param_vector(), before)
+
+    def test_n_evals_samples_objective(self) -> None:
+        """``n_evals > 0`` populates the sample lists with that many entries."""
+        from q2mm.optimizers.scipy_opt import ScipyOptimizer
+
+        sd, engine = self._load()
+        opt = ScipyOptimizer(method="L-BFGS-B", maxiter=1, ftol=1e-6, verbose=False)
+        result = SingleStageWorkflow().run(sd, engine, opt, n_evals=3)
+        assert len(result.initial_obj_samples) == 3
+        assert len(result.final_obj_samples) == 3
+        assert all(isinstance(s, float) for s in result.initial_obj_samples)
+
+    def test_n_evals_zero_skips_sampling(self) -> None:
+        """``n_evals=0`` produces empty sample lists."""
+        from q2mm.optimizers.scipy_opt import ScipyOptimizer
+
+        sd, engine = self._load()
+        opt = ScipyOptimizer(method="L-BFGS-B", maxiter=1, ftol=1e-6, verbose=False)
+        result = SingleStageWorkflow().run(sd, engine, opt, n_evals=0)
+        assert result.initial_obj_samples == []
+        assert result.final_obj_samples == []
+
+    def test_post_hoc_sampling_does_not_pollute_optimizer_bookkeeping(self) -> None:
+        """``_evaluate_samples`` restores n_eval and truncates history.
+
+        Without this, every workflow run would leak ``2 * n_evals``
+        spurious evaluations into ``ObjectiveFunction.n_eval`` and
+        ``ObjectiveFunction.history`` — confusing downstream
+        diagnostics and growing memory unboundedly for callers that
+        re-use the same ObjectiveFunction across multiple workflow
+        runs.  Mirrors the script's
+        ``_evaluate_objective_samples`` contract.
+        """
+        from q2mm.optimizers.objective import ObjectiveFunction
+
+        sd, engine = self._load()
+        obj = ObjectiveFunction(sd.forcefield, engine, sd.molecules, sd.reference)
+        # Call once to seed n_eval / history (just like the optimizer would).
+        params = sd.forcefield.get_param_vector()
+        _ = obj(params)
+        n_eval_baseline = obj.n_eval
+        history_len_baseline = len(obj.history)
+
+        # Sample 5 times; these must not pollute the counters.
+        from q2mm.workflows.single_stage import _evaluate_samples
+
+        samples = _evaluate_samples(obj, params, 5)
+        assert len(samples) == 5
+        assert obj.n_eval == n_eval_baseline, (
+            f"Sampling leaked into n_eval: baseline={n_eval_baseline}, after sampling={obj.n_eval}"
+        )
+        assert len(obj.history) == history_len_baseline, (
+            f"Sampling leaked into history: baseline len={history_len_baseline}, after sampling len={len(obj.history)}"
+        )


### PR DESCRIPTION
## Why merge this

Introduces a new `q2mm.workflows` package for multi-stage FF parameterization protocols, with the simplest concrete workflow (`SingleStageWorkflow`) that wraps the canonical pattern used throughout the codebase. The abstraction is the **scaffolding** for the forthcoming `MethodE2Workflow` (Phase 9.D, Limé & Norrby 2015's two-stage TSFF protocol that addresses the negative-`k_θ` problem documented in Phase 9.1).

**Why a new module instead of putting it in `q2mm/optimizers/`:**

The optimizers module defines *how* to search the parameter space — `ScipyOptimizer`, `MultiStartOptimizer`, `BasinHoppingOptimizer`, `CyclingOptimizer`. They all wrap each other via a shared Protocol and stay within the search-algorithm role.

A workflow is bigger:
- builds the `ObjectiveFunction` from a loaded `SystemData`
- runs one or more optimizer passes
- mutates the FF between stages (planned: lock force constants in Method E2)
- rebuilds reference data for later stages (planned: modified-Hessian eigenmatrix for Method E2 Round 2)
- aggregates per-stage diagnostics

That's not a search algorithm — it's an orchestration. Putting it in `q2mm/workflows/` keeps the search-algorithm primitives clean and gives multi-stage protocols a natural home.

## What ships

```
q2mm/workflows/
├── __init__.py         # public API (re-exports SingleStageWorkflow, Workflow, etc.)
├── base.py             # Workflow Protocol, WorkflowResult, StageResult dataclasses
└── single_stage.py     # SingleStageWorkflow + per-category metrics helpers

test/test_workflows.py   # 9 tests
```

### `SingleStageWorkflow` — the default

Equivalent to the inline pattern used throughout the codebase:

```python
obj = ObjectiveFunction(system.forcefield, engine, system.molecules, system.reference)
result = optimizer.optimize(obj)
final_ff = system.forcefield.with_params(result.final_params)
```

…rolled into a single `Workflow.run(system, engine, optimizer, n_evals=N)` call that returns a `WorkflowResult` with one `StageResult`. The per-category R²/RMSD/MAE metrics extraction (`_per_category_metrics`) mirrors the logic in `scripts/regenerate_convergence_results.py` exactly so a future refactor of that script can drop in `SingleStageWorkflow` and produce bit-identical JSON output.

### `Workflow` Protocol

```python
class Workflow(Protocol):
    name: str

    def run(
        self,
        system: SystemData,
        engine: Any,
        optimizer: _Optimizer,
        *,
        n_evals: int = 1,
    ) -> WorkflowResult: ...
```

`runtime_checkable` so callers can validate at runtime. Both `SingleStageWorkflow` and the planned `MethodE2Workflow` will satisfy this. The `_Optimizer` Protocol is the same minimal contract used by the existing `MultiStartOptimizer`.

## Behavior notes

- **The workflow snapshots the initial parameter vector** before invoking the optimizer. `ScipyOptimizer` mutates the FF inside the `ObjectiveFunction` during search; without the snapshot, `WorkflowResult.initial_ff` would point at the *final* state. The snapshot guarantees a stable before/after diff for consumers.
- **The workflow does NOT defensively copy `system.forcefield`.** After the call, `system.forcefield` may have mutated parameter values (current `ScipyOptimizer` behavior). Consumers should treat the workflow's returned `final_ff` and `initial_ff` as authoritative.

## Not in this PR

- Refactoring `scripts/regenerate_convergence_results.py` to use `SingleStageWorkflow` (deferred to a follow-up alongside `MethodE2Workflow`; landing the abstraction first reduces churn).
- `MethodE2Workflow` itself (Phase 9.D — implements the published two-stage Limé & Norrby protocol).

## Tests

9 tests in `test/test_workflows.py`:
- **Protocol conformance**: `SingleStageWorkflow + ScipyOptimizer` both satisfy their respective `runtime_checkable` Protocols.
- **`StageResult` / `WorkflowResult` dataclass defaults** are per-instance (no shared mutable state).
- **Parity**: `SingleStageWorkflow.run()` produces the same `final_params`, `final_score`, `n_iterations`, and `n_evaluations` as a direct `ObjectiveFunction + ScipyOptimizer.optimize()` pipeline on CH3F.
- **`initial_ff` snapshot** survives `ScipyOptimizer`'s in-place FF mutation.
- **`n_evals` sampling**: 0 produces empty lists, >0 produces N entries.
- **Per-category metrics** populated for systems with eigenmatrix refs.

**Test results:**
- 701 core tests pass with full supporting-info (zero regressions)
- 694 pass with simulated absent supporting-info (matches CI environment)

## Related work

- Predecessor: [#292 — plumb `replace_with` kwarg](https://github.com/ericchansen/q2mm/pull/292) (merged)
- Successor: forthcoming `MethodE2Workflow` PR (Phase 9.D)
- Methodology: Limé & Norrby, *J. Comput. Chem.* **2015**, *36*, 244–250 ([10.1002/jcc.23797](https://doi.org/10.1002/jcc.23797)); Farrugia 2025
