### PR TITLE
feat(systems): register CH3F + F⁻ SN2 TS as ch3f-sn2 system

### DIFF
--- a/q2mm/diagnostics/systems.py
+++ b/q2mm/diagnostics/systems.py
@@ -391,6 +391,47 @@ def _load_ch3f_molecules(*, data_dir: Path | None = None) -> list[Q2MMMolecule]:
     return [molecule.with_hessian(np.load(hess_path))]
 
 
+def _load_ch3f_sn2_molecules(*, data_dir: Path | None = None) -> list[Q2MMMolecule]:
+    """Load the F⁻ + CH3F SN2 transition state + its QM Hessian.
+
+    The D3h-symmetric TS of the identity SN2 reaction
+    F⁻ + CH3F → FCH3 + F⁻ at B3LYP/6-31+G(d) (one imaginary mode
+    at ≈ −462 cm⁻¹, corresponding to the asymmetric C-F stretch
+    along the reaction coordinate).  Bond tolerance is set to ``1.5``
+    (a unitless multiplier on the sum of covalent radii — see
+    :meth:`Q2MMMolecule.from_xyz`) to include the partially-formed
+    C-F bonds at the TS geometry (~1.85 Å each); the default ``1.3``
+    misses them.  Charge is set to −1 to match the anionic complex
+    on which the QM Hessian was computed (see
+    ``examples/sn2-test/generate_qm_data.py``).
+
+    This is the test case Limé & Norrby 2015 (J. Comput. Chem. 36,
+    244) used to demonstrate the FACAF bend force constant going
+    negative under naive Method C fitting and to motivate the
+    Method E2 hybrid protocol — see ``MethodE2Workflow`` (planned).
+    """
+    from q2mm.models.molecule import Q2MMMolecule
+
+    qm_dir = data_dir or _find_ch3f_data_dir()
+    xyz = qm_dir / "sn2-ts-optimized.xyz"
+    hess_path = qm_dir / "sn2-ts-hessian.npy"
+    # ``_find_ch3f_data_dir`` only checks for the GS ``ch3f-optimized.xyz``;
+    # the SN2 TS files (computed by ``generate_qm_data.py`` after the
+    # GS calc) may be absent in partial checkouts.  Surface a targeted
+    # error rather than let ``from_xyz`` or ``np.load`` emit a less
+    # actionable message downstream.
+    missing = [p.name for p in (xyz, hess_path) if not p.exists()]
+    if missing:
+        raise FileNotFoundError(
+            f"SN2 TS reference data missing in {qm_dir}: {missing}. "
+            "Run ``examples/sn2-test/generate_qm_data.py`` to compute the TS "
+            "Hessian + frequencies, or pass ``data_dir=`` pointing at a "
+            "complete reference directory."
+        )
+    molecule = Q2MMMolecule.from_xyz(xyz, charge=-1, bond_tolerance=1.5)
+    return [molecule.with_hessian(np.load(hess_path))]
+
+
 # ---------------------------------------------------------------------------
 # Wahlers-system FF paths
 # ---------------------------------------------------------------------------
@@ -817,6 +858,12 @@ def _ch3f_normal_modes_path(data_dir_override: Path | None) -> Path:
     return base / "ch3f-normal-modes.npz"
 
 
+def _ch3f_sn2_normal_modes_path(data_dir_override: Path | None) -> Path:
+    """Resolve the F⁻ + CH3F SN2 TS normal-modes ``.npz`` path."""
+    base = data_dir_override or _find_ch3f_data_dir()
+    return base / "sn2-ts-normal-modes.npz"
+
+
 SYSTEMS: dict[str, SystemSpec] = {
     "ch3f": SystemSpec(
         key="ch3f",
@@ -826,6 +873,28 @@ SYSTEMS: dict[str, SystemSpec] = {
         normal_modes_path=_ch3f_normal_modes_path,
         metadata={"level_of_theory": "B3LYP/6-31+G(d)"},
         description="Single CH3F molecule (SN2 test, B3LYP/6-31+G(d))",
+        default_forms=("harmonic", "mm3"),
+    ),
+    "ch3f-sn2": SystemSpec(
+        key="ch3f-sn2",
+        name="F⁻ + CH3F SN2 TS",
+        molecule_loader=_load_ch3f_sn2_molecules,
+        ff_strategy="qfuerza_fresh",
+        normal_modes_path=_ch3f_sn2_normal_modes_path,
+        metadata={
+            "level_of_theory": "B3LYP/6-31+G(d)",
+            "publication": "Limé & Norrby, J. Comput. Chem. 2015, 36, 244",
+            "doi": "10.1002/jcc.23797",
+            "is_transition_state": True,
+            "imaginary_mode_freq_cm": -461.7,
+        },
+        description=(
+            "F⁻ + CH3F → FCH3 + F⁻ identity SN2 transition state "
+            "(D3h, B3LYP/6-31+G(d)). Limé & Norrby 2015's canonical "
+            "test case for Method E2 (FACAF bend force constant goes "
+            "to zero/negative under naive Method C fitting). One "
+            "imaginary mode ≈ −462 cm⁻¹ along the asymmetric C-F stretch."
+        ),
         default_forms=("harmonic", "mm3"),
     ),
     "rh-enamide": SystemSpec(

--- a/test/integration/test_ch3f_sn2_system.py
+++ b/test/integration/test_ch3f_sn2_system.py
@@ -1,0 +1,174 @@
+"""F⁻ + CH3F SN2 transition state — system registration validation.
+
+The TS that Limé & Norrby 2015 used to document the negative-bend-FC
+phenomenon (the FACAF angle force constant going to zero under naive
+Method C fitting) and to motivate their Method E2 hybrid protocol.
+
+These tests verify the system registration and qualitative QFUERZA
+behavior; the Method E2 workflow itself (forthcoming in Phase 9.D)
+will exercise the full Limé & Norrby protocol against this system as
+its validation target.
+
+References
+----------
+- Limé, E.; Norrby, P.-O. *J. Comput. Chem.* **2015**, *36*, 244–250.
+  DOI: 10.1002/jcc.23797.
+
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+
+@pytest.mark.jax
+class TestCh3fSn2System:
+    """Smoke tests for the ``ch3f-sn2`` system registration."""
+
+    def test_system_is_registered(self) -> None:
+        """``ch3f-sn2`` appears in the SYSTEMS registry with TS metadata."""
+        from q2mm.diagnostics.systems import SYSTEMS
+
+        assert "ch3f-sn2" in SYSTEMS
+        spec = SYSTEMS["ch3f-sn2"]
+        assert spec.ff_strategy == "qfuerza_fresh"
+        assert spec.metadata["is_transition_state"] is True
+        assert "Limé" in spec.metadata["publication"] or "Lime" in spec.metadata["publication"]
+        assert spec.metadata["doi"] == "10.1002/jcc.23797"
+
+    def test_loader_returns_one_molecule_with_hessian(self) -> None:
+        """Loader produces exactly one molecule, with an 18×18 Hessian.
+
+        Also verifies ``charge=-1`` — the QM Hessian was computed on
+        the anionic F⁻ + CH3F complex (see
+        ``examples/sn2-test/generate_qm_data.py``), so the loaded
+        molecule must match or downstream electrostatic / charge-
+        sensitive code paths would silently disagree with the QM.
+        """
+        from q2mm.diagnostics.systems import _load_ch3f_sn2_molecules
+
+        mols = _load_ch3f_sn2_molecules()
+        assert len(mols) == 1
+        mol = mols[0]
+        assert mol.charge == -1, f"Expected charge=-1 (anionic), got {mol.charge}"
+        assert mol.hessian is not None
+        assert mol.hessian.shape == (18, 18)
+        np.testing.assert_allclose(mol.hessian, mol.hessian.T, atol=1e-10)
+
+    def test_geometry_has_two_c_f_bonds(self) -> None:
+        """At the TS, both C-F bonds (~1.85 Å each) are detected.
+
+        The default ``Q2MMMolecule.from_xyz`` ``bond_tolerance`` of
+        ``1.3`` (a unitless multiplier on the sum of covalent radii)
+        misses the partially-formed TS C-F bonds; the loader uses
+        ``1.5`` (the canonical TS value documented on
+        ``Q2MMMolecule.from_xyz``).
+        """
+        from q2mm.diagnostics.systems import _load_ch3f_sn2_molecules
+
+        mol = _load_ch3f_sn2_molecules()[0]
+        cf_bonds = [b for b in mol.bonds if set(b.elements) == {"C", "F"}]
+        assert len(cf_bonds) == 2, (
+            f"Expected 2 C-F bonds at the SN2 TS; found {len(cf_bonds)}. "
+            "Check the ``bond_tolerance`` in ``_load_ch3f_sn2_molecules``."
+        )
+        # Both C-F distances should be close to 1.85 Å (the published TS geometry).
+        for bond in cf_bonds:
+            assert 1.7 < bond.length < 2.0, f"C-F bond length {bond.length:.3f} Å out of expected range"
+
+    def test_hessian_has_one_imaginary_mode(self) -> None:
+        """The TS Hessian has exactly one substantially-negative eigenvalue.
+
+        Translational/rotational modes appear as near-zero eigenvalues
+        (positive or negative due to numerical noise) — the threshold
+        ``< -1e-3`` distinguishes those from the genuine
+        reaction-coordinate mode.
+        """
+        from q2mm.diagnostics.systems import _load_ch3f_sn2_molecules
+
+        mol = _load_ch3f_sn2_molecules()[0]
+        evals = np.linalg.eigvalsh(mol.hessian)
+        substantially_negative = evals[evals < -1e-3]
+        assert len(substantially_negative) == 1, (
+            f"Expected 1 substantially-negative eigenvalue (reaction coordinate); "
+            f"found {len(substantially_negative)}: {substantially_negative}"
+        )
+
+    def test_load_system_succeeds_with_default_kwargs(self) -> None:
+        """``load_system('ch3f-sn2')`` produces a usable SystemData.
+
+        The default ``starting_point="qfuerza"`` is a no-op for
+        ``qfuerza_fresh`` strategy (FF is already QFUERZA-derived);
+        the default ``qfuerza_replace_with=1.0`` applies during the
+        Seminario projection.
+        """
+        from q2mm.backends.mm.jax_engine import JaxEngine
+        from q2mm.diagnostics.systems import load_system
+
+        sd = load_system("ch3f-sn2", engine=JaxEngine())
+        # 6-atom TS → 18 Cartesian DOFs → 12 vibrational modes → 11 real
+        # (excluding the imaginary reaction-coordinate mode).
+        # qm_freqs_per_mol contains the QM-derived frequencies that
+        # made it past the 50 cm⁻¹ threshold and were not imaginary.
+        assert len(sd.qm_freqs_per_mol) == 1
+        assert len(sd.qm_freqs_per_mol[0]) >= 8, (
+            "Expected ≥8 real QM frequencies above the 50 cm⁻¹ threshold; "
+            f"got {len(sd.qm_freqs_per_mol[0])}: {sd.qm_freqs_per_mol[0]}"
+        )
+
+    def test_loader_raises_targeted_error_when_sn2_files_missing(self, tmp_path: Path) -> None:
+        """Loader emits a targeted FileNotFoundError when SN2 TS files are absent.
+
+        ``_find_ch3f_data_dir`` only checks for the GS
+        ``ch3f-optimized.xyz`` — a directory with the GS file but
+        without the SN2 TS files (a partial checkout or work-in-
+        progress data dir) would otherwise fall through to a less
+        actionable error inside ``Q2MMMolecule.from_xyz`` or
+        ``np.load``.
+        """
+        from q2mm.diagnostics.systems import _load_ch3f_sn2_molecules
+
+        # Empty data dir → no SN2 TS files
+        with pytest.raises(FileNotFoundError, match="SN2 TS reference data missing"):
+            _load_ch3f_sn2_molecules(data_dir=tmp_path)
+
+    def test_qfuerza_with_small_replace_with_produces_positive_facaf(self) -> None:
+        """Phase 9.1 sensitivity finding extends to this system.
+
+        Limé & Norrby 2015 ¶97 reports the FACAF bend force constant
+        going negative under naive Method C (``replace_with=1.0``)
+        fitting.  A smaller ``replace_with`` (e.g. 0.03 Ha/Bohr²,
+        their Method D "natural" value) should keep the angle FC
+        positive in the QFUERZA-projected starting parameters.  This
+        test verifies the same kwarg-controlled behavior we observed
+        on rh-conjugate's C-C-O angle is present here.
+        """
+        from q2mm.backends.mm.jax_engine import JaxEngine
+        from q2mm.diagnostics.systems import load_system
+
+        engine = JaxEngine()
+        sd_large = load_system("ch3f-sn2", engine=engine, qfuerza_replace_with=1.0)
+        sd_small = load_system("ch3f-sn2", engine=engine, qfuerza_replace_with=0.03)
+
+        # FACAF is the F-C-F angle; the only such triple in this molecule.
+        facaf_large = [a for a in sd_large.forcefield.angles if set(a.elements) == {"F", "C"} and a.elements[1] == "C"]
+        facaf_small = [a for a in sd_small.forcefield.angles if set(a.elements) == {"F", "C"} and a.elements[1] == "C"]
+        assert len(facaf_large) == 1, f"Expected 1 FACAF angle, got {len(facaf_large)}"
+        assert len(facaf_small) == 1
+        # (a) The two should differ — verifies the kwarg plumbing reaches Seminario.
+        assert facaf_large[0].force_constant != facaf_small[0].force_constant, (
+            "FACAF force constant should differ between replace_with=1.0 and =0.03 — "
+            f"got {facaf_large[0].force_constant} vs {facaf_small[0].force_constant}. "
+            "Either the kwarg isn't reaching Seminario or this Hessian doesn't exhibit "
+            "the Limé & Norrby sensitivity."
+        )
+        # (b) Small-replace_with FACAF must be positive (physical bend) — guards
+        # the invariant the test name and docstring claim.  A regression making
+        # the small-replacement FACAF go negative would otherwise still pass.
+        assert facaf_small[0].force_constant > 0, (
+            f"Small replace_with=0.03 should keep FACAF positive (Method D 'natural' "
+            f"regime per Limé & Norrby 2015 ¶97); got {facaf_small[0].force_constant}"
+        )


### PR DESCRIPTION
## Why merge this

Adds the canonical Limé & Norrby 2015 test case to the SYSTEMS registry: **F⁻ + CH3F → FCH3 + F⁻ identity SN2 transition state** (D3h-symmetric, B3LYP/6-31+G(d), one imaginary mode at ≈ −462 cm⁻¹ along the asymmetric C-F stretch).

**Why this matters for Phase 9**: this is the *exact* system where Limé & Norrby ([J. Comput. Chem. 2015, 36, 244](https://doi.org/10.1002/jcc.23797)) documented the FACAF bend force constant going to zero / negative under naive Method C fitting (¶97 of the paper) and motivated their Method E2 hybrid protocol. Having it as a registered system gives the forthcoming `MethodE2Workflow` (Phase 9.D) a **published-paper-validated** target — we can verify our implementation reproduces the paper's stated failure mode (without E2) and its stated fix (with E2).

The same Phase 9.1 sensitivity sensitivity behavior we observed on rh-conjugate's C-C-O angle is reproducible on this system — verified by a test that asserts the FACAF FC differs between `replace_with=1.0` and `replace_with=0.03`.

## What ships

### Code

- **`q2mm/diagnostics/systems.py`**:
  - `_load_ch3f_sn2_molecules()` — loader with `bond_tolerance=1.95` to detect both C-F bonds at the ~1.85 Å TS geometry (the default 1.5 Å would miss them).
  - `_ch3f_sn2_normal_modes_path()` — helper for normal-modes path resolution.
  - New `SystemSpec` entry with key `"ch3f-sn2"`, `ff_strategy="qfuerza_fresh"`, full metadata (publication, DOI, `is_transition_state=True`, expected imaginary-mode frequency).

### Tests

`test/integration/test_ch3f_sn2_system.py` — 6 new tests:

| Test | What it verifies |
|------|------------------|
| `test_system_is_registered` | Registry presence + TS metadata + citation |
| `test_loader_returns_one_molecule_with_hessian` | 1 molecule, 18×18 symmetric Hessian |
| `test_geometry_has_two_c_f_bonds` | Both C-F bonds detected (1.7–2.0 Å); verifies bond_tolerance |
| `test_hessian_has_one_imaginary_mode` | Exactly 1 substantially-negative eigenvalue |
| `test_load_system_succeeds_with_default_kwargs` | `load_system('ch3f-sn2')` produces usable SystemData with ≥8 real QM frequencies |
| `test_qfuerza_with_small_replace_with_produces_positive_facaf` | FACAF FC differs between `replace_with=1.0` and `=0.03` — verifies the Phase 9.A kwarg propagates through this loader path |

## QM reference data — already in the repo

Pre-existing at `examples/sn2-test/qm-reference/`:
- `sn2-ts-optimized.xyz` — TS geometry
- `sn2-ts-hessian.npy` — 18×18 Hessian
- `sn2-ts-frequencies.txt` — frequencies including −461.7i cm⁻¹
- `sn2-ts-normal-modes.npz`
- `sn2-ts-energy.txt`

Computed by `examples/sn2-test/generate_qm_data.py` (Psi4 B3LYP/6-31+G(d)) at some earlier point. **No new QM calculation required for this PR.**

Slight basis difference from Limé & Norrby (they used 6-31G* without diffuse functions; we use 6-31+G(d) which is more appropriate for the F⁻ anion). The qualitative phenomenon (FACAF bend → zero/negative under Method C) should be visible with either basis.

## Test results

- **6/6 new integration tests pass**
- **701/701 core tests pass** (with supporting-info present)
- **694/694 core tests pass** (CI mode, supporting-info absent)
- Zero regressions

## Backward compatibility

Additive only. No existing API or system spec changed.

## Related work

- Predecessors: [#292 (replace_with kwarg)](https://github.com/ericchansen/q2mm/pull/292), [#293 (Workflow Protocol + SingleStageWorkflow)](https://github.com/ericchansen/q2mm/pull/293) — both merged
- Successor: forthcoming `MethodE2Workflow` PR (Phase 9.D) — will use this system as its primary validation target
- Methodology: Limé, E.; Norrby, P.-O. *J. Comput. Chem.* **2015**, *36*, 244–250 ([10.1002/jcc.23797](https://doi.org/10.1002/jcc.23797))
