### PR TITLE
fix(scripts): repair unreachable Phase 2 in bench_composed

### DIFF
--- a/scripts/bench_composed.py
+++ b/scripts/bench_composed.py
@@ -107,7 +107,7 @@ def run_workflow_b(
     sys_data_p2 = SystemData(
         molecules=sys_data.molecules,
         forcefield=p1_result.optimized_ff.copy(),
-        freq_ref=sys_data.freq_ref,
+        reference=sys_data.reference,
         qm_freqs_per_mol=sys_data.qm_freqs_per_mol,
         metadata=sys_data.metadata,
         normal_modes=sys_data.normal_modes,


### PR DESCRIPTION
## Summary
`scripts/bench_composed.py` built its Phase 2 `SystemData` with a nonexistent
`freq_ref` field. `SystemData` is a frozen dataclass whose reference field is
named `reference`, and it has no `freq_ref` attribute either — so `run_workflow_b`
raised `AttributeError` (or `TypeError` on the unexpected kwarg) the instant Phase 1
finished. `main()` calls `run_workflow_b` without a guard, so the whole "multi-start
→ optax Adam refinement" composed workflow was dead code: it could never reach
Phase 2, never write the phase-2/composed JSON, and never print the composed summary.

The fix is one line: `freq_ref=sys_data.freq_ref` → `reference=sys_data.reference`.

## Context
Found during a latent-bug sweep of the repo (no diff was under review). This PR
contains only the confirmed, safe one-line fix. The sweep surfaced several other
issues that are **not** in this PR and want their own follow-up — most notably a
P1: the OpenMM analytical-gradient path (`_create_diff_handle`) silently drops
Urey–Bradley energy and gradients, so UB force constants never move during
optimization. A full audit report is available separately.

## Test
`ruff format` + `ruff check` pass (pre-commit). The change only corrects the
keyword/field name to the actual dataclass field; no behavior change beyond making
Phase 2 reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)