### PR TITLE
refactor(backends): extract OpenMM term records and unit converters (Phase 2)

### DIFF
--- a/docs/how-it-works/architecture.md
+++ b/docs/how-it-works/architecture.md
@@ -210,6 +210,8 @@ q2mm/
 │   ├── registry.py       # Decorator + lazy-discovery backend registry
 │   ├── mm/
 │   │   ├── openmm.py        # OpenMM engine (harmonic + MM3 dual-mode)
+│   │   ├── _openmm_terms.py # OpenMM internal term records
+│   │   ├── _openmm_units.py # OpenMM scalar unit converters
 │   │   ├── tinker.py        # Tinker engine (subprocess-based)
 │   │   ├── jax_engine.py    # JAX engine (differentiable, analytical gradients)
 │   │   ├── jax_md_engine.py # JAX-MD engine (periodic, neighbor lists)

--- a/q2mm/backends/mm/_openmm_terms.py
+++ b/q2mm/backends/mm/_openmm_terms.py
@@ -1,0 +1,165 @@
+"""Internal OpenMM term records.
+
+Private dataclasses mapping molecule bonds, angles, torsions, van der Waals
+particles, Urey-Bradley pairs, and CMAP corrections to their OpenMM force
+indices.  These are implementation details of
+:mod:`q2mm.backends.mm.openmm` and are not part of the public API.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class _BondTerm:
+    """Internal record mapping a molecule bond to its OpenMM force index.
+
+    Attributes:
+        force_index: Index of this bond in the OpenMM bond force object.
+        atom_i: First atom index.
+        atom_j: Second atom index.
+        elements: Element symbols for the two atoms.
+        env_id: Chemical environment identifier for parameter matching.
+        ff_row: Row index in the source force field file, if applicable.
+
+    """
+
+    force_index: int
+    atom_i: int
+    atom_j: int
+    elements: tuple[str, str]
+    env_id: str = ""
+    ff_row: int | None = None
+
+
+@dataclass
+class _AngleTerm:
+    """Internal record mapping a molecule angle to its OpenMM force index.
+
+    Attributes:
+        force_index: Index of this angle in the OpenMM angle force object.
+        atom_i: First atom index.
+        atom_j: Central atom index.
+        atom_k: Third atom index.
+        elements: Element symbols for the three atoms.
+        env_id: Chemical environment identifier for parameter matching.
+        ff_row: Row index in the source force field file, if applicable.
+
+    """
+
+    force_index: int
+    atom_i: int
+    atom_j: int
+    atom_k: int
+    elements: tuple[str, str, str]
+    env_id: str = ""
+    ff_row: int | None = None
+
+
+@dataclass
+class _VdwTerm:
+    """Internal record mapping a molecule atom to its OpenMM vdW particle.
+
+    Attributes:
+        particle_index: Index of this particle in the OpenMM vdW force.
+        atom_type: Atom type label for parameter matching.
+        element: Element symbol.
+        ff_row: Row index in the source force field file, if applicable.
+
+    """
+
+    particle_index: int
+    atom_type: str = ""
+    element: str = ""
+    ff_row: int | None = None
+
+
+@dataclass
+class _Exception14:
+    """A 1-4 nonbonded exception whose parameters must track particle updates.
+
+    Attributes:
+        exception_index: Index of this exception in the OpenMM NonbondedForce.
+        particle_i: First particle index.
+        particle_j: Second particle index.
+
+    """
+
+    exception_index: int
+    particle_i: int
+    particle_j: int
+
+
+@dataclass
+class _TorsionTerm:
+    """Internal record mapping a molecule torsion to its OpenMM force index.
+
+    Attributes:
+        force_index: Index of this torsion in the OpenMM torsion force object.
+        atom_i: First atom index.
+        atom_j: Second atom index.
+        atom_k: Third atom index.
+        atom_l: Fourth atom index.
+        elements: Element symbols for the four atoms.
+        periodicity: Fourier component periodicity (1, 2, or 3).
+        env_id: Chemical environment identifier for parameter matching.
+        ff_row: Row index in the source force field file, if applicable.
+        is_improper: Whether this term is an improper torsion.
+
+    """
+
+    force_index: int
+    atom_i: int
+    atom_j: int
+    atom_k: int
+    atom_l: int
+    elements: tuple[str, str, str, str]
+    periodicity: int = 1
+    env_id: str = ""
+    ff_row: int | None = None
+    is_improper: bool = False
+
+
+@dataclass
+class _UBTerm:
+    """Internal record mapping a Urey-Bradley 1-3 pair to its OpenMM force index.
+
+    Attributes:
+        force_index: Index of this UB bond in the OpenMM bond force object.
+        atom_i: First atom of the angle (outer).
+        atom_k: Third atom of the angle (outer).
+        elements: Element symbols for the three angle atoms (for matching).
+        env_id: Chemical environment identifier for parameter matching.
+        ff_row: Row index in the source force field file, if applicable.
+
+    """
+
+    force_index: int
+    atom_i: int
+    atom_k: int
+    elements: tuple[str, str, str]
+    env_id: str = ""
+    ff_row: int | None = None
+
+
+@dataclass
+class _CmapTerm:
+    """Internal record mapping a CMAP correction to its OpenMM force index.
+
+    Attributes:
+        torsion_index: Index of this CMAP torsion in the CMAPTorsionForce.
+        map_index: Index of the CMAP grid in the CMAPTorsionForce.
+        phi_atoms: Atom indices for the φ dihedral (4 atoms).
+        psi_atoms: Atom indices for the ψ dihedral (4 atoms).
+        phi_types: Atom types for the φ dihedral.
+        psi_types: Atom types for the ψ dihedral.
+
+    """
+
+    torsion_index: int
+    map_index: int
+    phi_atoms: tuple[int, int, int, int]
+    psi_atoms: tuple[int, int, int, int]
+    phi_types: tuple[str, str, str, str]
+    psi_types: tuple[str, str, str, str]

--- a/q2mm/backends/mm/_openmm_units.py
+++ b/q2mm/backends/mm/_openmm_units.py
@@ -1,0 +1,116 @@
+"""Scalar unit converters for the OpenMM backend.
+
+Thin wrappers over :mod:`q2mm.models.units` that translate canonical Q2MM
+parameter values into the units OpenMM expects.  These are implementation
+details of :mod:`q2mm.backends.mm.openmm` and are not part of the public API.
+"""
+
+from __future__ import annotations
+
+from q2mm.models.units import (
+    ang_to_nm,
+    canonical_to_openmm_angle_k,
+    canonical_to_openmm_bond_k,
+    canonical_to_openmm_epsilon,
+    canonical_to_openmm_harmonic_angle_k,
+    canonical_to_openmm_harmonic_bond_k,
+    rmin_half_to_sigma_nm,
+)
+
+
+def _bond_k_to_openmm(force_constant: float) -> float:
+    """Convert canonical bond force constant (kcal/mol/Å²) to kJ/mol/Å².
+
+    Args:
+        force_constant: Bond force constant in kcal/mol/Å².
+
+    Returns:
+        float: Bond force constant in kJ/mol/Å².
+
+    """
+    return canonical_to_openmm_bond_k(force_constant)
+
+
+def _angle_k_to_openmm(force_constant: float) -> float:
+    """Convert canonical angle force constant (kcal/mol/rad²) to kJ/mol/rad².
+
+    Args:
+        force_constant: Angle force constant in kcal/mol/rad².
+
+    Returns:
+        float: Angle force constant in kJ/mol/rad².
+
+    """
+    return canonical_to_openmm_angle_k(force_constant)
+
+
+def _bond_k_to_harmonic(force_constant: float) -> float:
+    """Canonical bond k (kcal/mol/Å²) → HarmonicBondForce k (kJ/mol/nm²).
+
+    OpenMM's HarmonicBondForce uses E = ½·k·(r−r₀)² while the canonical
+    convention is E = k·(r−r₀)², so k_openmm = 2·k.  Additionally convert
+    kcal→kJ (×4.184) and Å⁻²→nm⁻² (×100).
+
+    Args:
+        force_constant: Bond force constant in kcal/mol/Å².
+
+    Returns:
+        float: Bond force constant in kJ/mol/nm² with the ½ convention.
+
+    """
+    return canonical_to_openmm_harmonic_bond_k(force_constant)
+
+
+def _angle_k_to_harmonic(force_constant: float) -> float:
+    """Canonical angle k (kcal/mol/rad²) → HarmonicAngleForce k (kJ/mol/rad²).
+
+    OpenMM's HarmonicAngleForce uses E = ½·k·(θ−θ₀)² while the canonical
+    convention is E = k·(θ−θ₀)², so k_openmm = 2·k.  Convert kcal→kJ.
+
+    Args:
+        force_constant: Angle force constant in kcal/mol/rad².
+
+    Returns:
+        float: Angle force constant in kJ/mol/rad² with the ½ convention.
+
+    """
+    return canonical_to_openmm_harmonic_angle_k(force_constant)
+
+
+def _vdw_sigma_nm(radius: float) -> float:
+    """Convert Rmin/2 (Å) to LJ sigma (nm) for standard 12-6 NonbondedForce.
+
+    Args:
+        radius: Van der Waals radius (Rmin/2) in Å.
+
+    Returns:
+        float: LJ sigma in nm.
+
+    """
+    return rmin_half_to_sigma_nm(radius)
+
+
+def _vdw_radius_to_openmm(radius: float) -> float:
+    """Convert vdW radius from Å to nm for CustomNonbondedForce.
+
+    Args:
+        radius: Van der Waals radius in Å.
+
+    Returns:
+        float: Van der Waals radius in nm.
+
+    """
+    return ang_to_nm(radius)
+
+
+def _vdw_epsilon_to_openmm(epsilon: float) -> float:
+    """Convert vdW epsilon from kcal/mol to kJ/mol.
+
+    Args:
+        epsilon: Well depth in kcal/mol.
+
+    Returns:
+        float: Well depth in kJ/mol.
+
+    """
+    return canonical_to_openmm_epsilon(epsilon)

--- a/q2mm/backends/mm/openmm.py
+++ b/q2mm/backends/mm/openmm.py
@@ -19,6 +19,24 @@ logger = logging.getLogger(__name__)
 
 from q2mm.backends.base import MMEngine
 from q2mm.backends.registry import register_mm
+from q2mm.backends.mm._openmm_terms import (
+    _AngleTerm,
+    _BondTerm,
+    _CmapTerm,
+    _Exception14,
+    _TorsionTerm,
+    _UBTerm,
+    _VdwTerm,
+)
+from q2mm.backends.mm._openmm_units import (
+    _angle_k_to_harmonic,
+    _angle_k_to_openmm,
+    _bond_k_to_harmonic,
+    _bond_k_to_openmm,
+    _vdw_epsilon_to_openmm,
+    _vdw_radius_to_openmm,
+    _vdw_sigma_nm,
+)
 from q2mm.constants import (
     MM3_BOND_C3,
     MM3_BOND_C4,
@@ -35,16 +53,10 @@ from q2mm.models.units import (
     KCAL_TO_KJ,
     RAD_TO_DEG,
     ang_to_nm,
-    canonical_to_openmm_angle_k,
-    canonical_to_openmm_bond_k,
     canonical_to_openmm_bond_k_nm,
-    canonical_to_openmm_epsilon,
-    canonical_to_openmm_harmonic_angle_k,
-    canonical_to_openmm_harmonic_bond_k,
     canonical_to_openmm_torsion_k,
     hessian_kjmolnm2_to_au,
     kj_to_kcal,
-    rmin_half_to_sigma_nm,
 )
 from q2mm.models.forcefield import AngleParam, BondParam, ForceField, FunctionalForm, TorsionParam, VdwParam
 from q2mm.models.molecule import Q2MMMolecule
@@ -58,160 +70,6 @@ except ImportError:  # pragma: no cover - exercised when OpenMM is not installed
     mm = None
     unit = None
     _HAS_OPENMM = False
-
-
-@dataclass
-class _BondTerm:
-    """Internal record mapping a molecule bond to its OpenMM force index.
-
-    Attributes:
-        force_index: Index of this bond in the OpenMM bond force object.
-        atom_i: First atom index.
-        atom_j: Second atom index.
-        elements: Element symbols for the two atoms.
-        env_id: Chemical environment identifier for parameter matching.
-        ff_row: Row index in the source force field file, if applicable.
-
-    """
-
-    force_index: int
-    atom_i: int
-    atom_j: int
-    elements: tuple[str, str]
-    env_id: str = ""
-    ff_row: int | None = None
-
-
-@dataclass
-class _AngleTerm:
-    """Internal record mapping a molecule angle to its OpenMM force index.
-
-    Attributes:
-        force_index: Index of this angle in the OpenMM angle force object.
-        atom_i: First atom index.
-        atom_j: Central atom index.
-        atom_k: Third atom index.
-        elements: Element symbols for the three atoms.
-        env_id: Chemical environment identifier for parameter matching.
-        ff_row: Row index in the source force field file, if applicable.
-
-    """
-
-    force_index: int
-    atom_i: int
-    atom_j: int
-    atom_k: int
-    elements: tuple[str, str, str]
-    env_id: str = ""
-    ff_row: int | None = None
-
-
-@dataclass
-class _VdwTerm:
-    """Internal record mapping a molecule atom to its OpenMM vdW particle.
-
-    Attributes:
-        particle_index: Index of this particle in the OpenMM vdW force.
-        atom_type: Atom type label for parameter matching.
-        element: Element symbol.
-        ff_row: Row index in the source force field file, if applicable.
-
-    """
-
-    particle_index: int
-    atom_type: str = ""
-    element: str = ""
-    ff_row: int | None = None
-
-
-@dataclass
-class _Exception14:
-    """A 1-4 nonbonded exception whose parameters must track particle updates.
-
-    Attributes:
-        exception_index: Index of this exception in the OpenMM NonbondedForce.
-        particle_i: First particle index.
-        particle_j: Second particle index.
-
-    """
-
-    exception_index: int
-    particle_i: int
-    particle_j: int
-
-
-@dataclass
-class _TorsionTerm:
-    """Internal record mapping a molecule torsion to its OpenMM force index.
-
-    Attributes:
-        force_index: Index of this torsion in the OpenMM torsion force object.
-        atom_i: First atom index.
-        atom_j: Second atom index.
-        atom_k: Third atom index.
-        atom_l: Fourth atom index.
-        elements: Element symbols for the four atoms.
-        periodicity: Fourier component periodicity (1, 2, or 3).
-        env_id: Chemical environment identifier for parameter matching.
-        ff_row: Row index in the source force field file, if applicable.
-        is_improper: Whether this term is an improper torsion.
-
-    """
-
-    force_index: int
-    atom_i: int
-    atom_j: int
-    atom_k: int
-    atom_l: int
-    elements: tuple[str, str, str, str]
-    periodicity: int = 1
-    env_id: str = ""
-    ff_row: int | None = None
-    is_improper: bool = False
-
-
-@dataclass
-class _UBTerm:
-    """Internal record mapping a Urey-Bradley 1-3 pair to its OpenMM force index.
-
-    Attributes:
-        force_index: Index of this UB bond in the OpenMM bond force object.
-        atom_i: First atom of the angle (outer).
-        atom_k: Third atom of the angle (outer).
-        elements: Element symbols for the three angle atoms (for matching).
-        env_id: Chemical environment identifier for parameter matching.
-        ff_row: Row index in the source force field file, if applicable.
-
-    """
-
-    force_index: int
-    atom_i: int
-    atom_k: int
-    elements: tuple[str, str, str]
-    env_id: str = ""
-    ff_row: int | None = None
-
-
-@dataclass
-class _CmapTerm:
-    """Internal record mapping a CMAP correction to its OpenMM force index.
-
-    Attributes:
-        torsion_index: Index of this CMAP torsion in the CMAPTorsionForce.
-        map_index: Index of the CMAP grid in the CMAPTorsionForce.
-        phi_atoms: Atom indices for the φ dihedral (4 atoms).
-        psi_atoms: Atom indices for the ψ dihedral (4 atoms).
-        phi_types: Atom types for the φ dihedral.
-        psi_types: Atom types for the ψ dihedral.
-
-    """
-
-    torsion_index: int
-    map_index: int
-    phi_atoms: tuple[int, int, int, int]
-    psi_atoms: tuple[int, int, int, int]
-    phi_types: tuple[str, str, str, str]
-    psi_types: tuple[str, str, str, str]
 
 
 @dataclass
@@ -392,104 +250,6 @@ def _coerce_forcefield(forcefield: ForceField | None, molecule: Q2MMMolecule) ->
     if forcefield is not None:
         return forcefield
     return ForceField.create_for_molecule(molecule)
-
-
-def _bond_k_to_openmm(force_constant: float) -> float:
-    """Convert canonical bond force constant (kcal/mol/Å²) to kJ/mol/Å².
-
-    Args:
-        force_constant: Bond force constant in kcal/mol/Å².
-
-    Returns:
-        float: Bond force constant in kJ/mol/Å².
-
-    """
-    return canonical_to_openmm_bond_k(force_constant)
-
-
-def _angle_k_to_openmm(force_constant: float) -> float:
-    """Convert canonical angle force constant (kcal/mol/rad²) to kJ/mol/rad².
-
-    Args:
-        force_constant: Angle force constant in kcal/mol/rad².
-
-    Returns:
-        float: Angle force constant in kJ/mol/rad².
-
-    """
-    return canonical_to_openmm_angle_k(force_constant)
-
-
-def _bond_k_to_harmonic(force_constant: float) -> float:
-    """Canonical bond k (kcal/mol/Å²) → HarmonicBondForce k (kJ/mol/nm²).
-
-    OpenMM's HarmonicBondForce uses E = ½·k·(r−r₀)² while the canonical
-    convention is E = k·(r−r₀)², so k_openmm = 2·k.  Additionally convert
-    kcal→kJ (×4.184) and Å⁻²→nm⁻² (×100).
-
-    Args:
-        force_constant: Bond force constant in kcal/mol/Å².
-
-    Returns:
-        float: Bond force constant in kJ/mol/nm² with the ½ convention.
-
-    """
-    return canonical_to_openmm_harmonic_bond_k(force_constant)
-
-
-def _angle_k_to_harmonic(force_constant: float) -> float:
-    """Canonical angle k (kcal/mol/rad²) → HarmonicAngleForce k (kJ/mol/rad²).
-
-    OpenMM's HarmonicAngleForce uses E = ½·k·(θ−θ₀)² while the canonical
-    convention is E = k·(θ−θ₀)², so k_openmm = 2·k.  Convert kcal→kJ.
-
-    Args:
-        force_constant: Angle force constant in kcal/mol/rad².
-
-    Returns:
-        float: Angle force constant in kJ/mol/rad² with the ½ convention.
-
-    """
-    return canonical_to_openmm_harmonic_angle_k(force_constant)
-
-
-def _vdw_sigma_nm(radius: float) -> float:
-    """Convert Rmin/2 (Å) to LJ sigma (nm) for standard 12-6 NonbondedForce.
-
-    Args:
-        radius: Van der Waals radius (Rmin/2) in Å.
-
-    Returns:
-        float: LJ sigma in nm.
-
-    """
-    return rmin_half_to_sigma_nm(radius)
-
-
-def _vdw_radius_to_openmm(radius: float) -> float:
-    """Convert vdW radius from Å to nm for CustomNonbondedForce.
-
-    Args:
-        radius: Van der Waals radius in Å.
-
-    Returns:
-        float: Van der Waals radius in nm.
-
-    """
-    return ang_to_nm(radius)
-
-
-def _vdw_epsilon_to_openmm(epsilon: float) -> float:
-    """Convert vdW epsilon from kcal/mol to kJ/mol.
-
-    Args:
-        epsilon: Well depth in kcal/mol.
-
-    Returns:
-        float: Well depth in kJ/mol.
-
-    """
-    return canonical_to_openmm_epsilon(epsilon)
 
 
 def _collect_bond_assignments(


### PR DESCRIPTION
## Phase 2 — extract OpenMM term records and unit converters

Second phase of the staged repository refactor (research finding **4.4**).
This is a **pure, mechanical code-move with zero behavior change** — code was
relocated verbatim, imports fixed, and all tests kept green.

> **Rebased onto `master`.** Phase 1 (#302) has merged, so this branch is now
> rebased directly on `master` and contains **only** the Phase 2 code-move
> (4 files). The earlier stacked-PR base note no longer applies.

### What moved

`q2mm/backends/mm/openmm.py` was 1,982 lines. Two self-contained private
blocks were relocated into new private sibling modules:

| New module | Contents (moved verbatim) |
|---|---|
| `q2mm/backends/mm/_openmm_terms.py` | 7 term dataclasses: `_BondTerm`, `_AngleTerm`, `_VdwTerm`, `_Exception14`, `_TorsionTerm`, `_UBTerm`, `_CmapTerm` |
| `q2mm/backends/mm/_openmm_units.py` | 7 scalar unit-converter wrappers: `_bond_k_to_openmm`, `_angle_k_to_openmm`, `_bond_k_to_harmonic`, `_angle_k_to_harmonic`, `_vdw_sigma_nm`, `_vdw_radius_to_openmm`, `_vdw_epsilon_to_openmm` |

`OpenMMHandle` and `_DiffHandle` are **not** term records and stay in
`openmm.py`.

### Changes in `openmm.py`

- Re-imports both moved sets — they are still used internally (`_collect_*`,
  `_build_cmap_force`, `OpenMMHandle`, `create_context`), so external imports
  like `from q2mm.backends.mm.openmm import _BondTerm` remain valid.
- Drops the six now-unused `q2mm.models.units` imports
  (`canonical_to_openmm_bond_k`, `canonical_to_openmm_angle_k`,
  `canonical_to_openmm_harmonic_bond_k`, `canonical_to_openmm_harmonic_angle_k`,
  `rmin_half_to_sigma_nm`, `canonical_to_openmm_epsilon`); keeps `ang_to_nm`
  (still used in the body). `ruff check` (F401) confirms the exact set.
- **1,982 → 1,742 lines.**

### Docs

`docs/how-it-works/architecture.md` module tree gains `_openmm_terms.py` and
`_openmm_units.py`, matching the `_jax_common.py` sibling formatting. The
architecture guard test `test/test_architecture_doc.py` (landed with Phase 1,
now on `master`) validates this — its occurrence-counting check confirms both
`openmm.py` locations (`io/` and `backends/mm/`) stay documented.

### Verification (per-commit gate)

- `python -m ruff check q2mm/ test/ scripts/` → **All checks passed.**
- `python -m ruff format --check q2mm test scripts examples` → **all formatted.**
- `python -m pytest test/ -q -m "not (openmm or tinker or jax or jax_md or psi4)"`
  → **706 passed, 173 skipped, 18 failed.** The 18 failures are all the
  pre-existing `ModuleNotFoundError: No module named 'scipy'` in
  `test_basinhopping.py`, `test_multistart.py`, `test_optimizer_jac.py`
  (known local environment gap, not a regression; CI installs scipy).
  `test_architecture_doc.py` passes.
- `python -c "import q2mm.backends.mm.openmm"` → OK (openmm not installed; its
  tests auto-skip).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>