### PR TITLE
test: gate scipy-dependent optimizer tests behind importorskip

### DIFF
--- a/test/test_basinhopping.py
+++ b/test/test_basinhopping.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import numpy as np
+import pytest
+
+pytest.importorskip("scipy")
 
 from q2mm.optimizers.basinhopping import BasinHoppingOptimizer, _BoundedStep
 

--- a/test/test_multistart.py
+++ b/test/test_multistart.py
@@ -7,6 +7,8 @@ from unittest.mock import MagicMock
 import numpy as np
 import pytest
 
+pytest.importorskip("scipy")
+
 from q2mm.optimizers.multistart import MultiStartOptimizer
 from q2mm.optimizers.scipy_opt import OptimizationResult
 

--- a/test/test_optimizer_jac.py
+++ b/test/test_optimizer_jac.py
@@ -12,6 +12,8 @@ from unittest.mock import MagicMock
 import numpy as np
 import pytest
 
+pytest.importorskip("scipy")
+
 from q2mm.optimizers.scipy_opt import ScipyOptimizer
 from q2mm.diagnostics.benchmark import _resolve_gradients
 from q2mm.optimizers.objective import ObjectiveFunction, ReferenceData


### PR DESCRIPTION
## Problem

The documented **core test tier** is supposed to run with *no* optional dependencies (`pyproject.toml` declares only `numpy` + `pyyaml`; `scipy` lives in the `optimize`/`jax`/`dev` extras):

```
python -m pytest test/ -x -q -m "not (openmm or tinker or jax or jax_md or psi4)"
```

But with `scipy` absent, three unmarked core-tier modules fail:

- `test/test_basinhopping.py`
- `test/test_multistart.py`
- `test/test_optimizer_jac.py`

They are pure `MagicMock` unit tests, but they exercise optimizer code paths (`BasinHoppingOptimizer`, `MultiStartOptimizer`, `ScipyOptimizer`) that import `scipy`. With `scipy` uninstalled these three modules produce the **18 known core-tier failures**. CI passes only because it installs the `[dev]` extra, which pins `scipy`.

> Accuracy note: in this codebase the optimizer modules import scipy **lazily** (inside methods, e.g. `basinhopping.py:101`, `scipy_opt.py:391/633`), so the failures land at **run time** when a test calls `.run()`, not at collection time. `importorskip` gates the module correctly either way.

## Fix

Add `pytest.importorskip("scipy")` at the top of each of the three modules, **before** the `from q2mm...` imports:

```python
import numpy as np
import pytest

pytest.importorskip("scipy")

from q2mm.optimizers... import ...
```

This skips the whole module cleanly when `scipy` is absent and is a **no-op** when `scipy` is present. It mirrors the `importorskip("openmm")` guard already used across the integration suite. `E402` (module-import-not-at-top) is globally ignored in `pyproject.toml`, so the pre-import statement does not trip ruff.

Test-only change — **no source files under `q2mm/` were modified.**

## Why `importorskip` and not a `@pytest.mark.scipy` marker

The conftest auto-skip machinery keys off the **backend registry** (`openmm`/`tinker`/`jax`/`jax_md`/`psi4`) and has no `scipy` entry. A bare `@pytest.mark.scipy` marker would therefore skip *nothing* — the tests would still fail. Wiring `scipy` into that machinery (or restructuring the source's lazy imports) is broader scope than this fix warrants. `importorskip` is the minimal, idiomatic, self-contained tool for gating a module on an optional dependency.

## Verification (both dependency directions)

**Lint / format (scipy absent):**
- `python -m ruff check q2mm/ test/ scripts/` → `All checks passed!`
- `python -m ruff format --check q2mm test scripts examples` → `167 files already formatted`

**Core tier, scipy ABSENT** — `pytest test/ -q -m "not (openmm or tinker or jax or jax_md or psi4)"`:

| | passed | skipped | failed | deselected |
|---|---|---|---|---|
| **before** | 706 | 173 | **18** | 319 |
| **after** | 670 | 176 | **0** | 319 |

The three modules now report as module-level skips (`could not import 'scipy': No module named 'scipy'`). The 54 test items in those modules (36 previously-passing + 18 previously-failing) collapse into 3 module skips, which reconciles the counts exactly (`706→670` passed, `173→176` skipped, `18→0` failed).

**scipy PRESENT** — `pytest test/test_basinhopping.py test/test_multistart.py test/test_optimizer_jac.py -q` (with `scipy==1.17.1` installed): **54 passed**. Proves the guard is a no-op and hides no real failures. (scipy was uninstalled afterward to restore the minimal base env.)

Addresses refactor finding 4.12. Please do not merge — leaving the merge to the maintainer.