### PR TITLE
ci: enforce mypy in the Lint job with a grandfathered ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
       - run: python -m pip install -e ".[dev]"
       - run: python -m ruff check q2mm/ test/ scripts/
       - run: python -m ruff format --check q2mm test scripts examples
+      # mypy target (python_version=3.12) is set in [tool.mypy]; see the note
+      # there on why 3.12 rather than the 3.10 runtime floor.
+      - run: python -m mypy q2mm/
       - run: python scripts/check_env_dep_parity.py
 
   test-core:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,22 @@ python -m ruff check q2mm/ test/ scripts/
 python -m ruff format --check q2mm test scripts examples
 ```
 
+### Types (mypy)
+
+```bash
+python -m mypy q2mm/
+```
+
+mypy is enforced repo-wide in the CI Lint job via a grandfathered ratchet
+(see the `[[tool.mypy.overrides]]` block in `pyproject.toml`): the modules
+listed there with pre-existing type errors are exempt, so any **new** module —
+or any module removed from that grandfather list — must be mypy-clean.
+`[tool.mypy]` pins `python_version = "3.12"` (the CI Lint job's Python) as a
+single source of truth, so the command above matches CI with no extra flags.
+3.12 is required because numpy ≥2.5 ships PEP 695 `type` aliases in its stubs
+that mypy cannot parse under a 3.10 target; the ≥3.10 runtime floor is still
+enforced by ruff (`target-version=py310`) and the 3.10 test-core matrix.
+
 ### Core Tests (no backends required)
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ dev = [
     "pytest-benchmark",
     "pytest-cov",
     "ruff",
+    "mypy",
     "scipy",
     "parmed",
     "qcelemental",
@@ -180,10 +181,70 @@ ignore = [
 ]
 
 [tool.mypy]
-python_version = "3.10"
+# Target 3.12 (the CI Lint job's Python) as a single source of truth so plain
+# `python -m mypy q2mm/` matches CI locally. numpy>=2.5 ships PEP 695 `type`
+# aliases in its stubs that mypy rejects under python_version=3.10 (a fatal
+# stub parse error that halts all checking), so 3.10 is not a usable target
+# here. The >=3.10 runtime floor is still enforced by ruff (target-version=
+# py310) and the 3.10 test-core matrix.
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false  # too strict for existing codebase
 check_untyped_defs = true
 ignore_missing_imports = true
+
+# Grandfathered modules: mypy is enforced repo-wide via the CI Lint job, but
+# the modules listed below carry pre-existing type errors. They are still
+# followed for type info, but their own errors are not reported — so any NEW
+# module, or any module removed from this list, must be mypy-clean.
+# Un-grandfather modules one at a time as their errors are fixed.
+# See https://mypy.readthedocs.io/en/stable/existing_code.html
+[[tool.mypy.overrides]]
+ignore_errors = true
+module = [
+  "q2mm.backends.mm",
+  "q2mm.backends.mm._jax_common",
+  "q2mm.backends.mm.batched",
+  "q2mm.backends.mm.jax_engine",
+  "q2mm.backends.mm.jax_md_engine",
+  "q2mm.backends.mm.openmm",
+  "q2mm.backends.mm.tinker",
+  "q2mm.backends.qm.psi4",
+  "q2mm.backends.registry",
+  "q2mm.benchmark_runner",
+  "q2mm.diagnostics.benchmark",
+  "q2mm.diagnostics.cli",
+  "q2mm.diagnostics.systems",
+  "q2mm.diagnostics.tables",
+  "q2mm.io._helpers",
+  "q2mm.io.amber",
+  "q2mm.io.cmap",
+  "q2mm.io.gaussian",
+  "q2mm.io.jaguar",
+  "q2mm.io.macromodel",
+  "q2mm.io.mm3",
+  "q2mm.io.mol2",
+  "q2mm.io.openmm",
+  "q2mm.io.reference",
+  "q2mm.io.tinker",
+  "q2mm.models.forcefield",
+  "q2mm.models.hessian",
+  "q2mm.models.molecule",
+  "q2mm.models.seminario",
+  "q2mm.models.structure",
+  "q2mm.optimizers.cycling",
+  "q2mm.optimizers.evaluators.eigenmatrix",
+  "q2mm.optimizers.evaluators.energy",
+  "q2mm.optimizers.evaluators.frequency",
+  "q2mm.optimizers.jax_multistart",
+  "q2mm.optimizers.jaxloss",
+  "q2mm.optimizers.jaxopt_opt",
+  "q2mm.optimizers.objective",
+  "q2mm.optimizers.optax",
+  "q2mm.optimizers.reference",
+  "q2mm.optimizers.scipy_opt",
+  "q2mm.optimizers.spec",
+  "q2mm.workflows.method_e2",
+]
 


### PR DESCRIPTION
## Finding 4.11 — enforce mypy in CI via a fail-closed grandfather ratchet

mypy is configured in `pyproject.toml` (`[tool.mypy]`) but was **not enforced** in CI. The Lint job (`.github/workflows/ci.yml`) ran only `ruff check`, `ruff format --check`, and `check_env_dep_parity.py`.

A drop-in `mypy q2mm/` is not viable today: the package reports **936 errors across 43 modules** (baseline at the time of this PR). Fixing those is a separate, judgment-heavy effort and is **explicitly out of scope** here. Instead this PR installs a **fail-closed ratchet**: mypy runs repo-wide, the 43 currently-dirty modules are grandfathered so their existing errors are tolerated, and any **new** error in a currently-clean module (or any brand-new module) fails CI.

### Changes (three files only)
- **`pyproject.toml`** —
  - add `mypy` to the `[project.optional-dependencies] dev` extra (CI's Lint job installs `.[dev]`);
  - add one `[[tool.mypy.overrides]]` block with `ignore_errors = true` grandfathering the 43 dirty modules;
  - set `[tool.mypy].python_version = "3.12"` (was `"3.10"`) — see the numpy-stub note below. This is the **only** existing `[tool.mypy]` setting changed; the other five (`warn_return_any`, `warn_unused_configs`, `disallow_untyped_defs`, `check_untyped_defs`, `ignore_missing_imports`) are untouched.
- **`.github/workflows/ci.yml`** — add a `python -m mypy q2mm/` step to the `lint:` job (after `ruff format --check`, before `check_env_dep_parity.py`). All existing steps preserved.
- **`AGENTS.md`** — docs-only: add a `### Types (mypy)` subsection to §3 "Before Every Commit" documenting `python -m mypy q2mm/` and the `python_version = "3.12"` rationale.

### What this enforces
- mypy is now enforced on **all currently-clean modules** and **any new module** added to the package.
- The 43 grandfathered modules are still *followed* for type info, but their own errors are not reported. Un-grandfather them one at a time as errors are fixed (remove from the `module = [...]` list).
- **Fixing the 936 grandfathered errors is explicit future work** — not part of this PR.

### Grandfathered modules (43 — unchanged from the authored list)
```
q2mm.backends.mm, q2mm.backends.mm._jax_common, q2mm.backends.mm.batched,
q2mm.backends.mm.jax_engine, q2mm.backends.mm.jax_md_engine, q2mm.backends.mm.openmm,
q2mm.backends.mm.tinker, q2mm.backends.qm.psi4, q2mm.backends.registry,
q2mm.benchmark_runner, q2mm.diagnostics.benchmark, q2mm.diagnostics.cli,
q2mm.diagnostics.systems, q2mm.diagnostics.tables, q2mm.io._helpers, q2mm.io.amber,
q2mm.io.cmap, q2mm.io.gaussian, q2mm.io.jaguar, q2mm.io.macromodel, q2mm.io.mm3,
q2mm.io.mol2, q2mm.io.openmm, q2mm.io.reference, q2mm.io.tinker,
q2mm.models.forcefield, q2mm.models.hessian, q2mm.models.molecule, q2mm.models.seminario,
q2mm.models.structure, q2mm.optimizers.cycling, q2mm.optimizers.evaluators.eigenmatrix,
q2mm.optimizers.evaluators.energy, q2mm.optimizers.evaluators.frequency,
q2mm.optimizers.jax_multistart, q2mm.optimizers.jaxloss, q2mm.optimizers.jaxopt_opt,
q2mm.optimizers.objective, q2mm.optimizers.optax, q2mm.optimizers.reference,
q2mm.optimizers.scipy_opt, q2mm.optimizers.spec, q2mm.workflows.method_e2
```

### Env-drift resolution (numpy 2.5 + `python_version`)
The first CI run failed the Lint job, but **not** because of a q2mm module. CI's Lint job installs `.[dev]` on Python 3.12, which pulls **numpy 2.5.1**, whose bundled stubs use PEP 695 `type` aliases (e.g. `numpy/__init__.pyi:737`). mypy 2.2.0 rejects those under a `python_version = "3.10"` target:

```
numpy/__init__.pyi:737: error: Type statement is only supported in Python 3.12 and greater  [syntax]
Found 1 error in 1 file (errors prevented further checking)
```

This is a **fatal parse-time error that halts all checking** — so *no* q2mm module even gets analyzed. It cannot be grandfathered: per-module `ignore_errors` and `follow_imports = "skip"` do **not** suppress it (verified — mypy parses `py.typed` package stubs before per-module config applies). It did not reproduce locally at first only because the local env has the older numpy 2.4.6, whose stubs predate the `type` aliases.

**Resolution — single source of truth (`[tool.mypy].python_version = "3.12"`).** The mypy target is pinned to 3.12 (the Lint job's interpreter) directly in `pyproject.toml`, so both CI and local runs use plain `python -m mypy q2mm/` with **no `--python-version` override and no config drift**. An earlier revision of this PR used a CI-only `--python-version 3.12` flag while leaving the config at `"3.10"`; that was changed to the config pin in response to review feedback (Copilot flagged the CI/config divergence and the drift between the documented local command and what CI actually enforced). Pinning `python_version` is the one deliberate change to a previously-untouched `[tool.mypy]` setting, made consciously and surfaced here for the maintainer.

This does **not** suppress any q2mm error and does **not** weaken the ratchet. Targeting 3.12 rather than the 3.10 floor is unavoidable here (numpy's stubs cannot parse under 3.10), and the **≥3.10 runtime floor remains enforced** by ruff (`target-version = "py310"` + pyupgrade) and the 3.10 test-core matrix (3.10/3.11/3.12/3.13, all green).

**No q2mm modules were added to the grandfather list** — it stands at the authored 43.

### Local verification (Python 3.11, numpy 2.4.6, mypy 2.2.0)
- `python -m mypy q2mm/` → **Success: no issues found in 73 source files**
- `python -m ruff check q2mm/ test/ scripts/` → All checks passed
- `python -m ruff format --check q2mm test scripts examples` → 168 files already formatted
- `python -m pytest test/ -q -m "not (openmm or tinker or jax or jax_md or psi4)"` → 670 passed, 176 skipped, 0 failures
- `python scripts/check_env_dep_parity.py` → env-dep parity OK (the `dev` extra is not subject to the parity contract)

CI at the current head: **Lint job green** running plain `python -m mypy q2mm/`; all four `test-core` tiers (3.10–3.13) and the openmm/tinker/jax-md/psi4 backend jobs green.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>