### PR TITLE
refactor(systems): relocate benchmark system registry to top-level q2mm/systems.py

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ functions, and evaluation tools for force field development.
 
 Q2MM has a specific scientific lineage.  Before changing anything in
 `q2mm/models/seminario.py`, `q2mm/models/forcefield.py`, the
-parametrization loaders in `q2mm/diagnostics/systems.py`, or the
+parametrization loaders in `q2mm/systems.py`, or the
 optimizers in `q2mm/optimizers/`, look at the right paper.  Agents have
 repeatedly cited the wrong reference here.
 
@@ -470,7 +470,7 @@ file, ~2,000 lines) and do not need composition.
 
 ### Adding a new benchmark system
 
-1. Write a `load_*()` function in `q2mm/diagnostics/systems.py` following the
+1. Write a `load_*()` function in `q2mm/systems.py` following the
    pattern of `load_rh_enamide()` — load molecules, build `ReferenceData`,
    return `SystemData`.
 2. Register in the `SYSTEMS` dict at the bottom of `systems.py`.

--- a/docs/benchmarks/qfuerza-recovery.md
+++ b/docs/benchmarks/qfuerza-recovery.md
@@ -440,7 +440,7 @@ from the literature `.fld`.
 
 ## 7. Anchors
 
-- Code: [`q2mm/diagnostics/systems.py`](https://github.com/ericchansen/q2mm/blob/main/q2mm/diagnostics/systems.py) (`starting_point` parameter on `load_system`)
+- Code: [`q2mm/systems.py`](https://github.com/ericchansen/q2mm/blob/main/q2mm/systems.py) (`starting_point` parameter on `load_system`)
 - Bounds: [`q2mm/models/forcefield.py`](https://github.com/ericchansen/q2mm/blob/main/q2mm/models/forcefield.py) (`get_fractional_bounds`)
 - CLI: [`scripts/regenerate_convergence_results.py`](https://github.com/ericchansen/q2mm/blob/main/scripts/regenerate_convergence_results.py) (`--starting-point`, `--ftol`, `--fc-fraction`, `--eq-fraction`)
 - Analysis scripts:

--- a/docs/how-it-works/architecture.md
+++ b/docs/how-it-works/architecture.md
@@ -193,6 +193,7 @@ q2mm/
 ├── elements.py           # Periodic table data
 ├── geometry.py           # Geometry helpers (distances, angles, alignment)
 ├── benchmark_runner.py   # Canonical convergence benchmark runner (backs q2mm.benchmark)
+├── systems.py            # Benchmark system registry (SYSTEMS, SystemData, load_system)
 │
 ├── models/               # Format-neutral data structures
 │   ├── forcefield.py     # ForceField, BondParam, AngleParam, TorsionParam, FunctionalForm
@@ -261,8 +262,7 @@ q2mm/
 │   ├── single_stage.py   # SingleStageWorkflow
 │   └── method_e2.py      # MethodE2Workflow (two-stage)
 │
-└── diagnostics/          # Benchmark systems, analysis, and reporting
-    ├── systems.py        # Benchmark system registry (SYSTEMS, SystemData, load_system)
+└── diagnostics/          # Analysis and reporting
     ├── cli.py            # q2mm-benchmark console entry point
     ├── benchmark.py      # Multi-backend leaderboard benchmarks (run_combo)
     ├── pes_distortion.py # PES distortion analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,7 +215,6 @@ module = [
   "q2mm.benchmark_runner",
   "q2mm.diagnostics.benchmark",
   "q2mm.diagnostics.cli",
-  "q2mm.diagnostics.systems",
   "q2mm.diagnostics.tables",
   "q2mm.io._helpers",
   "q2mm.io.amber",
@@ -245,6 +244,7 @@ module = [
   "q2mm.optimizers.reference",
   "q2mm.optimizers.scipy_opt",
   "q2mm.optimizers.spec",
+  "q2mm.systems",
   "q2mm.workflows.method_e2",
 ]
 

--- a/q2mm/benchmark_runner.py
+++ b/q2mm/benchmark_runner.py
@@ -405,7 +405,7 @@ def run_benchmark(
 
     Args:
         system_key: Registered system identifier.  Must be present in
-            ``q2mm.diagnostics.systems.SYSTEMS``.
+            ``q2mm.systems.SYSTEMS``.
         workflow: ``"method-e2"`` (default), ``"single-stage"``, or a
             pre-configured :class:`~q2mm.workflows.base.Workflow`
             instance.
@@ -440,7 +440,7 @@ def run_benchmark(
 
     """
     from q2mm.backends.mm.jax_engine import JaxEngine
-    from q2mm.diagnostics.systems import SYSTEMS, load_system
+    from q2mm.systems import SYSTEMS, load_system
     from q2mm.optimizers.objective import ObjectiveFunction
     from q2mm.optimizers.scipy_opt import ScipyOptimizer
 

--- a/q2mm/diagnostics/__init__.py
+++ b/q2mm/diagnostics/__init__.py
@@ -13,14 +13,10 @@ from q2mm.diagnostics.benchmark import (
 )
 from q2mm.diagnostics.pes_distortion import compute_distortions, load_normal_modes
 from q2mm.diagnostics.report import detailed_report, full_report
-from q2mm.diagnostics.systems import SYSTEMS, SystemData, SystemSpec, load_system
 from q2mm.diagnostics.tables import TablePrinter
 
 __all__ = [
     "BenchmarkResult",
-    "SYSTEMS",
-    "SystemData",
-    "SystemSpec",
     "TablePrinter",
     "compute_distortions",
     "detailed_report",
@@ -28,7 +24,6 @@ __all__ = [
     "frequency_rmsd",
     "full_report",
     "load_normal_modes",
-    "load_system",
     "real_frequencies",
     "run_combo",
 ]

--- a/q2mm/diagnostics/benchmark.py
+++ b/q2mm/diagnostics/benchmark.py
@@ -23,7 +23,7 @@ from q2mm.constants import REAL_FREQUENCY_THRESHOLD
 
 if TYPE_CHECKING:
     from q2mm.backends.base import MMEngine
-    from q2mm.diagnostics.systems import SystemData
+    from q2mm.systems import SystemData
     from q2mm.models.forcefield import ForceField
     from q2mm.models.molecule import Q2MMMolecule
     from q2mm.optimizers.objective import ObjectiveFunction

--- a/q2mm/diagnostics/cli.py
+++ b/q2mm/diagnostics/cli.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from q2mm.diagnostics.benchmark import BenchmarkResult
-    from q2mm.diagnostics.systems import SystemSpec
+    from q2mm.systems import SystemSpec
 
 
 def _discover_backends() -> list[tuple[str, type, str]]:
@@ -130,7 +130,7 @@ def _resolve_system(system_key: str) -> SystemSpec:
         SystemExit: If the system is not registered.
 
     """
-    from q2mm.diagnostics.systems import SYSTEMS
+    from q2mm.systems import SYSTEMS
 
     if system_key not in SYSTEMS:
         available = ", ".join(sorted(SYSTEMS))
@@ -230,7 +230,7 @@ def _run_matrix(
 
             # Reload system data per-form (reference data depends on form)
             try:
-                from q2mm.diagnostics.systems import load_system
+                from q2mm.systems import load_system
 
                 molecule_loader_kwargs: dict[str, Any] | None = None
                 if system_key == "ch3f" and data_dir is not None:
@@ -660,7 +660,7 @@ def main(argv: list[str] | None = None) -> int:
 
     # --list: show what's available
     if args.list:
-        from q2mm.diagnostics.systems import SYSTEMS
+        from q2mm.systems import SYSTEMS
 
         print("\nAvailable systems:")
         for key, sys_cfg in SYSTEMS.items():

--- a/q2mm/systems.py
+++ b/q2mm/systems.py
@@ -11,7 +11,7 @@ Adding a new system = appending a :class:`SystemSpec` entry to
 
 Usage::
 
-    from q2mm.diagnostics.systems import load_system, SYSTEMS
+    from q2mm.systems import load_system, SYSTEMS
 
     sys_data = load_system("rh-enamide", engine=engine)
 
@@ -105,7 +105,7 @@ def _build_frequency_reference(
 # Loader: CH3F (single molecule, SN2 test reference data)
 # ---------------------------------------------------------------------------
 
-_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 def _find_ch3f_data_dir() -> Path:
@@ -206,7 +206,7 @@ def _resolve_supporting_info_dir() -> Path:
     si_env = os.environ.get("Q2MM_SUPPORTING_INFO")
     if si_env:
         return Path(si_env)
-    return Path(__file__).resolve().parent.parent.parent / "validation" / "supporting-info"
+    return Path(__file__).resolve().parent.parent / "validation" / "supporting-info"
 
 
 def _load_gaussian_molecules(log_dir: Path, *, bond_tolerance: float = 1.3) -> list[Q2MMMolecule]:

--- a/q2mm/workflows/base.py
+++ b/q2mm/workflows/base.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 from q2mm.optimizers.protocols import _Optimizer
 
 if TYPE_CHECKING:
-    from q2mm.diagnostics.systems import SystemData
+    from q2mm.systems import SystemData
     from q2mm.models.forcefield import ForceField
 
 

--- a/q2mm/workflows/method_e2.py
+++ b/q2mm/workflows/method_e2.py
@@ -56,7 +56,7 @@ from q2mm.workflows.base import StageResult, WorkflowResult
 from q2mm.workflows.single_stage import _evaluate_samples, _per_category_metrics
 
 if TYPE_CHECKING:
-    from q2mm.diagnostics.systems import SystemData
+    from q2mm.systems import SystemData
     from q2mm.models.forcefield import ForceField, _FrozenAwareParam
     from q2mm.workflows.base import _Optimizer
 

--- a/q2mm/workflows/single_stage.py
+++ b/q2mm/workflows/single_stage.py
@@ -19,7 +19,7 @@ import numpy as np
 from q2mm.workflows.base import StageResult, WorkflowResult
 
 if TYPE_CHECKING:
-    from q2mm.diagnostics.systems import SystemData
+    from q2mm.systems import SystemData
     from q2mm.optimizers.objective import ObjectiveFunction
     from q2mm.workflows.base import _Optimizer
 

--- a/scripts/bench_composed.py
+++ b/scripts/bench_composed.py
@@ -59,7 +59,7 @@ def run_workflow_b(
 
     """
     from q2mm.diagnostics.benchmark import run_combo
-    from q2mm.diagnostics.systems import SystemData
+    from q2mm.systems import SystemData
 
     results_dir = output_dir / "results"
     ff_dir = output_dir / "forcefields"
@@ -215,7 +215,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    from q2mm.diagnostics.systems import load_system
+    from q2mm.systems import load_system
 
     output_dir = args.output
     all_results: list[dict] = []

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -194,7 +194,7 @@ def main(argv: list[str] | None = None) -> int:
         datefmt="%H:%M:%S",
     )
 
-    from q2mm.diagnostics.systems import SYSTEMS
+    from q2mm.systems import SYSTEMS
 
     systems = args.system or list(SYSTEMS.keys())
     unknown = [s for s in systems if s not in SYSTEMS]

--- a/scripts/compare_opt_rows.py
+++ b/scripts/compare_opt_rows.py
@@ -250,7 +250,7 @@ def main() -> int:
         import tempfile as _tempfile
 
         _sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-        from q2mm.diagnostics.systems import load_system
+        from q2mm.systems import load_system
 
         # ``compare_opt_rows.py`` exists to diff the published baseline FF
         # against an optimizer's output, so we must load the literature OPT

--- a/scripts/compare_qfuerza_to_published.py
+++ b/scripts/compare_qfuerza_to_published.py
@@ -29,7 +29,7 @@ from pathlib import Path
 _REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO))
 
-from q2mm.diagnostics.systems import SYSTEMS  # noqa: E402
+from q2mm.systems import SYSTEMS  # noqa: E402
 from q2mm.models.forcefield import ForceField  # noqa: E402
 
 

--- a/scripts/diagnose_heck_relay.py
+++ b/scripts/diagnose_heck_relay.py
@@ -204,7 +204,7 @@ def _per_molecule_r2(obj: Any, ff: Any) -> list[dict[str, float]]:
 
 def _ff_path() -> Path:
     """Resolve the Rosales Heck-relay FF file path."""
-    from q2mm.diagnostics.systems import _resolve_supporting_info_dir
+    from q2mm.systems import _resolve_supporting_info_dir
 
     si = _resolve_supporting_info_dir()
     return si / "rosales" / "Rosales_Anthony_Supporting_Information" / "Chapter3_Heck" / "mm3.FF1.fld"
@@ -345,7 +345,7 @@ def main() -> int:
     )
 
     from q2mm.backends.mm.jax_engine import JaxEngine
-    from q2mm.diagnostics.systems import load_heck_relay_molecules
+    from q2mm.systems import load_heck_relay_molecules
     from q2mm.optimizers.objective import ReferenceData
 
     logger.info("Loading 23 Heck-relay molecules + QM Hessians")

--- a/scripts/run_rh_benchmarks.sh
+++ b/scripts/run_rh_benchmarks.sh
@@ -124,7 +124,7 @@ sys.path.insert(0, '.')
 # JAX_PLATFORMS left unset — let JAX auto-detect GPU
 
 from q2mm.backends.mm.jax_engine import JaxEngine
-from q2mm.diagnostics.systems import load_system
+from q2mm.systems import load_system
 from q2mm.io.mm3 import _mm3_import_ff
 from q2mm.optimizers.objective import ObjectiveFunction
 

--- a/test/benchmarks/test_optimization.py
+++ b/test/benchmarks/test_optimization.py
@@ -19,7 +19,7 @@ pytestmark = [pytest.mark.benchmark, pytest.mark.nightly]
 def _run_and_validate(engine: object) -> None:
     """Run the benchmark pipeline and validate structure."""
     from q2mm.diagnostics.benchmark import run_combo
-    from q2mm.diagnostics.systems import load_system
+    from q2mm.systems import load_system
 
     sys_data = load_system("ch3f", engine=engine)
     result = run_combo(

--- a/test/integration/test_backend_optimizer_matrix.py
+++ b/test/integration/test_backend_optimizer_matrix.py
@@ -186,7 +186,7 @@ class TestBenchmarkPipeline:
     def result(self) -> BenchmarkResult:
         from q2mm.backends.mm.openmm import OpenMMEngine
         from q2mm.diagnostics.benchmark import run_combo
-        from q2mm.diagnostics.systems import load_system
+        from q2mm.systems import load_system
 
         engine = OpenMMEngine()
         sys_data = load_system("ch3f", engine=engine)

--- a/test/integration/test_ch3f_sn2_system.py
+++ b/test/integration/test_ch3f_sn2_system.py
@@ -30,7 +30,7 @@ class TestCh3fSn2System:
 
     def test_system_is_registered(self) -> None:
         """``ch3f-sn2`` appears in the SYSTEMS registry with TS metadata."""
-        from q2mm.diagnostics.systems import SYSTEMS
+        from q2mm.systems import SYSTEMS
 
         assert "ch3f-sn2" in SYSTEMS
         spec = SYSTEMS["ch3f-sn2"]
@@ -48,7 +48,7 @@ class TestCh3fSn2System:
         molecule must match or downstream electrostatic / charge-
         sensitive code paths would silently disagree with the QM.
         """
-        from q2mm.diagnostics.systems import _load_ch3f_sn2_molecules
+        from q2mm.systems import _load_ch3f_sn2_molecules
 
         mols = _load_ch3f_sn2_molecules()
         assert len(mols) == 1
@@ -67,7 +67,7 @@ class TestCh3fSn2System:
         ``1.5`` (the canonical TS value documented on
         ``Q2MMMolecule.from_xyz``).
         """
-        from q2mm.diagnostics.systems import _load_ch3f_sn2_molecules
+        from q2mm.systems import _load_ch3f_sn2_molecules
 
         mol = _load_ch3f_sn2_molecules()[0]
         cf_bonds = [b for b in mol.bonds if set(b.elements) == {"C", "F"}]
@@ -87,7 +87,7 @@ class TestCh3fSn2System:
         ``< -1e-3`` distinguishes those from the genuine
         reaction-coordinate mode.
         """
-        from q2mm.diagnostics.systems import _load_ch3f_sn2_molecules
+        from q2mm.systems import _load_ch3f_sn2_molecules
 
         mol = _load_ch3f_sn2_molecules()[0]
         evals = np.linalg.eigvalsh(mol.hessian)
@@ -106,7 +106,7 @@ class TestCh3fSn2System:
         Seminario projection.
         """
         from q2mm.backends.mm.jax_engine import JaxEngine
-        from q2mm.diagnostics.systems import load_system
+        from q2mm.systems import load_system
 
         sd = load_system("ch3f-sn2", engine=JaxEngine())
         # 6-atom TS → 18 Cartesian DOFs → 12 vibrational modes → 11 real
@@ -129,7 +129,7 @@ class TestCh3fSn2System:
         actionable error inside ``Q2MMMolecule.from_xyz`` or
         ``np.load``.
         """
-        from q2mm.diagnostics.systems import _load_ch3f_sn2_molecules
+        from q2mm.systems import _load_ch3f_sn2_molecules
 
         # Empty data dir → no SN2 TS files
         with pytest.raises(FileNotFoundError, match="SN2 TS reference data missing"):
@@ -147,7 +147,7 @@ class TestCh3fSn2System:
         on rh-conjugate's C-C-O angle is present here.
         """
         from q2mm.backends.mm.jax_engine import JaxEngine
-        from q2mm.diagnostics.systems import load_system
+        from q2mm.systems import load_system
 
         engine = JaxEngine()
         sd_large = load_system("ch3f-sn2", engine=engine, qfuerza_replace_with=1.0)

--- a/test/integration/test_full_loop_parity.py
+++ b/test/integration/test_full_loop_parity.py
@@ -204,9 +204,9 @@ class TestRhEnamideSeminarioTiming:
 def _load_rh_enamide_molecules() -> list[Q2MMMolecule]:
     """Load 9 rh-enamide structures with Jaguar Hessians.
 
-    Delegates to the shared loader in :mod:`q2mm.diagnostics.systems`.
+    Delegates to the shared loader in :mod:`q2mm.systems`.
     """
-    from q2mm.diagnostics.systems import load_rh_enamide_molecules
+    from q2mm.systems import load_rh_enamide_molecules
 
     return load_rh_enamide_molecules()
 

--- a/test/integration/test_published_ff_validation.py
+++ b/test/integration/test_published_ff_validation.py
@@ -10,7 +10,7 @@ single, uniform pipeline:
 
 * molecules + published force field come from
   ``load_system(key, starting_point="published")`` (one loader path for all
-  systems — see :mod:`q2mm.diagnostics.systems`);
+  systems — see :mod:`q2mm.systems`);
 * frequencies come from :func:`q2mm.models.hessian.hessian_to_frequencies`
   (QM) and ``JaxEngine.frequencies`` (MM);
 * the objective score is the real :class:`~q2mm.optimizers.objective.
@@ -351,7 +351,7 @@ def _results_for(spec: Check1Spec) -> dict[str, Any]:
     if spec.key in _RESULTS_CACHE:
         return _RESULTS_CACHE[spec.key]
 
-    from q2mm.diagnostics.systems import load_system
+    from q2mm.systems import load_system
 
     try:
         sd = load_system(spec.key, starting_point="published")
@@ -489,7 +489,7 @@ def test_load_heck_relay_preserves_published_opt_values() -> None:
     ``load_system("heck-relay", starting_point="published")`` against the same
     params loaded directly from the .fld file with no Seminario step.
     """
-    from q2mm.diagnostics.systems import _heck_relay_ff_path, load_system
+    from q2mm.systems import _heck_relay_ff_path, load_system
     from q2mm.models.forcefield import ForceField
 
     ff_path = _heck_relay_ff_path()

--- a/test/test_bench_composed.py
+++ b/test/test_bench_composed.py
@@ -17,7 +17,7 @@ import ast
 import dataclasses
 from pathlib import Path
 
-from q2mm.diagnostics.systems import SystemData
+from q2mm.systems import SystemData
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BENCH_COMPOSED = REPO_ROOT / "scripts" / "bench_composed.py"

--- a/test/test_method_e2_workflow.py
+++ b/test/test_method_e2_workflow.py
@@ -114,7 +114,7 @@ class TestShortCircuit:
     @staticmethod
     def _load() -> tuple:
         from q2mm.backends.mm.jax_engine import JaxEngine
-        from q2mm.diagnostics.systems import load_system
+        from q2mm.systems import load_system
 
         engine = JaxEngine()
         return load_system("ch3f", engine=engine), engine
@@ -150,7 +150,7 @@ class TestActiveMaskRestoration:
     def test_active_mask_unchanged_on_short_circuit(self) -> None:
         """Single-stage path: no freezes applied, no unfreezes needed."""
         from q2mm.backends.mm.jax_engine import JaxEngine
-        from q2mm.diagnostics.systems import load_system
+        from q2mm.systems import load_system
         from q2mm.optimizers.scipy_opt import ScipyOptimizer
 
         engine = JaxEngine()
@@ -187,7 +187,7 @@ class TestTwoStageOnSn2:
     @staticmethod
     def _load() -> tuple:
         from q2mm.backends.mm.jax_engine import JaxEngine
-        from q2mm.diagnostics.systems import load_system
+        from q2mm.systems import load_system
 
         engine = JaxEngine()
         # Use a small replace_with to push FACAF (and similar fragile
@@ -340,7 +340,7 @@ class TestHelpers:
     def test_iter_active_force_constants_covers_bonds_and_angles(self) -> None:
         """The walker yields one entry per active bond_k + angle_k + ub_k."""
         from q2mm.backends.mm.jax_engine import JaxEngine
-        from q2mm.diagnostics.systems import load_system
+        from q2mm.systems import load_system
 
         sd = load_system("ch3f", engine=JaxEngine())
         items = _iter_active_force_constants(sd.forcefield)
@@ -356,7 +356,7 @@ class TestHelpers:
     def test_identify_candidates_threshold_inclusive(self) -> None:
         """With threshold above all FC magnitudes, every active FC is a candidate."""
         from q2mm.backends.mm.jax_engine import JaxEngine
-        from q2mm.diagnostics.systems import load_system
+        from q2mm.systems import load_system
 
         sd = load_system("ch3f", engine=JaxEngine())
         all_fcs = _iter_active_force_constants(sd.forcefield)
@@ -367,7 +367,7 @@ class TestHelpers:
     def test_identify_candidates_threshold_zero(self) -> None:
         """With threshold=0 and allow_negative=True, no candidates emerge."""
         from q2mm.backends.mm.jax_engine import JaxEngine
-        from q2mm.diagnostics.systems import load_system
+        from q2mm.systems import load_system
 
         sd = load_system("ch3f", engine=JaxEngine())
         candidates = _identify_method_e2_candidates(sd.forcefield, threshold=0.0, allow_negative=True)

--- a/test/test_systems.py
+++ b/test/test_systems.py
@@ -9,7 +9,7 @@ import pytest
 
 from test._shared import make_water
 
-from q2mm.diagnostics import systems
+from q2mm import systems
 from q2mm.models.molecule import Q2MMMolecule
 from q2mm.optimizers.objective import ReferenceData
 

--- a/test/test_workflows.py
+++ b/test/test_workflows.py
@@ -54,7 +54,7 @@ class TestStageResultDataclass:
     def test_workflow_result_default_lists(self) -> None:
         """Default lists/dicts are per-instance (not shared)."""
         from q2mm.backends.mm.jax_engine import JaxEngine
-        from q2mm.diagnostics.systems import load_system
+        from q2mm.systems import load_system
 
         sd = load_system("ch3f", engine=JaxEngine())
         wr1 = WorkflowResult(
@@ -86,7 +86,7 @@ class TestSingleStageWorkflowParity:
     def _load() -> tuple:
         """Fresh ``(SystemData, engine)`` per test."""
         from q2mm.backends.mm.jax_engine import JaxEngine
-        from q2mm.diagnostics.systems import load_system
+        from q2mm.systems import load_system
 
         engine = JaxEngine()
         return load_system("ch3f", engine=engine), engine


### PR DESCRIPTION
Implements **finding 4.8** of the approved multi-phase repo refactor. Pure mechanical relocation with **zero behavior change** — same discipline as the merged Phase 2 (#303) and Phase 3 (#305) code-moves.

## What & why
`q2mm/diagnostics/systems.py` (the benchmark **system registry**: `SYSTEMS`, `SystemData`, `SystemSpec`, `load_system`, plus loader helpers) is misfiled. It is core domain configuration that `benchmark_runner.py` and the `workflows/` package depend on, not a diagnostic/reporting utility. This moves it to a new top-level module `q2mm/systems.py`.

## Changes
- **`git mv q2mm/diagnostics/systems.py → q2mm/systems.py`** (99% rename similarity, history preserved). Content byte-identical except:
  - the docstring usage example `from q2mm.diagnostics.systems …` → `from q2mm.systems …`
  - the two `__file__`-relative path anchors (`_REPO_ROOT` and the supporting-info dir) changed from `parent.parent.parent` → `parent.parent` so the **resolved paths stay identical** after the file moves up one directory level. This is required to honor the zero-behavior-change invariant (a literal verbatim copy would silently resolve data paths one directory too high and break the `external_data` tests).
- **Repointed every importer** (source, tests, scripts, docstrings) from `q2mm.diagnostics.systems` → `q2mm.systems`. Private helpers (`_resolve_supporting_info_dir`, `load_heck_relay_molecules`, `_load_ch3f_sn2_molecules`, `load_rh_enamide_molecules`, `_heck_relay_ff_path`) remain importable from `q2mm.systems`.
- **`q2mm/diagnostics/__init__.py`**: dropped the four systems names (`SYSTEMS`, `SystemData`, `SystemSpec`, `load_system`) — nothing imported them from the package top level, so no re-export shim (AGENTS.md §2 alpha discipline).
- **`pyproject.toml`**: renamed the mypy grandfather entry `q2mm.diagnostics.systems` → `q2mm.systems` (same count, kept sorted). Pre-existing type errors stay grandfathered under the new name.
- **`docs/how-it-works/architecture.md`**: moved the `systems.py` node to the top-level tree; updated the `diagnostics/` comment. Guard test `test/test_architecture_doc.py` passes.

Scope guardrails respected: the `diagnostics/` package, `cli.py`, and the `q2mm-benchmark` entry point (`q2mm.diagnostics.cli:main`) are untouched — deferred to a later phase. `q2mm/__init__.py` public API unchanged.

## Verification
- `ruff check q2mm/ test/ scripts/` → All checks passed
- `ruff format --check q2mm test scripts examples` → 168 files already formatted
- `mypy q2mm/` → Success: no issues found in 73 source files
- `pytest test/ -m "not (openmm or tinker or jax or jax_md or psi4)"` → 670 passed, 176 skipped, 319 deselected (identical to pre-change baseline on master)
- `pytest test/test_architecture_doc.py` → 3 passed
- Grep oracle `q2mm.diagnostics.systems` / `diagnostics import systems` → **zero** hits repo-wide

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>