### PR TITLE
fix(models): preserve parser molecule fidelity

### DIFF
--- a/q2mm/io/gaussian.py
+++ b/q2mm/io/gaussian.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from q2mm import constants as co
-from q2mm.models.structure import Atom, Structure
+from q2mm.models.structure import Atom, HessianUnits, Structure
 
 if TYPE_CHECKING:
     from q2mm.models.molecule import Q2MMMolecule
@@ -164,31 +164,13 @@ class GaussLog:
 
         Each structure is converted via
         :meth:`Q2MMMolecule.from_structure`, preserving any Hessian data
-        attached to the underlying ``Structure`` when it is stored in
-        atomic units (Hartree/Bohr²).
-
-        Note:
-            ``Q2MMMolecule.hessian`` is documented in Hartree/Bohr².  When
-            this parser was constructed with ``au_hessian=False`` (the
-            default), any attached Hessian has already been converted to
-            kJ/(mol·Å²) and will **not** be forwarded to avoid silently
-            mixing unit systems.
+        attached to the underlying ``Structure`` and normalizing it to
+        Hartree/Bohr² from the parser-recorded unit provenance.
 
         """
         from q2mm.models.molecule import Q2MMMolecule
 
-        molecules: list[Q2MMMolecule] = []
-        for s in self.structures:
-            hess = getattr(s, "hess", None)
-            if hess is not None and not self._au_hessian:
-                logger.debug(
-                    "Non-atomic-unit Hessian detected (au_hessian=False); "
-                    "not attaching Hessian to Q2MMMolecule, which expects "
-                    "Hartree/Bohr²."
-                )
-                hess = None
-            molecules.append(Q2MMMolecule.from_structure(s, hessian=hess))
-        return molecules
+        return [Q2MMMolecule.from_structure(structure) for structure in self.structures]
 
     def read_out(self) -> None:
         """Read force constant and eigenvector data from a frequency calculation.
@@ -547,3 +529,4 @@ class GaussLog:
             if not self._au_hessian:
                 hess *= co.HESSIAN_AU_TO_KJMOLA2
             struct.hess = hess
+            struct.hessian_units = HessianUnits.ATOMIC if self._au_hessian else HessianUnits.KJ_MOL_ANGSTROM2

--- a/q2mm/io/macromodel.py
+++ b/q2mm/io/macromodel.py
@@ -126,17 +126,14 @@ class MacroModel:
                             section = None
                             # Sort the bonds, angles, and torsions before the start
                             # of a new structure
-                            if bonds:
-                                bonds.sort(key=lambda x: (x.atom_nums[0], x.atom_nums[1]))
-                                current_structure.bonds.extend(bonds)
-                            if angles:
-                                angles.sort(key=lambda x: (x.atom_nums[1], x.atom_nums[0], x.atom_nums[2]))
-                                current_structure.angles.extend(angles)
-                            if torsions:
-                                torsions.sort(
-                                    key=lambda x: (x.atom_nums[1], x.atom_nums[2], x.atom_nums[0], x.atom_nums[3])
-                                )
-                                current_structure.torsions.extend(torsions)
+                            bonds.sort(key=lambda x: (x.atom_nums[0], x.atom_nums[1]))
+                            angles.sort(key=lambda x: (x.atom_nums[1], x.atom_nums[0], x.atom_nums[2]))
+                            torsions.sort(
+                                key=lambda x: (x.atom_nums[1], x.atom_nums[2], x.atom_nums[0], x.atom_nums[3])
+                            )
+                            current_structure.bonds = bonds
+                            current_structure.angles = angles
+                            current_structure.torsions = torsions
                             if atoms:
                                 atoms.sort(key=lambda x: x.index)
                                 current_structure.atoms.extend(atoms)
@@ -478,17 +475,12 @@ class MacroModelLog:
                     if "Connection Table" in line:
                         # Sort the bonds, angles, and torsions before the start
                         # of a new structure
-                        if bonds:
-                            bonds.sort(key=lambda x: (x.atom_nums[0], x.atom_nums[1]))
-                            current_structure.bonds.extend(bonds)
-                        if angles:
-                            angles.sort(key=lambda x: (x.atom_nums[1], x.atom_nums[0], x.atom_nums[2]))
-                            current_structure.angles.extend(angles)
-                        if torsions:
-                            torsions.sort(
-                                key=lambda x: (x.atom_nums[1], x.atom_nums[2], x.atom_nums[0], x.atom_nums[3])
-                            )
-                            current_structure.torsions.extend(torsions)
+                        bonds.sort(key=lambda x: (x.atom_nums[0], x.atom_nums[1]))
+                        angles.sort(key=lambda x: (x.atom_nums[1], x.atom_nums[0], x.atom_nums[2]))
+                        torsions.sort(key=lambda x: (x.atom_nums[1], x.atom_nums[2], x.atom_nums[0], x.atom_nums[3]))
+                        current_structure.bonds = bonds
+                        current_structure.angles = angles
+                        current_structure.torsions = torsions
             logger.log(5, f"  -- Imported {len(self._structures)} structure(s).")
         return self._structures
 

--- a/q2mm/io/mol2.py
+++ b/q2mm/io/mol2.py
@@ -256,10 +256,10 @@ class Mol2:
             raise ValueError("Mol2 atom index values do not match their ordering.")
 
         # send chunk from @<TRIPOS>BOND to end-of-file to parse_bonds
-        struct._bonds = self.parse_bonds(bond_lines, struct)
+        struct.bonds = self.parse_bonds(bond_lines, struct)
 
         # use num bonds from @<TRIPOS>MOLECULE to verify parse is correct
-        if len(struct._bonds) != num_bonds:
+        if len(struct.bonds) != num_bonds:
             raise ValueError(f"Parsed {len(struct.bonds)} bonds but expected {num_bonds} bonds based on Mol2 data.")
 
         return struct

--- a/q2mm/models/molecule.py
+++ b/q2mm/models/molecule.py
@@ -23,7 +23,7 @@ from q2mm.models.identifiers import (
 )
 
 if TYPE_CHECKING:
-    from q2mm.models.structure import Structure
+    from q2mm.models.structure import HessianUnits, Structure
 
 try:
     import qcelemental as qcel
@@ -91,7 +91,7 @@ def _dihedral_angle(p0: np.ndarray, p1: np.ndarray, p2: np.ndarray, p3: np.ndarr
 
 
 def _strip_pint(hessian: Any) -> Any:
-    """Strip ``pint.Quantity`` wrapper, converting to canonical AU.
+    """Strip a ``pint.Quantity`` wrapper and convert it to canonical AU.
 
     When ``pint`` is installed, ``JaguarIn.get_hessian(tag_units=True)``
     returns a ``pint.Quantity`` tagged with units.  This helper converts to
@@ -106,6 +106,56 @@ def _strip_pint(hessian: Any) -> Any:
     return hessian
 
 
+_HESSIAN_ATOMIC_UNIT = "hartree/bohr**2"
+_HESSIAN_KJ_MOL_ANGSTROM2_UNIT = "kilojoule/(mole*angstrom**2)"
+
+
+def _hessian_to_atomic_units(hessian: Any, units: HessianUnits | str | None) -> np.ndarray | None:
+    """Convert a Hessian with known provenance to a bare canonical-AU array."""
+    if hessian is None:
+        return None
+    if hasattr(hessian, "magnitude") and hasattr(hessian, "to"):
+        return np.asarray(hessian.to(_HESSIAN_ATOMIC_UNIT).magnitude)
+    array = np.asarray(hessian, dtype=float)
+    unit_value = getattr(units, "value", units)
+    if unit_value == _HESSIAN_ATOMIC_UNIT:
+        return array
+    if unit_value == _HESSIAN_KJ_MOL_ANGSTROM2_UNIT:
+        from q2mm.constants import KJMOLA2_TO_HESSIAN_AU
+
+        return array * KJMOLA2_TO_HESSIAN_AU
+    raise ValueError(
+        "Structure Hessian unit provenance is unknown. Set "
+        "structure.hessian_units or pass an explicit canonical-AU hessian override."
+    )
+
+
+_CANONICAL_BOND_ORDERS = {
+    "-": "-",
+    "=": "=",
+    "*": "*",
+    "%": "%",
+    "1": "-",
+    "2": "=",
+    "ar": "*",
+    "3": "%",
+}
+
+
+def _canonicalize_bond_order(order: str | None) -> str:
+    """Map supported parser bond-order tokens into the MM3 symbol domain."""
+    if order is None:
+        return ""
+    return _CANONICAL_BOND_ORDERS.get(str(order).strip().lower(), "")
+
+
+class _HessianUnset:
+    """Sentinel distinguishing an omitted Hessian from an explicit ``None``."""
+
+
+_HESSIAN_UNSET = _HessianUnset()
+
+
 @dataclass
 class DetectedBond:
     """A bond detected from molecular geometry."""
@@ -117,6 +167,7 @@ class DetectedBond:
     env_id: str = ""
     ff_row: int | None = None
     bond_order: str = ""  # "-" single, "=" double, "*" aromatic, "%" triple
+    source_bond_order: str | None = None  # Original parser token, if supplied.
 
     @property
     def element_pair(self) -> tuple[str, str]:
@@ -186,9 +237,24 @@ class Q2MMMolecule:
     _angles: list[DetectedAngle] | None = field(default=None, repr=False)
     _torsions: list[DetectedTorsion] | None = field(default=None, repr=False)
     _improper_torsions: list[DetectedTorsion] | None = field(default=None, repr=False)
+    _bonds_explicit: bool = field(default=False, repr=False)
+    _angles_explicit: bool = field(default=False, repr=False)
+    _torsions_explicit: bool = field(default=False, repr=False)
+    partial_charges: list[float | None] | None = None
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Invalidate cached topology when the bond-detection tolerance changes."""
+        if name == "bond_tolerance":
+            value = float(value)
+            previous = self.__dict__.get(name)
+            object.__setattr__(self, name, value)
+            if previous is not None and previous != value:
+                self._invalidate_inferred_topology()
+            return
+        object.__setattr__(self, name, value)
 
     def __post_init__(self) -> None:
-        """Validate atom_types length and normalize geometry to float."""
+        """Validate per-atom data and normalize geometry to float."""
         self.symbols = [str(symbol) for symbol in self.symbols]
         if self.atom_types is None:
             self.atom_types = list(self.symbols)
@@ -196,6 +262,12 @@ class Q2MMMolecule:
             self.atom_types = [str(atom_type) for atom_type in self.atom_types]
         if len(self.atom_types) != len(self.symbols):
             raise ValueError("atom_types must have the same length as symbols.")
+        if self.partial_charges is not None:
+            if len(self.partial_charges) != len(self.symbols):
+                raise ValueError("partial_charges must have the same length as symbols.")
+            self.partial_charges = [
+                None if partial_charge is None else float(partial_charge) for partial_charge in self.partial_charges
+            ]
         self.geometry = np.asarray(self.geometry, dtype=float)
 
     @property
@@ -241,11 +313,26 @@ class Q2MMMolecule:
         """Clear all cached bond/angle/torsion data.
 
         Call this after changing ``atom_types`` so that ``env_id`` values
-        in the cached topology are recomputed on next access.
+        in the cached topology are recomputed on next access. This explicitly
+        discards parser-provided topology as well as inferred topology.
         """
         self._bonds = None
         self._angles = None
         self._torsions = None
+        self._improper_torsions = None
+        self._bonds_explicit = False
+        self._angles_explicit = False
+        self._torsions_explicit = False
+
+    def _invalidate_inferred_topology(self) -> None:
+        """Clear only topology that depends on distance-based bond detection."""
+        if self._bonds_explicit:
+            return
+        self._bonds = None
+        if not self._angles_explicit:
+            self._angles = None
+        if not self._torsions_explicit:
+            self._torsions = None
         self._improper_torsions = None
 
     def _detect_bonds(self, tolerance: float = 1.3) -> list[DetectedBond]:
@@ -441,90 +528,164 @@ class Q2MMMolecule:
         cls,
         structure: Structure,
         *,
-        charge: int = 0,
-        multiplicity: int = 1,
+        charge: int | None = None,
+        multiplicity: int | None = None,
         name: str = "",
         bond_tolerance: float = 1.3,
-        hessian: np.ndarray | None = None,
+        hessian: np.ndarray | None | _HessianUnset = _HESSIAN_UNSET,
     ) -> Q2MMMolecule:
-        """Create from a legacy Structure while preserving bond/angle metadata.
+        """Create from a parser ``Structure`` without losing supplied data.
+
+        Topology is preserved per degree of freedom: a supplied list,
+        including an explicitly empty one, is authoritative. Missing bonds are
+        inferred from geometry, while missing angles and torsions are inferred
+        from the resulting bonds.
 
         Args:
             structure: Source :class:`~q2mm.models.structure.Structure` instance.
-            charge: Molecular charge.
-            multiplicity: Spin multiplicity.
+            charge: Molecular charge override. Defaults to the ``Structure``
+                ``props["charge"]`` value, then zero.
+            multiplicity: Spin multiplicity override. Defaults to the
+                ``Structure`` ``props["multiplicity"]`` value, then one.
             name: Display name; defaults to ``structure.origin_name``.
             bond_tolerance: Multiplier on sum of covalent radii for bond
                 detection.
-            hessian: Optional Cartesian Hessian matrix to attach.
+            hessian: Cartesian Hessian override. When omitted, preserves
+                ``structure.hess`` and converts it from
+                ``structure.hessian_units`` to Hartree/Bohr². A bare explicit
+                override is interpreted as Hartree/Bohr². Pass ``None``
+                explicitly to omit it.
 
         Returns:
-            A new :class:`Q2MMMolecule` with bonds and angles copied from
-            *structure*.
+            A new :class:`Q2MMMolecule` with parser-supplied data preserved.
 
         """
         symbols = []
         atom_types = []
+        partial_charges: list[float | None] = []
         coords = []
         for atom in structure.atoms:
             atom_label = _structure_atom_label(atom)
             symbols.append(_structure_atom_element(atom))
             atom_types.append(atom_label.strip() or _extract_element(atom_label))
+            partial_charges.append(atom.partial_charge)
             coords.append(atom.coords)
 
-        bonds = []
-        for bond in structure.bonds:
-            atoms = structure.get_atoms_in_DOF(bond)
-            dof_atom_types = [_structure_atom_label(a) for a in atoms]
-            elements = tuple(_structure_atom_element(atom) for atom in atoms[:2])
-            length = bond.value
-            if length is None:
-                length = np.linalg.norm(atoms[0].coords - atoms[1].coords)
-            bonds.append(
-                DetectedBond(
-                    atom_i=bond.atom_nums[0] - 1,
-                    atom_j=bond.atom_nums[1] - 1,
-                    elements=elements,
-                    length=float(length),
-                    env_id=canonicalize_bond_env_id(dof_atom_types),
-                    ff_row=bond.ff_row,
+        bonds = None
+        if structure.has_explicit_bonds:
+            bonds = []
+            for bond in structure.bonds:
+                atoms = structure.get_atoms_in_DOF(bond)
+                dof_atom_types = [_structure_atom_label(a) for a in atoms]
+                elements = (
+                    _structure_atom_element(atoms[0]),
+                    _structure_atom_element(atoms[1]),
                 )
-            )
+                length = (
+                    float(bond.value)
+                    if bond.value is not None
+                    else float(np.linalg.norm(atoms[0].coords - atoms[1].coords))
+                )
+                bonds.append(
+                    DetectedBond(
+                        atom_i=bond.atom_nums[0] - 1,
+                        atom_j=bond.atom_nums[1] - 1,
+                        elements=elements,
+                        length=length,
+                        env_id=canonicalize_bond_env_id(dof_atom_types),
+                        ff_row=bond.ff_row,
+                        bond_order=_canonicalize_bond_order(bond.order),
+                        source_bond_order=bond.order,
+                    )
+                )
 
-        angles = []
-        for angle in structure.angles:
-            atoms = structure.get_atoms_in_DOF(angle)
-            dof_atom_types = [_structure_atom_label(a) for a in atoms]
-            elements = tuple(_structure_atom_element(atom) for atom in atoms[:3])
-            angle_value = angle.value
-            if angle_value is None:
-                v1 = atoms[0].coords - atoms[1].coords
-                v2 = atoms[2].coords - atoms[1].coords
-                cos_a = np.dot(v1, v2) / (np.linalg.norm(v1) * np.linalg.norm(v2))
-                angle_value = np.degrees(np.arccos(np.clip(cos_a, -1, 1)))
-            angles.append(
-                DetectedAngle(
-                    atom_i=angle.atom_nums[0] - 1,
-                    atom_j=angle.atom_nums[1] - 1,
-                    atom_k=angle.atom_nums[2] - 1,
-                    elements=elements,
-                    value=float(angle_value),
-                    env_id=canonicalize_angle_env_id(dof_atom_types),
-                    ff_row=angle.ff_row,
+        angles = None
+        if structure.has_explicit_angles:
+            angles = []
+            for angle in structure.angles:
+                atoms = structure.get_atoms_in_DOF(angle)
+                dof_atom_types = [_structure_atom_label(a) for a in atoms]
+                elements = (
+                    _structure_atom_element(atoms[0]),
+                    _structure_atom_element(atoms[1]),
+                    _structure_atom_element(atoms[2]),
                 )
-            )
+                angle_value = angle.value
+                if angle_value is None:
+                    v1 = atoms[0].coords - atoms[1].coords
+                    v2 = atoms[2].coords - atoms[1].coords
+                    cos_a = np.dot(v1, v2) / (np.linalg.norm(v1) * np.linalg.norm(v2))
+                    angle_value = np.degrees(np.arccos(np.clip(cos_a, -1, 1)))
+                angles.append(
+                    DetectedAngle(
+                        atom_i=angle.atom_nums[0] - 1,
+                        atom_j=angle.atom_nums[1] - 1,
+                        atom_k=angle.atom_nums[2] - 1,
+                        elements=elements,
+                        value=float(angle_value),
+                        env_id=canonicalize_angle_env_id(dof_atom_types),
+                        ff_row=angle.ff_row,
+                    )
+                )
+
+        torsions = None
+        if structure.has_explicit_torsions:
+            torsions = []
+            for torsion in structure.torsions:
+                atoms = structure.get_atoms_in_DOF(torsion)
+                dof_atom_types = [_structure_atom_label(a) for a in atoms]
+                elements = (
+                    _structure_atom_element(atoms[0]),
+                    _structure_atom_element(atoms[1]),
+                    _structure_atom_element(atoms[2]),
+                    _structure_atom_element(atoms[3]),
+                )
+                torsion_value = torsion.value
+                if torsion_value is None:
+                    torsion_value = _dihedral_angle(
+                        atoms[0].coords,
+                        atoms[1].coords,
+                        atoms[2].coords,
+                        atoms[3].coords,
+                    )
+                torsions.append(
+                    DetectedTorsion(
+                        atom_i=torsion.atom_nums[0] - 1,
+                        atom_j=torsion.atom_nums[1] - 1,
+                        atom_k=torsion.atom_nums[2] - 1,
+                        atom_l=torsion.atom_nums[3] - 1,
+                        elements=elements,
+                        value=float(torsion_value),
+                        env_id=canonicalize_torsion_env_id(dof_atom_types),
+                        ff_row=torsion.ff_row,
+                    )
+                )
+
+        resolved_charge = int(structure.props.get("charge", 0)) if charge is None else int(charge)
+        resolved_multiplicity = (
+            int(structure.props.get("multiplicity", 1)) if multiplicity is None else int(multiplicity)
+        )
+        if isinstance(hessian, _HessianUnset):
+            resolved_hessian = _hessian_to_atomic_units(structure.hess, structure.hessian_units)
+        else:
+            resolved_hessian = _hessian_to_atomic_units(hessian, _HESSIAN_ATOMIC_UNIT)
 
         return cls(
             symbols=symbols,
             atom_types=atom_types,
+            partial_charges=partial_charges if any(value is not None for value in partial_charges) else None,
             geometry=np.array(coords, dtype=float),
-            charge=charge,
-            multiplicity=multiplicity,
+            charge=resolved_charge,
+            multiplicity=resolved_multiplicity,
             name=name or structure.origin_name,
             bond_tolerance=bond_tolerance,
-            hessian=_strip_pint(hessian),
+            hessian=resolved_hessian,
             _bonds=bonds,
             _angles=angles,
+            _torsions=torsions,
+            _bonds_explicit=structure.has_explicit_bonds,
+            _angles_explicit=structure.has_explicit_angles,
+            _torsions_explicit=structure.has_explicit_torsions,
         )
 
     @classmethod
@@ -588,6 +749,7 @@ class Q2MMMolecule:
         return Q2MMMolecule(
             symbols=self.symbols,
             atom_types=list(self.atom_types),
+            partial_charges=copy.deepcopy(self.partial_charges),
             geometry=self.geometry.copy(),
             charge=self.charge,
             multiplicity=self.multiplicity,
@@ -600,6 +762,9 @@ class Q2MMMolecule:
             _improper_torsions=(
                 copy.deepcopy(self._improper_torsions) if self._improper_torsions is not None else None
             ),
+            _bonds_explicit=self._bonds_explicit,
+            _angles_explicit=self._angles_explicit,
+            _torsions_explicit=self._torsions_explicit,
         )
 
     def __repr__(self) -> str:

--- a/q2mm/models/structure.py
+++ b/q2mm/models/structure.py
@@ -15,7 +15,9 @@ as the adapter layer between file-format parsers (``q2mm.io``) and
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from collections.abc import Callable, Iterable
+from enum import Enum
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 import numpy as np
 
@@ -25,6 +27,76 @@ if TYPE_CHECKING:
     from q2mm.models.datum import Datum
 
 logger = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
+
+
+class HessianUnits(str, Enum):
+    """Supported units for bare Hessian arrays stored on :class:`Structure`."""
+
+    ATOMIC = "hartree/bohr**2"
+    KJ_MOL_ANGSTROM2 = "kilojoule/(mole*angstrom**2)"
+
+
+class _TopologyList(list[_T], Generic[_T]):
+    """List that records topology-supply intent on successful mutation."""
+
+    __slots__ = ("_on_mutate",)
+
+    def __init__(self, values: Iterable[_T] = (), *, on_mutate: Callable[[], None]) -> None:
+        super().__init__(values)
+        self._on_mutate = on_mutate
+
+    def append(self, item: _T) -> None:
+        super().append(item)
+        self._on_mutate()
+
+    def extend(self, values: Iterable[_T]) -> None:
+        super().extend(values)
+        self._on_mutate()
+
+    def insert(self, index: int, item: _T) -> None:
+        super().insert(index, item)
+        self._on_mutate()
+
+    def clear(self) -> None:
+        super().clear()
+        self._on_mutate()
+
+    def pop(self, index: int = -1) -> _T:
+        item = super().pop(index)
+        self._on_mutate()
+        return item
+
+    def remove(self, item: _T) -> None:
+        super().remove(item)
+        self._on_mutate()
+
+    def reverse(self) -> None:
+        super().reverse()
+        self._on_mutate()
+
+    def sort(self, *, key: Callable[[_T], object] | None = None, reverse: bool = False) -> None:
+        super().sort(key=key, reverse=reverse)
+        self._on_mutate()
+
+    def __setitem__(self, index: int | slice, value: _T | Iterable[_T]) -> None:
+        super().__setitem__(index, value)
+        self._on_mutate()
+
+    def __delitem__(self, index: int | slice) -> None:
+        super().__delitem__(index)
+        self._on_mutate()
+
+    def __iadd__(self, values: Iterable[_T]) -> _TopologyList[_T]:
+        super().__iadd__(values)
+        self._on_mutate()
+        return self
+
+    def __imul__(self, count: int) -> _TopologyList[_T]:
+        super().__imul__(count)
+        self._on_mutate()
+        return self
 
 
 class Atom:
@@ -370,7 +442,19 @@ class Torsion(DOF):
 class Structure:
     """Data class for a single structure, conformer, or snapshot."""
 
-    __slots__ = ["_atoms", "_bonds", "_angles", "_torsions", "hess", "props", "origin_name"]
+    __slots__ = [
+        "_atoms",
+        "_bonds",
+        "_angles",
+        "_torsions",
+        "_bonds_explicit",
+        "_angles_explicit",
+        "_torsions_explicit",
+        "hess",
+        "hessian_units",
+        "props",
+        "origin_name",
+    ]
 
     def __init__(self, origin_name: str) -> None:
         """Initialise a Structure.
@@ -380,11 +464,15 @@ class Structure:
                 structure originates.
 
         """
+        object.__setattr__(self, "_bonds_explicit", False)
+        object.__setattr__(self, "_angles_explicit", False)
+        object.__setattr__(self, "_torsions_explicit", False)
         self._atoms: list[Atom] = None
         self._bonds: list[Bond] = None
         self._angles: list[Angle] = None
         self._torsions: list[Torsion] = None
         self.hess = None
+        self.hessian_units: HessianUnits | None = None
         self.props = {}
         self.origin_name: str = origin_name
 
@@ -433,8 +521,22 @@ class Structure:
 
         """
         if self._bonds is None:
-            self._bonds: list[Bond] = []
+            object.__setattr__(self, "_bonds", _TopologyList(on_mutate=self._mark_bonds_explicit))
         return self._bonds
+
+    @bonds.setter
+    def bonds(self, value: list[Bond]) -> None:
+        """Replace bonds with an authoritative parser- or caller-supplied list."""
+        self._bonds = _TopologyList(value, on_mutate=self._mark_bonds_explicit)
+        self._bonds_explicit = True
+
+    def _mark_bonds_explicit(self) -> None:
+        self._bonds_explicit = True
+
+    @property
+    def has_explicit_bonds(self) -> bool:
+        """Whether the parser supplied a bond list, including an empty one."""
+        return self._bonds_explicit
 
     @property
     def angles(self) -> list[Angle]:
@@ -445,8 +547,22 @@ class Structure:
 
         """
         if self._angles is None:
-            self._angles: list[Angle] = []
+            object.__setattr__(self, "_angles", _TopologyList(on_mutate=self._mark_angles_explicit))
         return self._angles
+
+    @angles.setter
+    def angles(self, value: list[Angle]) -> None:
+        """Replace angles with an authoritative parser- or caller-supplied list."""
+        self._angles = _TopologyList(value, on_mutate=self._mark_angles_explicit)
+        self._angles_explicit = True
+
+    def _mark_angles_explicit(self) -> None:
+        self._angles_explicit = True
+
+    @property
+    def has_explicit_angles(self) -> bool:
+        """Whether the parser supplied an angle list, including an empty one."""
+        return self._angles_explicit
 
     @property
     def torsions(self) -> list[Torsion]:
@@ -457,8 +573,22 @@ class Structure:
 
         """
         if self._torsions is None:
-            self._torsions: list[Torsion] = []
+            object.__setattr__(self, "_torsions", _TopologyList(on_mutate=self._mark_torsions_explicit))
         return self._torsions
+
+    @torsions.setter
+    def torsions(self, value: list[Torsion]) -> None:
+        """Replace torsions with an authoritative parser- or caller-supplied list."""
+        self._torsions = _TopologyList(value, on_mutate=self._mark_torsions_explicit)
+        self._torsions_explicit = True
+
+    def _mark_torsions_explicit(self) -> None:
+        self._torsions_explicit = True
+
+    @property
+    def has_explicit_torsions(self) -> bool:
+        """Whether the parser supplied a torsion list, including an empty one."""
+        return self._torsions_explicit
 
     def guess_atoms(self) -> int:
         """Estimate the number of atoms from bond indices.

--- a/q2mm/optimizers/reference.py
+++ b/q2mm/optimizers/reference.py
@@ -771,8 +771,8 @@ class ReferenceData:
         *,
         weights: dict[str, float] | None = None,
         bond_tolerance: float = DEFAULT_BOND_TOLERANCE,
-        charge: int = 0,
-        multiplicity: int = 1,
+        charge: int | None = None,
+        multiplicity: int | None = None,
         include_frequencies: bool = False,
         skip_imaginary: bool = False,
         au_hessian: bool = True,
@@ -796,8 +796,10 @@ class ReferenceData:
                 keys as :meth:`from_molecule`).
             bond_tolerance (float): Multiplier for covalent-radii bond
                 detection. Use 1.4+ for TS.
-            charge (int): Molecular charge.
-            multiplicity (int): Spin multiplicity.
+            charge (int | None): Molecular charge override. ``None`` preserves
+                the value parsed from the Gaussian archive.
+            multiplicity (int | None): Spin multiplicity override. ``None``
+                preserves the value parsed from the Gaussian archive.
             include_frequencies (bool): Whether to add frequency data
                 from the log file. Default is ``False``.
             skip_imaginary (bool): If ``True``, negative frequencies are
@@ -819,8 +821,10 @@ class ReferenceData:
 
         # Build molecule from the last (optimised) structure
         mol = log.molecules[-1]
-        mol.charge = charge
-        mol.multiplicity = multiplicity
+        if charge is not None:
+            mol.charge = charge
+        if multiplicity is not None:
+            mol.multiplicity = multiplicity
         mol.bond_tolerance = bond_tolerance
 
         # ``mol.hessian`` carries the archive Cartesian Hessian (Hartree/Bohr²,

--- a/q2mm/systems.py
+++ b/q2mm/systems.py
@@ -239,7 +239,6 @@ def _load_gaussian_molecules(log_dir: Path, *, bond_tolerance: float = 1.3) -> l
         # Gaussian logs only carry element symbols; MM3 engines need
         # typed atoms (C2/C3, H1, N2, etc.) for parameter matching.
         mol.bond_tolerance = bond_tolerance
-        mol._bonds = None  # force re-detection with new tolerance
         _assign_mm3_atom_types(mol)
         # Invalidate topology caches so that bonds/angles/torsions are
         # re-detected with the updated MM3 atom_types (env_id depends

--- a/test/integration/test_seminario_parity.py
+++ b/test/integration/test_seminario_parity.py
@@ -527,21 +527,9 @@ class TestCisplatinZenodoQFUERZARules:
 
 @pytest.fixture(scope="module")
 def cisplatin_molecule() -> Q2MMMolecule:
-    """Parse the cisplatin Gaussian log and build a Q2MMMolecule.
-
-    Uses direct Q2MMMolecule construction (not GaussLog.molecules) because
-    GaussLog.molecules passes ``_bonds=[]`` via ``from_structure``, which
-    bypasses auto-detection.  Direct construction leaves ``_bonds=None``,
-    triggering covalent-radii bond detection.
-    """
+    """Parse the cisplatin Gaussian log and build a Q2MMMolecule."""
     log = GaussLog(str(CISPLATIN_GAUSSIAN_LOG), au_hessian=True)
-    s = log.structures[-1]
-    return Q2MMMolecule(
-        symbols=[a.element for a in s.atoms],
-        geometry=[a.coords for a in s.atoms],
-        hessian=s.hess,
-        bond_tolerance=1.3,
-    )
+    return log.molecules[-1]
 
 
 @pytest.mark.integration

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 
 import numpy as np
@@ -26,6 +27,7 @@ from q2mm.models.seminario import (
     _is_hydrogen_angle,
     QFUERZA_H_ANGLE_DEFAULT_CANONICAL,
 )
+from q2mm.models.structure import Angle, Bond, Torsion
 from q2mm.io.tinker import _tinker_import_ff
 
 # Fixture paths (test-specific, not shared)
@@ -105,6 +107,203 @@ class TestMoleculeFromXYZ:
         )
         assert any(bond.env_id == "1-5" for bond in mol.bonds)
         assert any(angle.env_id == "5-1-5" for angle in mol.angles)
+
+
+class TestMoleculeFromStructure:
+    def test_absent_topology_is_inferred(self) -> None:
+        from q2mm.models.structure import Atom, Structure
+
+        structure = Structure("water")
+        structure.atoms.extend(
+            [
+                Atom(element="O", coords=[0.0, 0.0, 0.0]),
+                Atom(element="H", coords=[0.96, 0.0, 0.0]),
+                Atom(element="H", coords=[-0.24, 0.93, 0.0]),
+            ]
+        )
+        assert structure.bonds == []
+        assert not structure.has_explicit_bonds
+
+        molecule = Q2MMMolecule.from_structure(structure)
+
+        assert len(molecule.bonds) == 2
+        assert len(molecule.angles) == 1
+
+    def test_explicit_empty_topology_is_authoritative(self) -> None:
+        from q2mm.models.structure import Atom, Structure
+
+        structure = Structure("hydrogen")
+        structure.atoms.extend(
+            [
+                Atom(element="H", coords=[0.0, 0.0, 0.0]),
+                Atom(element="H", coords=[0.74, 0.0, 0.0]),
+            ]
+        )
+        structure.bonds = []
+
+        molecule = Q2MMMolecule.from_structure(structure)
+
+        assert molecule.bonds == []
+
+    def test_structure_fields_and_overrides_are_preserved(self) -> None:
+        from q2mm.models.structure import Atom, Bond, HessianUnits, Structure
+
+        structure = Structure("charged")
+        structure.props.update(charge="-1", multiplicity="2")
+        structure.hess = np.eye(6)
+        structure.hessian_units = HessianUnits.ATOMIC
+        structure.atoms.extend(
+            [
+                Atom(element="C", coords=[0.0, 0.0, 0.0], partial_charge=-0.4),
+                Atom(element="O", coords=[1.2, 0.0, 0.0], partial_charge=0.4),
+            ]
+        )
+        structure.bonds.append(Bond(atom_nums=[1, 2], order="2"))
+
+        molecule = Q2MMMolecule.from_structure(structure)
+        overridden = Q2MMMolecule.from_structure(
+            structure,
+            charge=1,
+            multiplicity=3,
+            hessian=np.eye(6) * 2,
+        )
+        without_hessian = Q2MMMolecule.from_structure(structure, hessian=None)
+
+        assert molecule.charge == -1
+        assert molecule.multiplicity == 2
+        assert molecule.partial_charges == [-0.4, 0.4]
+        assert molecule.bonds[0].bond_order == "="
+        assert molecule.bonds[0].source_bond_order == "2"
+        np.testing.assert_array_equal(molecule.hessian, structure.hess)
+        assert overridden.charge == 1
+        assert overridden.multiplicity == 3
+        np.testing.assert_array_equal(overridden.hessian, np.eye(6) * 2)
+        assert without_hessian.hessian is None
+
+    def test_unit_unknown_structure_hessian_is_rejected(self) -> None:
+        from q2mm.models.structure import Atom, Structure
+
+        structure = Structure("unknown-units")
+        structure.atoms.append(Atom(element="H", coords=[0.0, 0.0, 0.0]))
+        structure.hess = np.eye(3)
+
+        with pytest.raises(ValueError, match="Hessian unit provenance"):
+            Q2MMMolecule.from_structure(structure)
+
+    @pytest.mark.parametrize("unit_provenance", [None, "kilojoule/(mole*angstrom**2)"])
+    def test_unit_bearing_structure_hessian_is_converted_once(self, unit_provenance: str | None) -> None:
+        from q2mm.constants import KJMOLA2_TO_HESSIAN_AU
+        from q2mm.models.structure import Atom, Structure
+
+        class FakeQuantity:
+            def __init__(self, magnitude: np.ndarray) -> None:
+                self.magnitude = magnitude
+
+            def to(self, target_unit: str) -> FakeQuantity:
+                assert target_unit == "hartree/bohr**2"
+                return FakeQuantity(self.magnitude * KJMOLA2_TO_HESSIAN_AU)
+
+        structure = Structure("unit-bearing")
+        structure.atoms.append(Atom(element="H", coords=[0.0, 0.0, 0.0]))
+        structure.hess = FakeQuantity(np.eye(3))
+        structure.hessian_units = unit_provenance
+
+        molecule = Q2MMMolecule.from_structure(structure)
+
+        np.testing.assert_allclose(molecule.hessian, np.eye(3) * KJMOLA2_TO_HESSIAN_AU)
+
+    @pytest.mark.parametrize("topology_name", ["bonds", "angles", "torsions"])
+    def test_empty_topology_extension_is_authoritative(self, topology_name: str) -> None:
+        from q2mm.models.structure import Atom, Structure
+
+        structure = Structure("chain")
+        structure.atoms.extend(
+            [
+                Atom(element="C", coords=[0.0, 0.0, 0.0]),
+                Atom(element="C", coords=[1.4, 0.0, 0.0]),
+                Atom(element="C", coords=[2.8, 0.0, 0.0]),
+                Atom(element="C", coords=[4.2, 0.0, 0.0]),
+            ]
+        )
+
+        getattr(structure, topology_name).extend([])
+
+        assert getattr(structure, f"has_explicit_{topology_name}")
+        assert getattr(Q2MMMolecule.from_structure(structure), topology_name) == []
+
+    @pytest.mark.parametrize(
+        ("topology_name", "item_factory"),
+        [
+            pytest.param(
+                "bonds",
+                lambda: Bond([1, 2]),
+                id="bonds",
+            ),
+            pytest.param(
+                "angles",
+                lambda: Angle([1, 2, 3]),
+                id="angles",
+            ),
+            pytest.param(
+                "torsions",
+                lambda: Torsion([1, 2, 3, 4]),
+                id="torsions",
+            ),
+        ],
+    )
+    def test_cleared_topology_remains_authoritative(
+        self, topology_name: str, item_factory: Callable[[], object]
+    ) -> None:
+        from q2mm.models.structure import Atom, Structure
+
+        structure = Structure("chain")
+        structure.atoms.extend(
+            [
+                Atom(element="C", coords=[0.0, 0.0, 0.0]),
+                Atom(element="C", coords=[1.4, 0.0, 0.0]),
+                Atom(element="C", coords=[2.8, 0.0, 0.0]),
+                Atom(element="C", coords=[4.2, 0.0, 0.0]),
+            ]
+        )
+        topology = getattr(structure, topology_name)
+        topology.append(item_factory())
+        topology.clear()
+
+        assert getattr(structure, f"has_explicit_{topology_name}")
+        assert getattr(Q2MMMolecule.from_structure(structure), topology_name) == []
+
+    def test_bond_tolerance_change_invalidates_dependent_topology(self) -> None:
+        molecule = Q2MMMolecule(
+            symbols=["O", "H", "H"],
+            geometry=np.array([[0.0, 0.0, 0.0], [0.96, 0.0, 0.0], [-0.24, 0.93, 0.0]]),
+        )
+        assert len(molecule.bonds) == 2
+        assert len(molecule.angles) == 1
+
+        molecule.bond_tolerance = 0.5
+
+        assert molecule.bonds == []
+        assert molecule.angles == []
+
+    def test_bond_tolerance_change_preserves_explicit_topology(self) -> None:
+        from q2mm.models.structure import Atom, Bond, Structure
+
+        structure = Structure("carbonyl")
+        structure.atoms.extend(
+            [
+                Atom(element="C", coords=[0.0, 0.0, 0.0]),
+                Atom(element="O", coords=[1.2, 0.0, 0.0]),
+            ]
+        )
+        structure.bonds.append(Bond(atom_nums=[1, 2], order="2", ff_row=42))
+        molecule = Q2MMMolecule.from_structure(structure)
+
+        molecule.bond_tolerance = 0.5
+
+        assert len(molecule.bonds) == 1
+        assert molecule.bonds[0].bond_order == "="
+        assert molecule.bonds[0].source_bond_order == "2"
+        assert molecule.bonds[0].ff_row == 42
 
 
 # ---- Torsion detection ----

--- a/test/test_reference_data.py
+++ b/test/test_reference_data.py
@@ -11,6 +11,7 @@ from test._shared import (
 )
 
 from q2mm.models.molecule import Q2MMMolecule
+from q2mm.models.seminario import qfuerza_fresh
 from q2mm.optimizers.objective import ReferenceData
 from q2mm.io.fchk import parse_fchk as _parse_fchk
 
@@ -291,3 +292,26 @@ class TestFromFchk:
         # Not all angles will be identical
         diffs = [abs(a - b) for a, b in zip(gs_angles, ts_angles)]
         assert max(diffs) > 0.1, "GS and TS angles should differ"
+
+
+class TestFromGaussian:
+    def test_ethane_log_builds_geometry_references_and_force_field(self) -> None:
+        ref, molecule = ReferenceData.from_gaussian(GS_FCHK.with_suffix(".log"), au_hessian=True)
+        force_field = qfuerza_fresh(molecule)
+
+        assert molecule.n_atoms == 8
+        assert len(molecule.bonds) == 7
+        assert len(molecule.angles) == 12
+        assert any(value.kind == "bond_length" for value in ref.values)
+        assert any(value.kind == "bond_angle" for value in ref.values)
+        assert force_field.n_params > 0
+
+    def test_explicit_charge_and_multiplicity_override_archive(self) -> None:
+        _, molecule = ReferenceData.from_gaussian(
+            GS_FCHK.with_suffix(".log"),
+            charge=-2,
+            multiplicity=3,
+        )
+
+        assert molecule.charge == -2
+        assert molecule.multiplicity == 3

--- a/test/test_seminario.py
+++ b/test/test_seminario.py
@@ -3,12 +3,19 @@ from pathlib import Path
 import numpy as np
 
 from q2mm.io.mm3 import _mm3_import_ff
-from q2mm.io import GaussLog, Mol2
+from q2mm.io import GaussLog, JaguarIn, JaguarOut, MacroModel, Mol2
 from q2mm.models.hessian import mass_weight_hessian
+from q2mm.models.forcefield import BondParam, ForceField
+from q2mm.models.molecule import Q2MMMolecule
+from q2mm.models.structure import Atom, HessianUnits, Structure
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 ETHANE_DIR = REPO_ROOT / "examples" / "ethane"
 RH_SEMINARIO_DIR = REPO_ROOT / "examples" / "rh-enamide"
+RH_TRAINING_DIR = RH_SEMINARIO_DIR / "rh_enamide_training_set"
+RH_MMO = RH_TRAINING_DIR / "rh_enamide_training_set.mmo"
+RH_JAGUAR_IN = RH_TRAINING_DIR / "jaguar_spe_freq_in_out" / "1ZDMPfromJCTCSI_loner1.01.in"
+RH_JAGUAR_OUT = RH_TRAINING_DIR / "jaguar_spe_freq_in_out" / "1ZDMPfromJCTCSI_loner1.out"
 
 
 @unittest.skipUnless(
@@ -31,6 +38,32 @@ class TestGaussLogParsing(unittest.TestCase):
         log = GaussLog(str(ETHANE_DIR / "GS.log"))
         struct = log.structures[0]
         self.assertIsNotNone(struct.hess, "No Hessian parsed from GS.log")
+
+    def test_gaussian_molecule_preserves_archive_fields_and_infers_topology(self) -> None:
+        molecule = GaussLog(str(ETHANE_DIR / "GS.log"), au_hessian=True).molecules[-1]
+
+        self.assertEqual(molecule.charge, 0)
+        self.assertEqual(molecule.multiplicity, 1)
+        self.assertIsNotNone(molecule.hessian)
+        self.assertEqual(len(molecule.bonds), 7)
+        self.assertEqual(len(molecule.angles), 12)
+        self.assertIsNone(molecule.partial_charges)
+
+    def test_gaussian_hessian_units_normalize_at_domain_boundary(self) -> None:
+        default_log = GaussLog(str(ETHANE_DIR / "GS.log"))
+        atomic_log = GaussLog(str(ETHANE_DIR / "GS.log"), au_hessian=True)
+
+        default_structure = default_log.structures[-1]
+        atomic_structure = atomic_log.structures[-1]
+        self.assertEqual(default_structure.hessian_units, HessianUnits.KJ_MOL_ANGSTROM2)
+        self.assertEqual(atomic_structure.hessian_units, HessianUnits.ATOMIC)
+
+        direct_default = Q2MMMolecule.from_structure(default_structure)
+        direct_atomic = Q2MMMolecule.from_structure(atomic_structure)
+        np.testing.assert_allclose(direct_default.hessian, direct_atomic.hessian, rtol=1e-12, atol=1e-12)
+        np.testing.assert_allclose(
+            default_log.molecules[-1].hessian, atomic_log.molecules[-1].hessian, rtol=1e-12, atol=1e-12
+        )
 
     def test_parse_ts_log(self) -> None:
         log = GaussLog(str(ETHANE_DIR / "TS.log"))
@@ -87,6 +120,114 @@ class TestMol2Parsing(unittest.TestCase):
         struct = mol2.structures[0]
         # Ethane: 7 bonds (1 C-C + 6 C-H)
         self.assertEqual(len(struct.bonds), 7, "Ethane should have 7 bonds")
+
+    def test_mol2_molecule_preserves_bonds_and_infers_higher_topology(self) -> None:
+        molecule = Mol2(str(ETHANE_DIR / "GS.mol2")).molecules[0]
+
+        self.assertEqual(len(molecule.bonds), 7)
+        self.assertEqual(len(molecule.angles), 12)
+        self.assertEqual(len(molecule.torsions), 9)
+        self.assertEqual(molecule.bonds[0].bond_order, "-")
+        self.assertEqual(molecule.bonds[0].source_bond_order, "1")
+        self.assertEqual(molecule.partial_charges[0], 0.0227)
+        self.assertIsNone(molecule.hessian)
+
+    def test_mol2_bond_orders_use_canonical_force_field_symbols(self) -> None:
+        parser = Mol2(str(ETHANE_DIR / "GS.mol2"))
+        for source_order, canonical_order in (("2", "="), ("ar", "*"), ("3", "%")):
+            with self.subTest(source_order=source_order):
+                structure = Structure("bond-order")
+                structure.atoms.extend(
+                    [
+                        Atom(element="C", atom_type_name="C.2", coords=[0.0, 0.0, 0.0]),
+                        Atom(element="C", atom_type_name="C.2", coords=[1.3, 0.0, 0.0]),
+                    ]
+                )
+                structure.bonds = parser.parse_bonds([f"1 1 2 {source_order}"], structure)
+                molecule = Q2MMMolecule.from_structure(structure)
+                bond = molecule.bonds[0]
+
+                self.assertEqual(bond.bond_order, canonical_order)
+                self.assertEqual(bond.source_bond_order, source_order)
+
+                forcefield = ForceField(
+                    bonds=[
+                        BondParam(("C", "C"), 1.54, 300.0, env_id=bond.env_id, bond_order="-", label="single"),
+                        BondParam(
+                            ("C", "C"),
+                            1.30,
+                            500.0,
+                            env_id=bond.env_id,
+                            bond_order=canonical_order,
+                            label=source_order,
+                        ),
+                    ]
+                )
+                matched = forcefield.match_bond(
+                    bond.elements,
+                    env_id=bond.env_id,
+                    bond_order=bond.bond_order,
+                    bond_length=bond.length,
+                )
+                self.assertIsNotNone(matched)
+                self.assertEqual(matched.label, source_order)
+
+    def test_unknown_mol2_bond_order_is_not_canonicalized(self) -> None:
+        parser = Mol2(str(ETHANE_DIR / "GS.mol2"))
+        structure = Structure("unknown-order")
+        structure.atoms.extend(
+            [
+                Atom(element="C", atom_type_name="C.2", coords=[0.0, 0.0, 0.0]),
+                Atom(element="N", atom_type_name="N.am", coords=[1.3, 0.0, 0.0]),
+            ]
+        )
+        structure.bonds = parser.parse_bonds(["1 1 2 am"], structure)
+
+        bond = Q2MMMolecule.from_structure(structure).bonds[0]
+
+        self.assertEqual(bond.bond_order, "")
+        self.assertEqual(bond.source_bond_order, "am")
+
+
+@unittest.skipUnless(RH_JAGUAR_OUT.exists(), "Jaguar fixture not found")
+class TestJaguarConversion(unittest.TestCase):
+    def test_jaguar_molecule_infers_missing_topology_only(self) -> None:
+        parser = JaguarOut(str(RH_JAGUAR_OUT))
+        structure = parser.structures[-1]
+        molecule = parser.molecules[-1]
+
+        self.assertFalse(structure.has_explicit_bonds)
+        self.assertGreater(len(molecule.bonds), 0)
+        self.assertGreater(len(molecule.angles), 0)
+        self.assertIsNone(molecule.hessian)
+        self.assertIsNone(molecule.partial_charges)
+
+    def test_jaguar_hessian_override_is_preserved(self) -> None:
+        structure = MacroModel(str(RH_MMO)).structures[0]
+        hessian = JaguarIn(str(RH_JAGUAR_IN)).get_hessian(len(structure.atoms))
+
+        from q2mm.models.molecule import Q2MMMolecule
+
+        molecule = Q2MMMolecule.from_structure(structure, hessian=hessian)
+
+        np.testing.assert_array_equal(molecule.hessian, hessian)
+
+
+@unittest.skipUnless(RH_MMO.exists(), "MacroModel fixture not found")
+class TestMacroModelConversion(unittest.TestCase):
+    def test_macromodel_molecule_preserves_all_supplied_topology(self) -> None:
+        parser = MacroModel(str(RH_MMO))
+        structure = parser.structures[0]
+        molecule = parser.molecules[0]
+
+        self.assertEqual(len(molecule.bonds), len(structure.bonds))
+        self.assertEqual(len(molecule.angles), len(structure.angles))
+        self.assertEqual(len(molecule.torsions), len(structure.torsions))
+        self.assertEqual(molecule.bonds[0].ff_row, structure.bonds[0].ff_row)
+        self.assertEqual(molecule.angles[0].ff_row, structure.angles[0].ff_row)
+        self.assertEqual(molecule.torsions[0].ff_row, structure.torsions[0].ff_row)
+        self.assertEqual(molecule.bonds[0].bond_order, "")
+        self.assertIsNone(molecule.partial_charges)
 
 
 @unittest.skipUnless((RH_SEMINARIO_DIR / "mm3.fld").exists(), "rh-enamide fixture not found")


### PR DESCRIPTION
## Summary

Preserve parser-supplied molecular information when converting `Structure`
objects into `Q2MMMolecule` domain objects, while retaining lazy inference for
topology that a parser genuinely did not provide.

This fixes a correctness gap where parsed molecules could lose topology,
Hessian provenance, bond orders, charge state, or partial charges at the
parser/domain boundary. In the tracked ethane regression, that loss previously
produced no bonds, no angles, no geometry references, and no QFUERZA starting
parameters.

### Changes

#### Preserve topology and its provenance

- Track bond, angle, and torsion provenance independently.
- Distinguish missing topology (eligible for lazy inference) from
  parser-supplied topology, including an explicitly empty section.
- Preserve bond-only parser output while inferring only the missing higher-order
  topology.
- Return mutation-aware topology lists so successful list operations retain an
  explicit-empty state instead of silently restoring inference.
- Keep `bond_tolerance` invalidation limited to distance-inferred topology and
  its inferred dependents; authoritative parser topology remains intact.
- Retain `invalidate_topology()` as the stronger operation for changes that
  invalidate atom environments or types.

#### Make Hessian units explicit

- Add `HessianUnits` provenance to `Structure`.
- Label Gaussian Hessians according to their actual representation.
- Convert inherited parser Hessians into the domain model's canonical
  Hartree/Bohr-squared units exactly once.
- Reject unit-unknown inherited bare arrays instead of silently interpreting
  them with the wrong scale.
- Preserve the existing explicit-override contract: a bare explicit override is
  canonical atomic units, while a unit-bearing quantity uses its embedded
  units.

#### Retain parser metadata

- Preserve molecular charge and multiplicity.
- Preserve Mol2 atom types and optional per-atom partial charges.
- Normalize Mol2 bond orders at the domain boundary:
  - `1` -> `-`
  - `2` -> `=`
  - `ar` -> `*`
  - `3` -> `%`
- Retain the original parser token as `DetectedBond.source_bond_order`.
- Represent unsupported bond-order tokens as canonical unknown values without
  discarding their source values.
- Keep MacroModel topology authoritative and remove a direct topology-cache
  write from the system loader path.

#### Clarify conversion precedence

`Q2MMMolecule.from_structure()` now follows an explicit precedence contract:

1. Explicit conversion argument.
2. Value and provenance carried by `Structure`.
3. Domain default.

An omitted Hessian argument therefore preserves a parser-provided Hessian,
while an explicit `hessian=None` suppresses it.

### Tests

- `python -m ruff check q2mm/ test/ scripts/`
- `python -m ruff format --check q2mm test scripts examples`
- `python -m mypy q2mm/`
- `python -m pytest test/integration/test_seminario_parity.py test/test_models.py test/test_reference_data.py test/test_seminario.py -q`
  - 217 passed, 32 skipped, 3 subtests passed
- `python -m pytest test/ -x -q -m "not (openmm or tinker or jax or jax_md or psi4)"`
  - 695 passed, 175 skipped, 319 deselected, 3 subtests passed

The core run retains the existing 54 higher-order-saddle Hessian warnings from
the system starting-point tests.

### Scope

This PR does not change QFUERZA projection methodology, transition-state
curvature inversion, package-data policy, release artifacts, or external-data
classification. Packaging and data hygiene remain separate changes.
